### PR TITLE
Adding config argument for BedrockEmbeddings

### DIFF
--- a/libs/aws/langchain_aws/embeddings/bedrock.py
+++ b/libs/aws/langchain_aws/embeddings/bedrock.py
@@ -68,6 +68,9 @@ class BedrockEmbeddings(BaseModel, Embeddings):
     normalize: bool = False
     """Whether the embeddings should be normalized to unit vectors"""
 
+    config: Any = None
+    """An optional botocore.config.Config instance to pass to the client."""
+
     class Config:
         """Configuration for this pydantic object."""
 
@@ -95,6 +98,9 @@ class BedrockEmbeddings(BaseModel, Embeddings):
 
             if values["endpoint_url"]:
                 client_params["endpoint_url"] = values["endpoint_url"]
+
+            if values["config"]:
+                client_params["config"] = values["config"]
 
             values["client"] = session.client("bedrock-runtime", **client_params)
 


### PR DESCRIPTION
### Description

This pull request enhances the functionality of the `BedrockEmbeddings` class by adding an optional `config` argument as a `botocore.config.Config` to give more possible configuration for the boto3 client, in the same way as how it is done on the class `ChatBedrock`.

Here an example answer before the change:
```
embedding = BedrockEmbeddings(
    model_id="MODEL_ID",
    region_name="REGION_NAME",
    profile="PROFILE",
)
```
And now after the change:
```
config = BotocoreConfig(
    read_timeout=1000,
    retries=1,
)
embedding = BedrockEmbeddings(
    model_id="MODEL_ID",
    region_name="REGION_NAME",
    profile="PROFILE",
    config=config
)
```

### Change

- Added `config` parameter to the class `BedrockEmbeddings`

### Motivation

This change will allow user to configure `BedrockEmbeddings` the same way as  `ChatBedrock`.

### Additional Notes

This change maintains backwards compatibility with existing usage.
