### PR TITLE
ChatBedrock: add usage metadata

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -486,7 +486,7 @@ class ChatBedrock(BaseChatModel, BedrockBase):
         ):
             delta = chunk.text
             if generation_info := chunk.generation_info:
-                usage_metadata = _unpack_usage_from_generation_info(generation_info)
+                usage_metadata = generation_info.pop("usage_metadata", None)
             else:
                 usage_metadata = None
             yield ChatGenerationChunk(
@@ -830,22 +830,6 @@ class ChatBedrock(BaseChatModel, BedrockBase):
             base_url=self.endpoint_url,
             **kwargs,
         )
-
-
-def _unpack_usage_from_generation_info(
-    generation_info: dict,
-) -> Optional[UsageMetadata]:
-    """Extract usage metadata from generation info."""
-    usage = generation_info.get("usage")
-    if usage is None:
-        return None
-    input_tokens = (usage.get("input_tokens") or [0])[0]
-    output_tokens = (usage.get("output_tokens") or [0])[0]
-    return UsageMetadata(
-        input_tokens=input_tokens,
-        output_tokens=output_tokens,
-        total_tokens=input_tokens + output_tokens,
-    )
 
 
 @deprecated(since="0.1.0", removal="0.2.0", alternative="ChatBedrock")

--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -94,8 +94,22 @@ def _stream_response_to_generation_chunk(
         msg_type = stream_response.get("type")
         if msg_type == "message_start":
             usage_info = stream_response.get("message", {}).get("usage", None)
+            if provider == "anthropic":
+                # Anthropic streams output_tokens == 1 in message_start events.
+                # To avoid double-counting with output_tokens in message_dleta,
+                # here we set output_tokens to 0.
+                input_tokens = usage_info.get("input_tokens", 0)
+                usage_metadata = {
+                    "input_tokens": input_tokens,
+                    "output_tokens": 0,
+                    "total_tokens": input_tokens,
+                }
+            else:
+                usage_metadata = {}
             usage_info = _nest_usage_info_token_counts(usage_info)
             generation_info = {"usage": usage_info}
+            if usage_metadata:
+                generation_info["usage_metadata"] = usage_metadata
             return GenerationChunk(text="", generation_info=generation_info)
         elif msg_type == "content_block_delta":
             if not stream_response["delta"]:
@@ -108,9 +122,20 @@ def _stream_response_to_generation_chunk(
             )
         elif msg_type == "message_delta":
             usage_info = stream_response.get("usage", None)
+            if provider == "anthropic":
+                output_tokens = usage_info.get("output_tokens", 0)
+                usage_metadata = {
+                    "input_tokens": 0,
+                    "output_tokens": output_tokens,
+                    "total_tokens": output_tokens,
+                }
+            else:
+                usage_metadata = {}
             usage_info = _nest_usage_info_token_counts(usage_info)
             stop_reason = stream_response.get("delta", {}).get("stop_reason")
             generation_info = {"stop_reason": stop_reason, "usage": usage_info}
+            if usage_metadata:
+                generation_info["usage_metadata"] = usage_metadata
             return GenerationChunk(text="", generation_info=generation_info)
         else:
             return None

--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock.py
@@ -143,8 +143,16 @@ def test_bedrock_streaming(chat: ChatBedrock) -> None:
 async def test_bedrock_astream(chat: ChatBedrock) -> None:
     """Test streaming tokens from OpenAI."""
 
+    full = None
     async for token in chat.astream("I'm Pickle Rick"):
+        full = token if full is None else full + token  # type: ignore[operator]
         assert isinstance(token.content, str)
+    assert isinstance(full, AIMessageChunk)
+    assert isinstance(full.content, str)
+    assert full.usage_metadata is not None
+    assert full.usage_metadata["input_tokens"] > 0
+    assert full.usage_metadata["output_tokens"] > 0
+    assert full.usage_metadata["total_tokens"] > 0
 
 
 @pytest.mark.scheduled

--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock.py
@@ -124,9 +124,18 @@ def test_chat_bedrock_streaming_generation_info() -> None:
 
 
 @pytest.mark.scheduled
-def test_bedrock_streaming(chat: ChatBedrock) -> None:
-    """Test streaming tokens from OpenAI."""
-
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "anthropic.claude-3-sonnet-20240229-v1:0",
+        "mistral.mistral-7b-instruct-v0:2",
+    ],
+)
+def test_bedrock_streaming(model_id: str) -> None:
+    chat = ChatBedrock(
+        model_id=model_id,
+        model_kwargs={"temperature": 0},
+    )  # type: ignore[call-arg]
     full = None
     for token in chat.stream("I'm Pickle Rick"):
         full = token if full is None else full + token  # type: ignore[operator]
@@ -140,9 +149,19 @@ def test_bedrock_streaming(chat: ChatBedrock) -> None:
 
 
 @pytest.mark.scheduled
-async def test_bedrock_astream(chat: ChatBedrock) -> None:
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "anthropic.claude-3-sonnet-20240229-v1:0",
+        "mistral.mistral-7b-instruct-v0:2",
+    ],
+)
+async def test_bedrock_astream(model_id: str) -> None:
     """Test streaming tokens from OpenAI."""
-
+    chat = ChatBedrock(
+        model_id=model_id,
+        model_kwargs={"temperature": 0},
+    )  # type: ignore[call-arg]
     full = None
     async for token in chat.astream("I'm Pickle Rick"):
         full = token if full is None else full + token  # type: ignore[operator]

--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock.py
@@ -1,6 +1,6 @@
 """Test Bedrock chat model."""
 import json
-from typing import Any, cast
+from typing import Any
 
 import pytest
 from langchain_core.messages import (
@@ -131,7 +131,12 @@ def test_bedrock_streaming(chat: ChatBedrock) -> None:
     for token in chat.stream("I'm Pickle Rick"):
         full = token if full is None else full + token  # type: ignore[operator]
         assert isinstance(token.content, str)
-    assert isinstance(cast(AIMessageChunk, full).content, str)
+    assert isinstance(full, AIMessageChunk)
+    assert isinstance(full.content, str)
+    assert full.usage_metadata is not None
+    assert full.usage_metadata["input_tokens"] > 0
+    assert full.usage_metadata["output_tokens"] > 0
+    assert full.usage_metadata["total_tokens"] > 0
 
 
 @pytest.mark.scheduled

--- a/libs/aws/tests/integration_tests/chat_models/test_standard.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_standard.py
@@ -23,10 +23,6 @@ class TestBedrockStandard(ChatModelIntegrationTests):
         return {}
 
     @pytest.mark.xfail(reason="Not implemented.")
-    def test_usage_metadata(self, model: BaseChatModel) -> None:
-        super().test_usage_metadata(model)
-
-    @pytest.mark.xfail(reason="Not implemented.")
     def test_stop_sequence(self, model: BaseChatModel) -> None:
         super().test_stop_sequence(model)
 


### PR DESCRIPTION
langchain-core 0.2.2 released a standard field to store usage metadata returned from chat model responses, such as input / output token counts. AIMessage objects have a `.usage_metadata` attribute which can hold a [UsageMetadata](https://api.python.langchain.com/en/latest/messages/langchain_core.messages.ai.UsageMetadata.html) dict. For now it is only holding token counts. Standardizing this information makes it simpler to track in monitoring / observability platforms and similar applications.

Here we unpack usage metadata returned by the Bedrock API onto AIMessages generated by chat models.

There are at least two options for implementing this in a streaming context:
1. (Implemented here) Currently, Bedrock streams a final chunk containing usage data in `"amazon-bedrock-invocationMetrics"`, which we ignore. These data appear standardized, at least for Anthropic and Mistral (I also checked Cohere and Llama3, but streaming for chat models does not work on either currently). We can emit an additional chunk containing these data. The advantage of this is that we may not have to implement any provider-specific processing. The disadvantage is that currently the final chunk contains a `"stop_reason"`, and if users are assuming this is the final chunk, this could break workflows.

Before:
```
content='' response_metadata={'usage': {'input_tokens': [8], 'output_tokens': [1]}}
content='Hello' response_metadata={'stop_reason': None}
content='!' response_metadata={'stop_reason': None}
content='' response_metadata={'stop_reason': 'max_tokens', 'usage': {'output_tokens': [2]}}
```

After:
```
content='' response_metadata={'usage': {'input_tokens': [8], 'output_tokens': [1]}}
content='Hello' response_metadata={'stop_reason': None}
content='!' response_metadata={'stop_reason': None}
content='' response_metadata={'stop_reason': 'max_tokens', 'usage': {'output_tokens': [2]}}
content='' usage_metadata={'input_tokens': 8, 'output_tokens': 2, 'total_tokens': 10}
```

2. (Implemented in commit history) Implement provider-specific processing, specifically for Anthropic. This is what I did first. Commit https://github.com/langchain-ai/langchain-aws/pull/85/commits/2b9e4003bee8c57f974cf8dd7a8618a534e2d2c5 changes to option 1, and if we want we can revert that commit.