### PR TITLE
Fixes error when stop reason missing in response.

### DIFF
--- a/libs/aws/langchain_aws/llms/__init__.py
+++ b/libs/aws/langchain_aws/llms/__init__.py
@@ -3,6 +3,7 @@ from langchain_aws.llms.bedrock import (
     Bedrock,
     BedrockBase,
     BedrockLLM,
+    LLMInputOutputAdapter,
 )
 from langchain_aws.llms.sagemaker_endpoint import SagemakerEndpoint
 
@@ -11,5 +12,6 @@ __all__ = [
     "Bedrock",
     "BedrockBase",
     "BedrockLLM",
+    "LLMInputOutputAdapter",
     "SagemakerEndpoint",
 ]

--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -257,7 +257,7 @@ class LLMInputOutputAdapter:
                 "completion_tokens": completion_tokens,
                 "total_tokens": prompt_tokens + completion_tokens,
             },
-            "stop_reason": response_body["stop_reason"],
+            "stop_reason": response_body.get("stop_reason"),
         }
 
     @classmethod


### PR DESCRIPTION
Fixes #55, #56.

All integration tests pass.

```
(base) ➜  aws git:(fix-stop-reason-error) make integration_tests             
poetry run pytest tests/integration_tests/
================================================================== test session starts ==================================================================
platform darwin -- Python 3.9.13, pytest-7.4.4, pluggy-1.5.0
rootdir: /Users/pijain/projects/langchain-aws-dev/langchain-aws/libs/aws
configfile: pyproject.toml
plugins: syrupy-4.6.1, anyio-4.3.0, cov-4.1.0, asyncio-0.23.6
asyncio: mode=auto
collected 34 items                                                                                                                                      

tests/integration_tests/test_compile.py .                                                                                                         [  2%]
tests/integration_tests/chat_models/test_bedrock.py ...................                                                                           [ 58%]
tests/integration_tests/embeddings/test_bedrock_embeddings.py .....s...                                                                           [ 85%]
tests/integration_tests/llms/test_sagemaker_endpoint.py ..                                                                                        [ 91%]
tests/integration_tests/retrievers/test_amazon_kendra_retriever.py .                                                                              [ 94%]
tests/integration_tests/retrievers/test_amazon_knowledgebases_retriever.py ..                                                                     [100%]
====================================================== 33 passed, 1 skipped, 2 warnings in 50.68s =======================================================
``` 