### PR TITLE
Support for generate and return tool_calls with Anthropic models

### DIFF
--- a/libs/aws/langchain_aws/function_calling.py
+++ b/libs/aws/langchain_aws/function_calling.py
@@ -137,3 +137,25 @@ def convert_to_anthropic_tool(
             description=formatted["description"],
             input_schema=formatted["parameters"],
         )
+
+
+def parse_tool_calls_from_xml(xml_str: str) -> List[Dict[Any, Any]]:
+    tool_calls: List[Dict[Any, Any]] = []
+    invokes = xml_str.split("<invoke>")[1:]
+    for invoke in invokes:
+        tool_name = invoke.split("<tool_name>")[1].split("</tool_name>")[0]
+        parameters_str = invoke.split("<parameters>")[1].split("</parameters>")[0]
+        parameters = {}
+        for param in parameters_str.split("<")[1:]:
+            # ignore closing tag
+            if ">\n" in param:
+                continue
+            tag, value = param.split(">")
+            tag = tag.strip()
+            value = value.split("</")[0]
+            parameters[tag] = value
+        tool_call = {
+            "function": {"name": tool_name, "arguments": parameters, "type": "function"}
+        }
+        tool_calls.append(tool_call)
+    return tool_calls

--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock.py
@@ -1,6 +1,6 @@
 """Test Bedrock chat model."""
 
-from typing import Any, cast
+from typing import Any, List, cast
 
 import pytest
 from langchain_core.language_models.chat_models import BaseChatModel
@@ -246,7 +246,7 @@ def test_function_call_generate_with_system(chat: ChatBedrock) -> None:
 
     llm_with_tools: BaseChatModel = chat.bind_tools([GetWeather])
 
-    messages: list[list[BaseMessage]] = [
+    messages: List[List[BaseMessage]] = [
         [
             SystemMessage(content="anwser only in french"),
             HumanMessage(content="what is the weather like in San Francisco"),
@@ -269,7 +269,7 @@ def test_function_call_generate_without_system(chat: ChatBedrock) -> None:
 
     llm_with_tools: BaseChatModel = chat.bind_tools([GetWeather])
 
-    messages: list[list[BaseMessage]] = [
+    messages: List[List[BaseMessage]] = [
         [HumanMessage(content="what is the weather like in San Francisco")]
     ]
 

--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock.py
@@ -196,6 +196,8 @@ def test_function_call_invoke_with_system(chat: ChatBedrock) -> None:
     response = llm_with_tools.invoke(messages)
     assert isinstance(response, BaseMessage)
     assert isinstance(response.content, str)
+    assert response.response_metadata["stop_reason"] == "tool_use"
+    assert len(response.response_metadata["tool_calls"]) == 1
 
 
 @pytest.mark.scheduled
@@ -231,6 +233,7 @@ def test_function_call_invoke_without_system(chat: ChatBedrock) -> None:
     response = llm_with_tools.invoke(messages)
     assert isinstance(response, BaseMessage)
     assert isinstance(response.content, str)
+    assert response.response_metadata["stop_reason"] == "tool_use"
 
 
 @pytest.mark.scheduled


### PR DESCRIPTION
The proposed changes include:
1/ Ability to use tools with `.generate()`
2/ Returning `stop_reason` and `tool_calls` to AIMessage when using tools in the response metadata

Support for function call using the `generate` function not directly implemented in ChatBedrock.

```
from bedrock import ChatBedrock

chat = ChatBedrock(
    model_id=model_id,
    model_kwargs={"temperature": 0.1},
)

class GetWeather(BaseModel):
    """Get the current weather in a given location"""

    location: str = Field(..., description="The city and state, e.g. San Francisco, CA")

llm_with_tools = chat.bind_tools([GetWeather])
llm_with_tools

messages = [
    HumanMessage(
        content="what is the weather like in San Francisco"
    )
]
ai_msg = llm_with_tools.generate(messages)
ai_msg
```