### PR TITLE
Set stop sequence parameter based on provider

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -434,7 +434,9 @@ class ChatBedrock(BaseChatModel, BedrockBase):
                 )
 
             if stop:
-                params["stop_sequences"] = stop
+                provider = self._get_provider()
+                if k := self.provider_stop_sequence_key_name_map.get(provider):
+                    params[k] = stop
 
             completion, llm_output = self._prepare_input_and_invoke(
                 prompt=prompt,


### PR DESCRIPTION
instead of hard coding the parameter name 'stop_sequence', pick the name based on provider

closes #62 