### PR TITLE
fix guardrail attributes when invoking bedrock

### DIFF
--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -345,7 +345,7 @@ class BedrockBase(BaseLanguageModel, ABC):
     guardrails: Optional[Mapping[str, Any]] = {
         "trace": None,
         "guardrailIdentifier": None,
-        "guardrailVersion": None
+        "guardrailVersion": None,
     }
     """
     An optional dictionary to configure guardrails for Bedrock.
@@ -446,9 +446,9 @@ class BedrockBase(BaseLanguageModel, ABC):
             "model_id": self.model_id,
             "provider": self._get_provider(),
             "stream": self.streaming,
-            "trace": self.guardrails.get('trace'),
-            "guardrailIdentifier": self.guardrails.get('guardrailIdentifier'),
-            "guardrailVersion": self.guardrails.get('guardrailVersion'),
+            "trace": self.guardrails.get("trace"),  # type: ignore[union-attr]
+            "guardrailIdentifier": self.guardrails.get("guardrailIdentifier", None),  # type: ignore[union-attr]
+            "guardrailVersion": self.guardrails.get("guardrailVersion", None),  # type: ignore[union-attr]
             **_model_kwargs,
         }
 
@@ -488,9 +488,9 @@ class BedrockBase(BaseLanguageModel, ABC):
 
         except KeyError as e:
             raise TypeError(
-                "Guardrails must be a dictionary with 'guardrailIdentifier' and 'guardrailVersion' keys."
+                "Guardrails must be a dictionary with 'guardrailIdentifier'  \
+                and 'guardrailVersion' keys."
             ) from e
-
 
     def _prepare_input_and_invoke(
         self,
@@ -525,8 +525,12 @@ class BedrockBase(BaseLanguageModel, ABC):
         }
 
         if self._guardrails_enabled:
-            request_options["guardrailIdentifier"] = self.guardrails.get("guardrailIdentifier")
-            request_options["guardrailVersion"] = self.guardrails.get("guardrailVersion")
+            request_options["guardrailIdentifier"] = self.guardrails.get(  # type: ignore[union-attr]
+                "guardrailIdentifier", ""
+            )
+            request_options["guardrailVersion"] = self.guardrails.get(  # type: ignore[union-attr]
+                "guardrailVersion", ""
+            )
             if self.guardrails.get("trace"):  # type: ignore[union-attr]
                 request_options["trace"] = "ENABLED"
 
@@ -631,8 +635,12 @@ class BedrockBase(BaseLanguageModel, ABC):
         }
 
         if self._guardrails_enabled:
-            request_options["guardrailIdentifier"] = self.guardrails.get("guardrailIdentifier")
-            request_options["guardrailVersion"] = self.guardrails.get("guardrailVersion")
+            request_options["guardrailIdentifier"] = self.guardrails.get(  # type: ignore[union-attr]
+                "guardrailIdentifier", ""
+            )
+            request_options["guardrailVersion"] = self.guardrails.get(  # type: ignore[union-attr]
+                "guardrailVersion", ""
+            )
             if self.guardrails.get("trace"):  # type: ignore[union-attr]
                 request_options["trace"] = "ENABLED"
 

--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -343,9 +343,9 @@ class BedrockBase(BaseLanguageModel, ABC):
     }
 
     guardrails: Optional[Mapping[str, Any]] = {
-        "id": None,
-        "version": None,
-        "trace": False,
+        "trace": None,
+        "guardrailIdentifier": None,
+        "guardrailVersion": None
     }
     """
     An optional dictionary to configure guardrails for Bedrock.
@@ -446,7 +446,9 @@ class BedrockBase(BaseLanguageModel, ABC):
             "model_id": self.model_id,
             "provider": self._get_provider(),
             "stream": self.streaming,
-            "guardrails": self.guardrails,
+            "trace": self.guardrails.get('trace'),
+            "guardrailIdentifier": self.guardrails.get('guardrailIdentifier'),
+            "guardrailVersion": self.guardrails.get('guardrailVersion'),
             **_model_kwargs,
         }
 
@@ -480,31 +482,15 @@ class BedrockBase(BaseLanguageModel, ABC):
         try:
             return (
                 isinstance(self.guardrails, dict)
-                and bool(self.guardrails["id"])
-                and bool(self.guardrails["version"])
+                and bool(self.guardrails["guardrailIdentifier"])
+                and bool(self.guardrails["guardrailVersion"])
             )
 
         except KeyError as e:
             raise TypeError(
-                "Guardrails must be a dictionary with 'id' and 'version' keys."
+                "Guardrails must be a dictionary with 'guardrailIdentifier' and 'guardrailVersion' keys."
             ) from e
 
-    def _get_guardrails_canonical(self) -> Dict[str, Any]:
-        """
-        The canonical way to pass in guardrails to the bedrock service
-        adheres to the following format:
-
-        "amazon-bedrock-guardrailDetails": {
-            "guardrailId": "string",
-            "guardrailVersion": "string"
-        }
-        """
-        return {
-            "amazon-bedrock-guardrailDetails": {
-                "guardrailId": self.guardrails.get("id"),  # type: ignore[union-attr]
-                "guardrailVersion": self.guardrails.get("version"),  # type: ignore[union-attr]
-            }
-        }
 
     def _prepare_input_and_invoke(
         self,
@@ -519,8 +505,7 @@ class BedrockBase(BaseLanguageModel, ABC):
 
         provider = self._get_provider()
         params = {**_model_kwargs, **kwargs}
-        if self._guardrails_enabled:
-            params.update(self._get_guardrails_canonical())
+
         input_body = LLMInputOutputAdapter.prepare_input(
             provider=provider,
             model_kwargs=params,
@@ -540,7 +525,8 @@ class BedrockBase(BaseLanguageModel, ABC):
         }
 
         if self._guardrails_enabled:
-            request_options["guardrail"] = "ENABLED"
+            request_options["guardrailIdentifier"] = self.guardrails.get("guardrailIdentifier")
+            request_options["guardrailVersion"] = self.guardrails.get("guardrailVersion")
             if self.guardrails.get("trace"):  # type: ignore[union-attr]
                 request_options["trace"] = "ENABLED"
 
@@ -628,9 +614,6 @@ class BedrockBase(BaseLanguageModel, ABC):
 
         params = {**_model_kwargs, **kwargs}
 
-        if self._guardrails_enabled:
-            params.update(self._get_guardrails_canonical())
-
         input_body = LLMInputOutputAdapter.prepare_input(
             provider=provider,
             prompt=prompt,
@@ -648,7 +631,8 @@ class BedrockBase(BaseLanguageModel, ABC):
         }
 
         if self._guardrails_enabled:
-            request_options["guardrail"] = "ENABLED"
+            request_options["guardrailIdentifier"] = self.guardrails.get("guardrailIdentifier")
+            request_options["guardrailVersion"] = self.guardrails.get("guardrailVersion")
             if self.guardrails.get("trace"):  # type: ignore[union-attr]
                 request_options["trace"] = "ENABLED"
 


### PR DESCRIPTION
Fixed bedrock attributes when using guardrails. See example of usage:

```
from langchain_core.messages import HumanMessage
from langchain_aws.chat_models import ChatBedrock



llm_model_id='anthropic.claude-3-haiku-20240307-v1:0'

chat = ChatBedrock(
    model_id=llm_model_id,
    streaming=True,
    model_kwargs={"temperature": 0.1},
    guardrails={"guardrailIdentifier": "identifier", "guardrailVersion": "1", "trace": True},
)

messages = [
    HumanMessage(
        content="What are the financial advice you can give me?"
    )
]
for chunk in chat.stream(messages):
    print(chunk.content,  end="", flush=True)
```