### PR TITLE
Determine embedding size with Titan Embedding v2 model 

### DIFF
--- a/libs/aws/tests/integration_tests/embeddings/test_bedrock_embeddings.py
+++ b/libs/aws/tests/integration_tests/embeddings/test_bedrock_embeddings.py
@@ -73,3 +73,18 @@ def test_embed_query_normalized(bedrock_embeddings) -> None:
     bedrock_embeddings.normalize = True
     output = bedrock_embeddings.embed_query("foo walked to the market")
     assert np.isclose(np.linalg.norm(output), 1.0)
+
+
+@pytest.mark.scheduled
+def test_embed_query_with_size(bedrock_embeddings) -> None:
+    prompt_data = """Priority should be funding retirement through ROTH/IRA/401K 
+    over HSA extra. You need to fund your HSA for reasonable and expected medical 
+    expenses. 
+    """
+    embed_size = 256
+    normalize = True
+    embed_model = BedrockEmbeddings(model_id="amazon.titan-embed-text-v2:0")
+    response = embed_model.embed_documents([prompt_data], embed_size, normalize)
+    output = embed_model.embed_query(prompt_data, embed_size, False)
+    assert len(response[0]) == 256
+    assert len(output) == 256


### PR DESCRIPTION
Support for Titan Embedding v2 with changing embedding sizes based on this [blog](https://aws.amazon.com/blogs/machine-learning/get-started-with-amazon-titan-text-embeddings-v2-a-new-state-of-the-art-embeddings-model-on-amazon-bedrock/). This change lets the user specify `dimension`.

```
from langchain_aws.embeddings import BedrockEmbeddings

prompt_data = """Priority should be funding retirement through ROTH/IRA/401K over HSA extra.  
You need to fund your HSA for reasonable and expected medical expenses. """

bedrock_embedding_model_id = "amazon.titan-embed-text-v2:0"

embed_model = BedrockEmbeddings(model_id=bedrock_embedding_model_id)
response = embed_model.embed_documents([prompt_data], 256, True) 
response = embed_model.embed_query(prompt_data, 512, True)
```