### PR TITLE
Fix llama3 SSE int usage values

### DIFF
--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -117,6 +117,12 @@ def _stream_response_to_generation_chunk(
     else:
         # chunk obj format varies with provider
         generation_info = {k: v for k, v in stream_response.items() if k != output_key}
+        if provider == "meta":
+            if "prompt_token_count" in generation_info:
+                generation_info["prompt_token_count"] = [generation_info["prompt_token_count"]]
+            if "generation_token_count" in generation_info:
+                generation_info["generation_token_count"] = [generation_info["generation_token_count"]]
+
         return GenerationChunk(
             text=(
                 stream_response[output_key]


### PR DESCRIPTION
Currently when streaming from bedrock llama3, the usage numbers feedback from streaming chunks will cause error in Langchain core merge_dicts function.

Change:
- format `prompt_token_count` and `generation_token_count` from int to list[int]

This should enable the streaming from bedrock llama3 models.