### PR TITLE
Add text extraction to tool call processing in BedrockLLM

### DIFF
--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -149,6 +149,7 @@ def _combine_generation_info_for_llm_result(
     Takes a list of generation_info from GenerationChunks
     If the messages api is being used,
     the generation_info from some of these chunks should contain "usage" keys
+    if not, the token counts should be found within "amazon-bedrock-invocationMetrics"
     """
     total_usage_info = {"prompt_tokens": 0, "completion_tokens": 0}
     stop_reason = ""


### PR DESCRIPTION
## Description
This pull request enhances the functionality of the `BedrockLLM` class by modifying how tool calls and text are extracted from the model's response. Previously, when tools were provided, only tool calls were extracted, and any text content was ignored. This change allows for both tool calls and text to be processed and returned.

Here an example answer before the change:
```
content='' additional_kwargs={'usage': {'prompt_tokens': 411, 'completion_tokens': 89, 'total_tokens': 500}, 'stop_reason': 'tool_use', 'model_id': 'anthropic.claude-3-sonnet-20240229-v1:0'} response_metadata={'usage': {'prompt_tokens': 411, 'completion_tokens': 89, 'total_tokens': 500}, 'stop_reason': 'tool_use', 'model_id': 'anthropic.claude-3-sonnet-20240229-v1:0'} id='run-7e8d1ca5-7556-414c-9c29-9a51e79aced1-0' tool_calls=[{'name': 'multiply', 'args': {'first_int': 23, 'second_int': 7}, 'id': 'toolu_bdrk_01MqueVwRGpJuKh6mC8mU5Zm'}] usage_metadata={'input_tokens': 411, 'output_tokens': 89, 'total_tokens': 500}
```

Here after the change: 
```
content="Okay, let's multiply 5 and 42 using the tool:", additional_kwargs={'usage': {'prompt_tokens': 246, 'completion_tokens': 90, 'total_tokens': 336}, 'stop_reason': 'tool_use', 'model_id': 'anthropic.claude-3-sonnet-20240229-v1:0'}, response_metadata={'usage': {'prompt_tokens': 246, 'completion_tokens': 90, 'total_tokens': 336}, 'stop_reason': 'tool_use', 'model_id': 'anthropic.claude-3-sonnet-20240229-v1:0'}, id='run-7d3ae303-ce91-4994-881a-31ecc241994d-0', tool_calls=[{'name': 'multiply', 'args': {'first_int': 5, 'second_int': 42}, 'id': 'toolu_bdrk_01S5BvS4Ws2GFhVxKUQ7UDDo'}], usage_metadata={'input_tokens': 246, 'output_tokens': 90, 'total_tokens': 336}
```

## Changes
- Created a new function `extract_tool_calls_and_text` which replaces the existing `extract_tool_calls` function.
- The new function returns both a list of `ToolCall` objects and a string containing any text content from the response.
- Modified the relevant parts of the `BedrockLLM` class to utilize this new function and handle the returned text.

## Motivation
This change allows users to receive both tool calls and text content when using the BedrockLLM with tools, providing a more complete and flexible interaction with the model.

## Additional Notes
This change maintains backwards compatibility with existing usage while providing enhanced functionality for users who need access to both tool calls and text content.