### PR TITLE
Adds Bedrock KB metadata to AmazonKnowledgeBasesRetriever Document metadata

### DIFF
--- a/libs/aws/README.md
+++ b/libs/aws/README.md
@@ -54,7 +54,7 @@ retriever = AmazonKendraRetriever(
 retriever.get_relevant_documents(query="What is the meaning of life?")
 ```
 
-`AmazonKnowlegeBasesRetriever` class provides a retriever to connect with Amazon Knowledge Bases.
+`AmazonKnowledgeBasesRetriever` class provides a retriever to connect with Amazon Knowledge Bases.
 
 ```python
 from langchain_aws import AmazonKnowledgeBasesRetriever

--- a/libs/aws/langchain_aws/retrievers/bedrock.py
+++ b/libs/aws/langchain_aws/retrievers/bedrock.py
@@ -120,6 +120,9 @@ class AmazonKnowledgeBasesRetriever(BaseRetriever):
                     metadata={
                         "location": result["location"],
                         "score": result["score"] if "score" in result else 0,
+                        "source_metadata": (
+                            result["metadata"] if "metadata" in result else None
+                        ),
                     },
                 )
             )

--- a/libs/aws/tests/integration_tests/retrievers/test_amazon_knowledgebases_retriever.py
+++ b/libs/aws/tests/integration_tests/retrievers/test_amazon_knowledgebases_retriever.py
@@ -34,6 +34,12 @@ def test_get_relevant_documents(retriever, mock_client) -> None:  # type: ignore
                 "score": 0.8,
             },
             {"content": {"text": "This is the third result."}, "location": "location3"},
+            {
+                "content": {"text": "This is the fourth result."},
+                "location": "location4",
+                "score": 0.4,
+                "metadata": {"url": "http://example.com", "title": "Example Title"},
+            },
         ]
     }
     mock_client.retrieve.return_value = response
@@ -43,19 +49,30 @@ def test_get_relevant_documents(retriever, mock_client) -> None:  # type: ignore
     expected_documents = [
         Document(
             page_content="This is the first result.",
-            metadata={"location": "location1", "score": 0.9},
+            metadata={"location": "location1", "score": 0.9, "source_metadata": None},
         ),
         Document(
             page_content="This is the second result.",
-            metadata={"location": "location2", "score": 0.8},
+            metadata={"location": "location2", "score": 0.8, "source_metadata": None},
         ),
         Document(
             page_content="This is the third result.",
-            metadata={"location": "location3", "score": 0.0},
+            metadata={"location": "location3", "score": 0.0, "source_metadata": None},
+        ),
+        Document(
+            page_content="This is the fourth result.",
+            metadata={
+                "location": "location4",
+                "score": 0.4,
+                "source_metadata": {
+                    "url": "http://example.com",
+                    "title": "Example Title",
+                },
+            },
         ),
     ]
 
-    documents = retriever.get_relevant_documents(query)
+    documents = retriever.invoke(query)
 
     assert documents == expected_documents
 


### PR DESCRIPTION
AWS Bedrock Knowledge Bases support custom user metadata per source document. This change adds that metadata to AmazonKnowledgeBasesRetriever Documents metadata as `source_metadata`.

This addresses the feature request in https://github.com/langchain-ai/langchain/discussions/20649

I'm open to suggestions on the `source_metadata` key name, but I was avoiding `metadata["metadata"]`

There are a few different ways to handle this. In this PR, `source_metadata` is set to `None` if the Bedrock KB result does not contain a `metadata` key. I prefer this approach as the presence of the `source_metadata` key is guaranteed for the caller - i.e., the caller does not have to check for it's presence.

If it's preferred to not set `source_metadata` if it's empty, then here are a couple of options.
```python
for result in results:
    metadata={
        "location": result["location"],
        "score": result["score"] if "score" in result else 0,
    }
    if "metadata" in result:
        metadata["source_metadata"] = result["metadata"]
    documents.append(
        Document(
            page_content=result["content"]["text"],
            metadata=metadata,
        )
    )
```

Requires Python 3.9+
```python
for result in results:
    documents.append(
        Document(
            page_content=result["content"]["text"],
            metadata={
                "location": result["location"],
                "score": result["score"] if "score" in result else 0} |
                ({'source_metadata': result["metadata"] } if "metadata" in result else {}),
        )
    )
```

I updated the integration tests to reflect these changes and added a response that includes KB metadata.

I changed the integration test `get_relevant_documents` to `invoke` based on

>   /home/knewell/.cache/pypoetry/virtualenvs/langchain-aws-eO7Ij7mw-py3.9/lib/python3.9/site-packages/langchain_core/_api/deprecation.py:119: LangChainDeprecationWarning: The method `BaseRetriever.get_relevant_documents` was deprecated in langchain-core 0.1.46 and will be removed in 0.3.0. Use invoke instead.
>     warn_deprecated(

Two simple typos in README.md were fixed.