### PR TITLE
[WIP] Bedrock Agents Runnable

### DIFF
--- a/libs/aws/langchain_aws/agents/base.py
+++ b/libs/aws/langchain_aws/agents/base.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import boto3
+import botocore
+from langchain_core.agents import AgentAction, AgentFinish
+from langchain_core.messages import AIMessage
+from langchain_core.pydantic_v1 import Field, root_validator
+from langchain_core.runnables import RunnableConfig, RunnableSerializable, ensure_config
+
+_DEFAULT_ACTION_GROUP_NAME = "DEFAULT_AG_"
+_TEST_AGENT_ALIAS_ID = "TSTALIASID"
+
+
+def get_bedrock_agents_client() -> None:
+    bedrock_config = botocore.client.Config(
+        connect_timeout=120,
+        read_timeout=120,
+        retries={"max_attempts": 3},
+        region_name="us-west-2",
+    )
+    return boto3.client("bedrock-agent-runtime", config=bedrock_config)
+
+
+def parse_agent_response(response: Any) -> OutputType:
+    response_text = ""
+    event_stream = response["completion"]
+    for event in event_stream:
+        if "returnControl" in event:
+            response_text = json.dumps(event)
+            break
+
+        if "chunk" in event:
+            response_text = event["chunk"]["bytes"].decode("utf-8")
+
+    agent_finish = AgentFinish({"output": response_text}, log=response_text)
+    if not response_text:
+        return agent_finish
+
+    if "returnControl" not in response_text:
+        return agent_finish
+
+    return_control = json.loads(response_text).get("returnControl")
+    if not return_control:
+        return agent_finish
+
+    invocation_inputs = return_control.get("invocationInputs")
+    if not invocation_inputs:
+        return agent_finish
+
+    try:
+        invocation_input = invocation_inputs[0].get("functionInvocationInput", {})
+        action_group = invocation_input.get("actionGroup", "")
+        function = invocation_input.get("function", "")
+        parameters = invocation_input.get("parameters", [])
+        parameters_json = {}
+        for parameter in parameters:
+            parameters_json[parameter.get("name")] = parameter.get("value", "")
+
+        tool = f"{action_group}::{function}"
+        if _DEFAULT_ACTION_GROUP_NAME in action_group:
+            tool = f"{function}"
+        return [AgentAction(tool=tool, tool_input=parameters_json, log=response_text)]
+    except Exception as ex:
+        raise Exception("Parse exception encountered {}".format(repr(ex)))
+
+
+OutputType = Union[List[AgentAction], AgentFinish]
+
+
+class BedrockAgentsRunnable(RunnableSerializable[Dict, OutputType]):
+    client: Any = Field(default_factory=get_bedrock_agents_client)
+    agent_alias_id: str = _TEST_AGENT_ALIAS_ID
+    agent_id: Optional[str] = None
+    session_id: Optional[str] = None
+    enable_trace: bool = False
+
+    @root_validator
+    def validate_agent(cls, values: dict) -> dict:
+        # Can create and prepare agents here
+        # Set agent_id, agent_alias_id, session_id etc.
+        if not values["session_id"]:
+            values["session_id"] = uuid.uuid4().hex
+
+        return values
+
+    @classmethod
+    def create_agent(cls, kwargs: Any) -> BedrockAgentsRunnable:
+        return cls(**kwargs)
+
+    def invoke(
+        self, input: Dict, config: Optional[RunnableConfig] = None
+    ) -> OutputType:
+        config = ensure_config(config)
+        agent_input = {
+            "agentId": self.agent_id,
+            "agentAliasId": self.agent_alias_id,
+            "enableTrace": self.enable_trace,
+            "sessionId": self.session_id,
+        }
+        if input.get("intermediate_steps"):
+            session_state = self._parse_intermediate_steps(
+                input.get("intermediate_steps")  # type: ignore[arg-type]
+            )
+            if session_state is not None:
+                agent_input["sessionState"] = session_state
+        else:
+            agent_input["inputText"] = input.get("input", "")
+
+        output = self.client.invoke_agent(**agent_input)
+        return parse_agent_response(output)
+
+    def _parse_intermediate_steps(
+        self, intermediate_steps: List[Tuple[AgentAction, str]]
+    ) -> Any:
+        last_step = max(0, len(intermediate_steps) - 1)
+        action = intermediate_steps[last_step][0]
+        tool_invoked = action.tool
+        messages = action.messages
+
+        if tool_invoked:
+            action_group_name = _DEFAULT_ACTION_GROUP_NAME
+            function_name = tool_invoked
+            tool_name_split = tool_invoked.split("::")
+            if len(tool_name_split) > 1:
+                action_group_name = tool_name_split[0]
+                function_name = tool_name_split[1]
+
+            if messages:
+                last_message = max(0, len(messages) - 1)
+                message = messages[last_message]
+                if type(message) is AIMessage:
+                    response = intermediate_steps[last_step][1]
+                    session_state = {
+                        "invocationId": json.loads(message.content)  # type: ignore[arg-type]
+                        .get("returnControl", {})
+                        .get("invocationId", ""),
+                        "returnControlInvocationResults": [
+                            {
+                                "functionResult": {
+                                    "actionGroup": action_group_name,
+                                    "function": function_name,
+                                    "responseBody": {"TEXT": {"body": response}},
+                                }
+                            }
+                        ],
+                    }
+
+                    return session_state

--- a/libs/aws/tests/integration_tests/agents/test_bedrock_agents.py
+++ b/libs/aws/tests/integration_tests/agents/test_bedrock_agents.py
@@ -4,13 +4,13 @@ from langchain_aws.agents.base import BedrockAgentsRunnable
 
 
 @tool("AssetDetail::getAssetValue")
-def getAssetValue(asset_holder_id: str = " ") -> str:
+def getAssetValue(asset_holder_id: str) -> str:
     """Get the asset value for an owner id"""
     return f"The total asset value for {asset_holder_id} is 100K"
 
 
 @tool
-def getMortgageRate(asset_holder_id: str = " ", asset_value: str = " ") -> str:
+def getMortgageRate(asset_holder_id: str, asset_value: str) -> str:
     """Get the mortgage rate based on asset value"""
     return (
         f"The mortgage rate for {asset_holder_id} "

--- a/libs/aws/tests/integration_tests/agents/test_bedrock_agents.py
+++ b/libs/aws/tests/integration_tests/agents/test_bedrock_agents.py
@@ -1,0 +1,34 @@
+from langchain_core.tools import tool
+
+from langchain_aws.agents.base import BedrockAgentsRunnable
+
+
+@tool("AssetDetail::getAssetValue")
+def getAssetValue(asset_holder_id: str = " ") -> str:
+    """Get the asset value for an owner id"""
+    return f"The total asset value for {asset_holder_id} is 100K"
+
+
+@tool
+def getMortgageRate(asset_holder_id: str = " ", asset_value: str = " ") -> str:
+    """Get the mortgage rate based on asset value"""
+    return (
+        f"The mortgage rate for {asset_holder_id} "
+        f"with asset value of {asset_value} is 8.87%"
+    )
+
+
+def test_bedrock_agent() -> None:
+    from langchain.agents import AgentExecutor
+
+    agent = BedrockAgentsRunnable.create_agent(
+        {"agent_id": "UKYYJIV1O1", "enable_trace": True}
+    )
+    tools = [getAssetValue, getMortgageRate]
+    agent_executor = AgentExecutor(agent=agent, tools=tools)  # type: ignore[arg-type]
+
+    output = agent_executor.invoke(
+        {"input": "what is my mortgage rate for id AVC-1234"}
+    )
+
+    assert output["output"] == "The mortgage rate for id AVC-1234 is 8.87%"


### PR DESCRIPTION
# Description
This PR introduces a new Bedrock Agents Runnable that allows using [Bedrock Agents](https://docs.aws.amazon.com/bedrock/latest/userguide/agents-returncontrol.html) with return of control functions as tools.

## Usage
Define tools
```python
from langchain_core.tools import tool

@tool("AssetDetail::getAssetValue")
def getAssetValue(asset_holder_id: str = " ") -> str:
    """Get the asset value for an owner id"""
    return f"The total asset value for {asset_holder_id} is 100K"


@tool
def getMortgageRate(asset_holder_id: str = " ", asset_value: str = " ") -> str:
    """Get the mortgage rate based on asset value"""
    return (
        f"The mortgage rate for {asset_holder_id} "
        f"with asset value of {asset_value} is 8.87%"
    )
```

Create the agent and use with AgentExecutor
```python
from langchain.agents import AgentExecutor

agent = BedrockAgentsRunnable.create_agent(
    {"agent_id": "UKYYJIV1O1", "enable_trace": True}
)
tools = [getAssetValue, getMortgageRate]
agent_executor = AgentExecutor(agent=agent, tools=tools)  # type: ignore[arg-type]

output = agent_executor.invoke(
    {"input": "what is my mortgage rate for id AVC-1234"}
)

assert output["output"] == "The mortgage rate for id AVC-1234 is 8.87%"
```

## Notes
This change follows a strategy similar to the [OpenAIAssistantRunnable](https://github.com/langchain-ai/langchain/blob/800b0ff3b9e7fb5712445e8e4182107135f9f5f6/libs/langchain/langchain/agents/openai_assistant/base.py#L145) to create an agent. However, it's still missing the callback related code that should be plugged in before merging. This code also assumes that the agent and the corresponding actions have been setup and prepared to call before calling; this setup could be automated in the agent creation or validation function, but missing here.
