### PR TITLE
Fix stop sequence key for Mistral model in BedrockBase

### DIFF
--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -412,7 +412,7 @@ class BedrockBase(BaseLanguageModel, ABC):
         "amazon": "stopSequences",
         "ai21": "stop_sequences",
         "cohere": "stop_sequences",
-        "mistral": "stop_sequences",
+        "mistral": "stop",
     }
 
     provider_stop_reason_key_map: Mapping[str, str] = {


### PR DESCRIPTION
Correct the stop sequence key for the Mistral model from 'stop_sequences' to 'stop' in the provider_stop_sequence_key_name_map. This ensures proper handling of stop sequences for Mistral.