### PR TITLE
Add RunnableSageMakerInferenceEvaluator to be used with langchain for inference evaluator

### DIFF
--- a/libs/aws/langchain_aws/evaluators/action_registry.py
+++ b/libs/aws/langchain_aws/evaluators/action_registry.py
@@ -1,0 +1,135 @@
+import typing
+from abc import ABC, abstractmethod
+from collections import UserDict
+
+from langchain_aws.evaluators.inference_evaluator_exception import (
+    InferenceEvaluatorError,
+)
+
+
+class ActionRegistry(UserDict[str, "ActionInterface"]):
+    """
+    Action registry.
+    """
+
+    def __setitem__(self, key: str, value: "ActionInterface"):  # type: ignore
+        """
+        Set actions
+
+        :param key: action name
+        :param value: action class
+        """
+        if "ActionInterface" in (c.__name__ for c in value.__mro__):  # type: ignore
+            super().__setitem__(key, value)
+        else:
+            raise ValueError(
+                "Please inherit the action from EvaluationAlgorithmInterface"
+            )
+
+    def get_action(self, action_name: str) -> "ActionInterface":
+        """
+        Get action class with name
+
+        :param action_name: action name
+        :return: action class
+        """
+        if action_name in self:
+            return self[action_name]
+        else:
+            raise KeyError(f"Unknown action {action_name}")
+
+
+ACTION_REGISTRY = ActionRegistry()
+
+
+class ActionInterface(ABC):
+    """
+    Interface class for action.
+
+    All the action classes inheriting this interface will be registered in the registry.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        try:
+            import boto3
+
+            self.events_client = boto3.client("events")
+
+        except ImportError:
+            raise ModuleNotFoundError(
+                "Could not import boto3 python package. "
+                "Please install it with `pip install boto3`."
+            )
+
+        except Exception as e:
+            if type(e).__name__ == "UnknownServiceError":
+                raise ModuleNotFoundError(
+                    "NeptuneGraph requires a boto3 version 1.28.38 or greater."
+                    "Please install it with `pip install -U boto3`."
+                ) from e
+            else:
+                raise ValueError(
+                    "Could not load credentials to authenticate with AWS client. "
+                    "Please check that credentials in the specified "
+                    "profile name are valid."
+                ) from e
+
+    def __init_subclass__(cls, **kwargs):  # type: ignore
+        """
+        Method to register algorithms
+        """
+        super().__init_subclass__(**kwargs)
+        ACTION_REGISTRY[cls.__name__] = cls
+
+    @abstractmethod
+    def run(self, input_text: str, additional_parameters: dict) -> typing.Any:
+        """Run the custom defined actions"""
+        pass
+
+
+class Deny(ActionInterface):
+    def run(self, input_text: str, configuration: dict) -> None:
+        raise InferenceEvaluatorError(configuration["alternative_response"])
+
+
+class Instruct(ActionInterface):
+    def _event_bus_exists(self, name: str) -> bool:
+        try:
+            self.events_client.describe_event_bus(Name=name)
+            return True
+        except Exception:
+            return False
+
+    def _create_event_bus(self, payload: dict) -> None:
+        if "Name" not in payload:
+            raise ValueError(
+                "Name for the event bus is not provided in "
+                "the inference evaluator config"
+            )
+
+        name = payload["Name"]
+        if not self._event_bus_exists(name):
+            self.events_client.create_event_bus(**payload)
+
+    def _put_events(self, payload: dict) -> None:
+        self.events_client.put_events(**payload)
+
+    def run(self, input_text: str, configuration: dict) -> str:
+        api_invokes = configuration["additional_parameters"]["api_invokes"]
+
+        if "create_event_bus" in api_invokes:
+            create_event_bus_payload = api_invokes["create_event_bus"]
+            self._create_event_bus(create_event_bus_payload)
+
+        if "put_events" in api_invokes:
+            put_events_payload = api_invokes["put_events"]
+            self._put_events(put_events_payload)
+
+        return input_text
+
+
+class Redact(ActionInterface):
+    def run(self, input_text: str, configuration: dict) -> str:
+        message = configuration["additional_parameters"]["message"]
+        return "{0}\n{1}".format(input_text, message)

--- a/libs/aws/langchain_aws/evaluators/inference_evaluator.py
+++ b/libs/aws/langchain_aws/evaluators/inference_evaluator.py
@@ -1,0 +1,281 @@
+import json
+import time
+from typing import Any, Optional, cast
+
+from botocore.exceptions import ClientError
+from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.prompt_values import ChatPromptValue, StringPromptValue
+from langchain_core.runnables import Runnable
+from langchain_core.runnables.config import RunnableConfig
+from langchain_core.runnables.utils import Input, Output
+
+from langchain_aws.evaluators.action_registry import ACTION_REGISTRY
+
+
+class RunnableSageMakerInferenceEvaluator(Runnable[Input, Output]):
+    inference_evaluator_image = (
+        "551039116605.dkr.ecr.us-west-2.amazonaws.com/mockingbird-beta"
+    )
+
+    # Endpoint name and inference component name is populated
+    #  after "RunnableSageMakerInferenceEvaluator" is deployed
+    endpoint_name = None
+    inference_component_name = None
+
+    def __init__(
+        self, inference_evaluator_name: str, inference_evaluators_configuration: dict
+    ):
+        self.inference_evaluator_name = inference_evaluator_name
+        self.inference_evaluators_configuration = inference_evaluators_configuration
+
+        try:
+            import boto3
+
+            my_session = boto3.session.Session()
+
+            self.sm_client = my_session.client("sagemaker")
+            self.sm_runtime_client = boto3.client(service_name="sagemaker-runtime")
+
+        except ImportError:
+            raise ModuleNotFoundError(
+                "Could not import boto3 python package. "
+                "Please install it with `pip install boto3`."
+            )
+
+        except Exception as e:
+            if type(e).__name__ == "UnknownServiceError":
+                raise ModuleNotFoundError(
+                    "NeptuneGraph requires a boto3 version 1.28.38 or greater."
+                    "Please install it with `pip install -U boto3`."
+                ) from e
+            else:
+                raise ValueError(
+                    "Could not load credentials to authenticate with AWS client. "
+                    "Please check that credentials in the specified "
+                    "profile name are valid."
+                ) from e
+
+    def _endpoint_exists(self, endpoint_name: str) -> bool:
+        """
+        Return True if and only if endpoint exists with name <endpoint_name>
+        otherwise return False.
+
+        :param endpoint_name: name of a sagemaker endpoint
+        """
+        try:
+            self.sm_client.describe_endpoint(EndpointName=endpoint_name)
+            return True
+        except Exception:
+            return False
+
+    def _inference_component_exists(self, inference_component_name: str) -> bool:
+        """
+        Return True if and only if inference component exists
+        with name <inference_component_name> otherwise return False.
+
+        :param inference_component_name: name of an inference component
+        """
+        try:
+            self.sm_client.describe_inference_component(
+                InferenceComponentName=inference_component_name
+            )
+            return True
+        except Exception:
+            return False
+
+    def _deploy_endpoint(
+        self, endpoint_name: str, execution_role: str, instance_type: str
+    ) -> None:
+        endpoint_config_name = f"{endpoint_name}-config"
+        self.sm_client.create_endpoint_config(
+            EndpointConfigName=endpoint_config_name,
+            ExecutionRoleArn=execution_role,
+            ProductionVariants=[
+                {
+                    "VariantName": "AllTraffic",
+                    "InstanceType": instance_type,
+                    "InitialInstanceCount": 1,
+                    "RoutingConfig": {"RoutingStrategy": "LEAST_OUTSTANDING_REQUESTS"},
+                }
+            ],
+        )
+        self.sm_client.create_endpoint(
+            EndpointName=endpoint_name,
+            EndpointConfigName=endpoint_config_name,
+        )
+
+        status = "Creating"
+        while status == "Creating":
+            response = self.sm_client.describe_endpoint(EndpointName=endpoint_name)
+            status = response["EndpointStatus"]
+            time.sleep(30)
+
+        if status == "Failed":
+            raise ClientError(
+                "Failed to create a new endpoint {0}"
+                "See inference component logs for more details".format(endpoint_name)
+            )
+
+    def _deploy_inference_component(
+        self, endpoint_name: str, inference_component_name: str
+    ) -> None:
+        # Do not change this variable name before changing it in the
+        # mockingbird container
+        environment_variables = {
+            "INFERENCE_EVALUATOR_CONFIG": json.dumps(
+                self.inference_evaluators_configuration
+            )
+        }
+
+        self.sm_client.create_inference_component(
+            InferenceComponentName=inference_component_name,
+            EndpointName=endpoint_name,
+            VariantName="AllTraffic",
+            Specification={
+                "ComputeResourceRequirements": {
+                    "NumberOfAcceleratorDevicesRequired": 1,
+                    "MinMemoryRequiredInMb": 1024,
+                },
+                "Container": {
+                    "Environment": environment_variables,
+                    "Image": self.inference_evaluator_image,
+                },
+            },
+            RuntimeConfig={"CopyCount": 1},
+        )
+
+        status = "Creating"
+        while status == "Creating":
+            response = self.sm_client.describe_inference_component(
+                InferenceComponentName=inference_component_name
+            )
+            status = response["InferenceComponentStatus"]
+            time.sleep(30)
+
+        if status == "Failed":
+            raise ClientError(
+                "Failed to create a new inference component {0}. "
+                "See inference component logs for more details".format(
+                    inference_component_name
+                )
+            )
+
+    def _convert_text_to_prompt(self, prompt: Any, text: str) -> Any:
+        if isinstance(prompt, StringPromptValue):
+            return StringPromptValue(text=text)
+        elif isinstance(prompt, str):
+            return text
+        elif isinstance(prompt, ChatPromptValue):
+            # Copy the messages because we may need to mutate them.
+            messages = prompt.to_messages()
+            message = messages[self.chat_message_index]
+
+            if isinstance(message, HumanMessage):
+                messages[self.chat_message_index] = HumanMessage(
+                    content=text,
+                    example=message.example,
+                    additional_kwargs=message.additional_kwargs,
+                )
+            if isinstance(message, AIMessage):
+                messages[self.chat_message_index] = AIMessage(
+                    content=text,
+                    example=message.example,
+                    additional_kwargs=message.additional_kwargs,
+                )
+            return ChatPromptValue(messages=messages)
+        else:
+            raise ValueError(
+                f"Invalid input type {type(input)}. "
+                "Must be a PromptValue, str, or list of BaseMessages."
+            )
+
+    def _convert_prompt_to_text(self, prompt: Any) -> str:
+        input_text = str()
+        if isinstance(prompt, StringPromptValue):
+            input_text = prompt.text
+        elif isinstance(prompt, str):
+            input_text = prompt
+        elif isinstance(prompt, ChatPromptValue):
+            message = prompt.messages[-1]
+            self.chat_message_index = len(prompt.messages) - 1
+            if isinstance(message, HumanMessage):
+                input_text = cast(str, message.content)
+
+            if isinstance(message, AIMessage):
+                input_text = cast(str, message.content)
+        else:
+            raise ValueError(
+                f"Invalid input type {type(prompt)}. "
+                "Must be a PromptValue, str, or list of BaseMessages."
+            )
+        return input_text
+
+    def _call_inference_evaluator(self, request: str) -> dict:
+        if self.endpoint_name and self.inference_component_name:
+            response = self.sm_runtime_client.invoke_endpoint(
+                EndpointName=self.endpoint_name,
+                InferenceComponentName=self.inference_component_name,
+                ContentType="application/json",
+                Accept="application/json",
+                Body=json.dumps(request),
+            )
+        else:
+            raise ValueError("Inference evaluator must be deployed prior to invocation")
+
+        return json.loads(response["Body"].read().decode("utf-8"))
+
+    def _execute_actions(
+        self, input_text: str, inference_evaluator_response: dict
+    ) -> str:
+        # The input_text could be modified with redact action
+        output_text = input_text
+        for action_data in inference_evaluator_response["actions"]:
+            if action_data["type"] in ACTION_REGISTRY:
+                action = ACTION_REGISTRY[action_data["type"]]()  # type: ignore
+
+            elif action_data["type"] == "Custom":
+                if action_data["configuration"]["action_name"] in ACTION_REGISTRY:
+                    action = ACTION_REGISTRY[  # type: ignore
+                        action_data["configuration"]["action_name"]
+                    ]()
+                else:
+                    action_name = action_data["configuration"]["action_name"]
+                    raise ValueError(
+                        f"Invalid action name {action_name} for CustomBehavior"
+                    )
+            else:
+                raise ValueError(f'Invalid action type {action_data["type"]}.')
+
+            output_text = action.run(input_text, action_data["configuration"])
+        return output_text
+
+    def deploy(
+        self,
+        endpoint_name: str,
+        inference_component_name: str,
+        execution_role: str,
+        instance_type: str = "ml.g5.xlarge",
+    ) -> None:
+        if not self._endpoint_exists(endpoint_name):
+            self._deploy_endpoint(endpoint_name, execution_role, instance_type)
+
+        if not self._inference_component_exists(inference_component_name):
+            self._deploy_inference_component(endpoint_name, inference_component_name)
+
+        # Set the endpoint name and inference component name once they are deployed
+        # These variables are used to verify if the resources are deployed
+        # before invocation.
+        self.endpoint_name = endpoint_name
+        self.inference_component_name = inference_component_name
+
+    def invoke(
+        self,
+        input: Input,
+        config: Optional[RunnableConfig] = None,
+        **kwargs: Optional[Any],
+    ) -> Output:
+        input_text = self._convert_prompt_to_text(prompt=input)
+        inference_evaluator_response = self._call_inference_evaluator(input_text)
+
+        output_text = self._execute_actions(input_text, inference_evaluator_response)
+        return self._convert_text_to_prompt(prompt=input, text=output_text)

--- a/libs/aws/langchain_aws/evaluators/inference_evaluator_exception.py
+++ b/libs/aws/langchain_aws/evaluators/inference_evaluator_exception.py
@@ -1,0 +1,11 @@
+class InferenceEvaluatorError(Exception):
+    """
+    Exception raised if PII entities are detected.
+
+    Attributes:
+        message -- explanation of the error
+    """
+
+    def __init__(self, message: str):
+        self.message = message
+        super().__init__(self.message)

--- a/libs/aws/tests/unit_tests/evaluators/test_inference_evaluator.py
+++ b/libs/aws/tests/unit_tests/evaluators/test_inference_evaluator.py
@@ -1,0 +1,468 @@
+# flake8: noqa
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from langchain_aws.evaluators.action_registry import ActionInterface
+from langchain_aws.evaluators.inference_evaluator import (
+    RunnableSageMakerInferenceEvaluator,
+)
+from langchain_aws.evaluators.inference_evaluator_exception import (
+    InferenceEvaluatorError,
+)
+
+RUNNABLE_INFERENCE_EVALUATOR_PATH = (
+    "langchain_aws.evaluators.inference_evaluator.RunnableSageMakerInferenceEvaluator"
+)
+
+TEST_INFERENCE_EVALUATOR_CONFIG = {
+    "name": "example_config_1",
+    "policies": [
+        {
+            "evaluation_algorithm": {
+                "type": "toxicity",
+                "evaluation_algorithm_config": {"model_type": "toxigen"},
+            },
+            "actions": [
+                {
+                    "type": "Deny",
+                    "criteria": {"category": "toxicity", "operator": ">", "value": 0.4},
+                    "configuration": {
+                        "alternative_response": "Please provide a safe prompt."
+                        + "The toxicity score is above 0.5.",
+                    },
+                },
+            ],
+        },
+        {
+            "evaluation_algorithm": {
+                "type": "toxicity",
+                "evaluation_algorithm_config": {"model_type": "detoxify"},
+            },
+            "actions": [
+                {
+                    "type": "Redact",
+                    "criteria": {"category": "toxicity", "operator": "<", "value": 0.4},
+                    "configuration": {
+                        "action_name": "AppendMessage",
+                        "additional_parameters": {"message": "RAG_CONTEXT=API"},
+                    },
+                },
+            ],
+        },
+        {
+            "evaluation_algorithm": {
+                "type": "rule",
+                "evaluation_algorithm_config": {
+                    "model_type": "regex",
+                    "pattern": ".*Instruct.*",
+                },
+            },
+            "actions": [
+                {
+                    "type": "Instruct",
+                    "criteria": {"category": "RULE", "operator": "=", "value": 1},
+                    "configuration": {
+                        "action_name": "EventBridge",
+                        "additional_parameters": {
+                            "api_invokes": {
+                                "create_event_bus": {"Name": "TestEventBridgeName"},
+                                "put_events": {
+                                    "Entries": [
+                                        {
+                                            "Source": "com.mycompany.myapp",
+                                            "Detail": '{ "key1": "value1", '
+                                            + '"key2": "value2" }',
+                                            "Resources": ["resource1", "resource2"],
+                                            "DetailType": "myDetailType",
+                                        },
+                                    ],
+                                },
+                            }
+                        },
+                    },
+                }
+            ],
+        },
+    ],
+}
+
+
+def inference_evaluator_method_path(method_name: str) -> str:
+    return "{0}.{1}".format(RUNNABLE_INFERENCE_EVALUATOR_PATH, method_name)
+
+
+@pytest.fixture
+def runnable_sagemaker_inference_evaluator_fixture() -> (
+    RunnableSageMakerInferenceEvaluator
+):
+    # Mock boto3 import
+    mock_boto3 = MagicMock()
+    mock_boto3.Session.return_value.client.return_value = (
+        MagicMock()
+    )  # Mocking the client method of the Session object
+
+    with patch.dict(
+        "sys.modules", {"boto3": mock_boto3}
+    ):  # Mocking boto3 at the top level using patch.dict
+        return RunnableSageMakerInferenceEvaluator(
+            inference_evaluator_name="test-inference-evaluator",
+            inference_evaluators_configuration=TEST_INFERENCE_EVALUATOR_CONFIG,
+        )
+
+
+@pytest.fixture
+def deployed_runnable_sagemaker_inference_evaluator_fixture(
+    runnable_sagemaker_inference_evaluator_fixture: RunnableSageMakerInferenceEvaluator,
+) -> RunnableSageMakerInferenceEvaluator:
+    runnable_sagemaker_inference_evaluator_fixture._endpoint_exists = MagicMock(  # type: ignore
+        return_value=True
+    )
+    runnable_sagemaker_inference_evaluator_fixture._inference_component_exists = (  # type: ignore
+        MagicMock(return_value=True)
+    )
+
+    runnable_sagemaker_inference_evaluator_fixture.deploy(
+        endpoint_name="test-endpoint",
+        inference_component_name="test-inference-component",
+        execution_role="arn:aws:iam::<account-number>:role/test-exec-role",
+    )
+
+    return runnable_sagemaker_inference_evaluator_fixture
+
+
+@pytest.fixture
+def deployed_runnable_sagemaker_inference_evaluator_with_deny_action(
+    deployed_runnable_sagemaker_inference_evaluator_fixture: RunnableSageMakerInferenceEvaluator,
+) -> RunnableSageMakerInferenceEvaluator:
+    inference_evaluator_output = {
+        "name": "test-inference-evaluation",
+        "actions": [
+            {
+                "type": "Deny",
+                "configuration": {
+                    "alternative_response": "Please provide a safe prompt."
+                    + "The toxicity score is above 0.5."
+                },
+            }
+        ],
+        "evaluation_scores": [
+            {
+                "evaluation_algorithm_type": "toxicity",
+                "model_type": "toxigen",
+                "scores": [{"name": "toxicity", "value": 0.9}],
+            }
+        ],
+    }
+
+    deployed_runnable_sagemaker_inference_evaluator_fixture._call_inference_evaluator = MagicMock(  # type: ignore
+        return_value=inference_evaluator_output
+    )
+
+    return deployed_runnable_sagemaker_inference_evaluator_fixture
+
+
+@pytest.fixture
+def deployed_runnable_sagemaker_inference_evaluator_with_redact_action(
+    deployed_runnable_sagemaker_inference_evaluator_fixture: RunnableSageMakerInferenceEvaluator,
+) -> RunnableSageMakerInferenceEvaluator:
+    inference_evaluator_output = {
+        "name": "test-inference-evaluation",
+        "actions": [
+            {
+                "type": "Redact",
+                "configuration": {
+                    "action_name": "AppendMessage",
+                    "additional_parameters": {"message": "RAG_CONTEXT=API"},
+                },
+            }
+        ],
+        "evaluation_scores": [
+            {
+                "evaluation_algorithm_type": "toxicity",
+                "model_type": "toxigen",
+                "scores": [{"name": "toxicity", "value": 0.9}],
+            }
+        ],
+    }
+
+    deployed_runnable_sagemaker_inference_evaluator_fixture._call_inference_evaluator = MagicMock(  # type: ignore
+        return_value=inference_evaluator_output
+    )
+
+    return deployed_runnable_sagemaker_inference_evaluator_fixture
+
+
+@pytest.fixture
+def deployed_runnable_sagemaker_inference_evaluator_with_instruct_action(
+    deployed_runnable_sagemaker_inference_evaluator_fixture: RunnableSageMakerInferenceEvaluator,
+) -> RunnableSageMakerInferenceEvaluator:
+    inference_evaluator_output = {
+        "name": "test-inference-evaluation",
+        "actions": [
+            {
+                "type": "Instruct",
+                "configuration": {
+                    "action_name": "EventBridge",
+                    "additional_parameters": {
+                        "api_invokes": {
+                            "create_event_bus": {"Name": "TestEventBridgeName"},
+                            "put_events": {
+                                "Entries": [
+                                    {
+                                        "Source": "com.mycompany.myapp",
+                                        "Detail": (
+                                            '{ "key1": "value1", "key2": "value2" }'
+                                        ),
+                                        "Resources": ["resource1", "resource2"],
+                                        "DetailType": "myDetailType",
+                                    }
+                                ]
+                            },
+                        }
+                    },
+                },
+            }
+        ],
+        "evaluation_scores": [
+            {
+                "evaluation_algorithm_type": "toxicity",
+                "model_type": "toxigen",
+                "scores": [{"name": "toxicity", "value": 0.9}],
+            }
+        ],
+    }
+
+    deployed_runnable_sagemaker_inference_evaluator_fixture._call_inference_evaluator = MagicMock(  # type: ignore
+        return_value=inference_evaluator_output
+    )
+
+    return deployed_runnable_sagemaker_inference_evaluator_fixture
+
+
+@pytest.fixture
+def deployed_runnable_sagemaker_inference_evaluator_without_event_bus_name(
+    deployed_runnable_sagemaker_inference_evaluator_fixture: RunnableSageMakerInferenceEvaluator,
+) -> RunnableSageMakerInferenceEvaluator:
+    inference_evaluator_output = {
+        "name": "test-inference-evaluation",
+        "actions": [
+            {
+                "type": "Instruct",
+                "configuration": {
+                    "action_name": "EventBridge",
+                    "additional_parameters": {
+                        "api_invokes": {
+                            "create_event_bus": {},
+                        }
+                    },
+                },
+            }
+        ],
+        "evaluation_scores": [
+            {
+                "evaluation_algorithm_type": "toxicity",
+                "model_type": "toxigen",
+                "scores": [{"name": "toxicity", "value": 0.9}],
+            }
+        ],
+    }
+
+    deployed_runnable_sagemaker_inference_evaluator_fixture._call_inference_evaluator = MagicMock(  # type: ignore
+        return_value=inference_evaluator_output
+    )
+
+    return deployed_runnable_sagemaker_inference_evaluator_fixture
+
+
+@pytest.fixture
+def deployed_runnable_sagemaker_inference_evaluator_with_custom_action(
+    deployed_runnable_sagemaker_inference_evaluator_fixture: RunnableSageMakerInferenceEvaluator,
+) -> RunnableSageMakerInferenceEvaluator:
+    inference_evaluator_output = {
+        "name": "test-inference-evaluation",
+        "actions": [
+            {
+                "type": "Custom",
+                "configuration": {
+                    "action_name": "MyCustomAction",
+                    "additional_parameters": {"message": "Message for custom action!"},
+                },
+            }
+        ],
+        "evaluation_scores": [
+            {
+                "evaluation_algorithm_type": "toxicity",
+                "model_type": "toxigen",
+                "scores": [{"name": "toxicity", "value": 0.9}],
+            }
+        ],
+    }
+
+    deployed_runnable_sagemaker_inference_evaluator_fixture._call_inference_evaluator = MagicMock(  # type: ignore
+        return_value=inference_evaluator_output
+    )
+
+    return deployed_runnable_sagemaker_inference_evaluator_fixture
+
+
+def test_inference_evaluator_invoke_without_deploying(
+    runnable_sagemaker_inference_evaluator_fixture: RunnableSageMakerInferenceEvaluator,
+) -> None:
+    with pytest.raises(ValueError) as invoke_error:
+        runnable_sagemaker_inference_evaluator_fixture.invoke(input="toxic text")
+        assert invoke_error.value == (
+            "Inference evaluator must be deployed prior to invocation"
+        )
+
+
+def test_convert_text_to_prompt(
+    deployed_runnable_sagemaker_inference_evaluator_fixture: RunnableSageMakerInferenceEvaluator,
+) -> None:
+    with pytest.raises(ValueError) as invoke_error:
+        deployed_runnable_sagemaker_inference_evaluator_fixture._convert_text_to_prompt(
+            None, "mock-text"
+        )
+
+
+def test_convert_prompt_to_text(
+    deployed_runnable_sagemaker_inference_evaluator_fixture: RunnableSageMakerInferenceEvaluator,
+) -> None:
+    with pytest.raises(ValueError) as invoke_error:
+        deployed_runnable_sagemaker_inference_evaluator_fixture._convert_prompt_to_text(
+            None
+        )
+
+
+@patch(inference_evaluator_method_path("_deploy_inference_component"))
+@patch(inference_evaluator_method_path("_deploy_endpoint"))
+def test_inference_evaluator_deploy_when_resources_exist(
+    mock_deploy_inference_component: MagicMock,
+    mock_deploy_endpoint: MagicMock,
+    deployed_runnable_sagemaker_inference_evaluator_fixture: RunnableSageMakerInferenceEvaluator,
+) -> None:
+    mock_deploy_inference_component.assert_not_called()
+    mock_deploy_endpoint.assert_not_called()
+
+    assert (
+        deployed_runnable_sagemaker_inference_evaluator_fixture.endpoint_name
+        is not None
+    )
+    assert (
+        deployed_runnable_sagemaker_inference_evaluator_fixture.inference_component_name
+        is not None
+    )
+
+
+@patch(inference_evaluator_method_path("_deploy_inference_component"))
+@patch(inference_evaluator_method_path("_deploy_endpoint"))
+def test_inference_evaluator_deploy_when_resources_does_not_exist(
+    mock_deploy_inference_component: MagicMock,
+    mock_deploy_endpoint: MagicMock,
+    runnable_sagemaker_inference_evaluator_fixture: RunnableSageMakerInferenceEvaluator,
+) -> None:
+    runnable_sagemaker_inference_evaluator_fixture._endpoint_exists = MagicMock(  # type: ignore
+        return_value=False
+    )
+    runnable_sagemaker_inference_evaluator_fixture._inference_component_exists = (  # type: ignore
+        MagicMock(return_value=False)
+    )
+
+    runnable_sagemaker_inference_evaluator_fixture.deploy(
+        endpoint_name="test-endpoint",
+        inference_component_name="test-inference-component",
+        execution_role="arn:aws:iam::<account-number>:role/test-exec-role",
+    )
+
+    mock_deploy_inference_component.assert_called_once()
+    mock_deploy_endpoint.assert_called_once()
+
+    assert runnable_sagemaker_inference_evaluator_fixture.endpoint_name is not None
+    assert (
+        runnable_sagemaker_inference_evaluator_fixture.inference_component_name
+        is not None
+    )
+
+
+def test_inference_evaluator_when_deny_action_is_triggered(
+    deployed_runnable_sagemaker_inference_evaluator_with_deny_action: RunnableSageMakerInferenceEvaluator,
+) -> None:
+    with pytest.raises(InferenceEvaluatorError) as inference_evaluator_error:
+        deployed_runnable_sagemaker_inference_evaluator_with_deny_action.invoke(
+            input="toxic text"
+        )
+
+        assert inference_evaluator_error.value == (
+            "Please provide a safe prompt. The toxicity score is above 0.5."
+        )
+
+
+def test_inference_evaluator_when_redact_action_is_triggered(
+    deployed_runnable_sagemaker_inference_evaluator_with_redact_action: RunnableSageMakerInferenceEvaluator,
+) -> None:
+    output = deployed_runnable_sagemaker_inference_evaluator_with_redact_action.invoke(
+        input="toxic text"
+    )
+
+    assert output == "toxic text\nRAG_CONTEXT=API"
+
+
+@patch("boto3.client")
+def test_inference_evaluator_when_instruct_action_is_triggered(
+    mock_boto_client: MagicMock,
+    deployed_runnable_sagemaker_inference_evaluator_with_instruct_action: RunnableSageMakerInferenceEvaluator,
+) -> None:
+    with patch(
+        "boto3.client.return_value.describe_event_bus"
+    ) as mock_describe_event_bus:
+        mock_describe_event_bus.side_effect = Exception("event-bus does not exist.")
+
+        output = (
+            deployed_runnable_sagemaker_inference_evaluator_with_instruct_action.invoke(
+                input="toxic text"
+            )
+        )
+
+        mock_boto_client.assert_called_once_with("events")
+        mock_boto_client.return_value.create_event_bus.assert_called()
+        mock_boto_client.return_value.put_events.assert_called()
+
+        assert output == "toxic text"
+
+
+def test_inference_evaluator_when_custom_action_is_not_registered(
+    deployed_runnable_sagemaker_inference_evaluator_with_custom_action: RunnableSageMakerInferenceEvaluator,
+) -> None:
+    with pytest.raises(ValueError) as inference_evaluator_error:
+        deployed_runnable_sagemaker_inference_evaluator_with_custom_action.invoke(
+            input="toxic text"
+        )
+        assert inference_evaluator_error.value == (
+            "Invalid action name MyCustomAction for CustomBehavior"
+        )
+
+
+def test_inference_evaluator_when_custom_action_is_triggered(
+    deployed_runnable_sagemaker_inference_evaluator_with_custom_action: RunnableSageMakerInferenceEvaluator,
+) -> None:
+    class MyCustomAction(ActionInterface):
+        def run(self, input_text: str, configuration: dict) -> str:
+            message = configuration["additional_parameters"]["message"]
+            return message
+
+    output = deployed_runnable_sagemaker_inference_evaluator_with_custom_action.invoke(
+        input="toxic text"
+    )
+    assert output == "Message for custom action!"
+
+
+def test_inference_evaluator_when_instruct_action_is_triggered_without_event_bus_name(
+    deployed_runnable_sagemaker_inference_evaluator_without_event_bus_name: RunnableSageMakerInferenceEvaluator,
+) -> None:
+    with pytest.raises(ValueError) as create_bus_error:
+        deployed_runnable_sagemaker_inference_evaluator_without_event_bus_name.invoke(
+            input="toxic text"
+        )
+        assert create_bus_error.value == (
+            "Name for the event bus is not provided in the inference evaluator config"
+        )


### PR DESCRIPTION
### Notes
- Add `RunnableSageMakerInferenceEvaluator` to be used with langchain
-  Class methods to covert the text to prompt and vise-versa
- Methods to create endpoint and inference components
- Action registry and methods to trigger actions 

### Testing
```
> make test TEST_FILE=tests/unit_tests/evaluators/test_inference_evaluator.py
```