### PR TITLE
Fix bug in _drop_none

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -825,7 +825,7 @@ def _snake_to_camel_keys(obj: _T) -> _T:
 def _drop_none(obj: Any) -> Any:
     if isinstance(obj, dict):
         new = {k: _drop_none(v) for k, v in obj.items() if _drop_none(v) is not None}
-        return new or None
+        return new
     else:
         return obj
 


### PR DESCRIPTION
The current implementation of `_drop_none` :
```python
def _drop_none(obj: Any) -> Any:
    if isinstance(obj, dict):
        new = {k: _drop_none(v) for k, v in obj.items() if _drop_none(v) is not None}
        return new or None
    else:
        return obj
```
throws out empty dictionaries. 
```python
_drop_none(
    {'tools': [{"toolSpec": {
                    "name": "Answer",
                    "description": "Your answer",
                    "inputSchema": {
                        "json": {
                            "type": "object",
                            "properties": {
                                "answer": {
                                    "type": "string",
                                    "description": "Your answer"
                                },
                            },
                            "required": ["answer"]
                        }
                    }
                }},
            {'toolSpec':
                {
                    "name": "get_weather",
                    "description": "Get the current weather in a given location",
                    "inputSchema": {
                        "json": {
                            "type": "object",
                            "properties": {
                                "location": {
                                    "type": "string",
                                    "description": "The city and state, e.g. San Francisco, CA"
                                },
                                "unit": {
                                    "type": "string",
                                    "enum": ["celsius", "fahrenheit"],
                                    "description": "The unit of temperature, either \"celsius\" or \"fahrenheit\""
                                }
                            },
                            "required": ["location"]
                        }
                    }
                }
                }],
     'toolChoice': {'any': {}}}
)
```
returns 
```python
{'tools': [{'toolSpec': {'name': 'Answer',
    'description': 'Your answer',
    'inputSchema': {'json': {'type': 'object',
      'properties': {'answer': {'type': 'string',
        'description': 'Your answer'}},
      'required': ['answer']}}}},
  {'toolSpec': {'name': 'get_weather',
    'description': 'Get the current weather in a given location',
    'inputSchema': {'json': {'type': 'object',
      'properties': {'location': {'type': 'string',
        'description': 'The city and state, e.g. San Francisco, CA'},
       'unit': {'type': 'string',
        'enum': ['celsius', 'fahrenheit'],
        'description': 'The unit of temperature, either "celsius" or "fahrenheit"'}},
      'required': ['location']}}}}]}
```
with the **'toolChoice': {'any': {}}** part  missing.

The new implementation
```python
def _drop_none(obj: Any) -> Any:
    if isinstance(obj, dict):
        new = {k: _drop_none(v) for k, v in obj.items() if _drop_none(v) is not None}
        return new
    else:
        return obj
```
Correctly handles this case.
```python
_drop_none(
    {'tools': [{"toolSpec": {
                    "name": "Answer",
                    "description": "Your answer",
                    "inputSchema": {
                        "json": {
                            "type": "object",
                            "properties": {
                                "answer": {
                                    "type": "string",
                                    "description": "Your answer"
                                },
                            },
                            "required": ["answer"]
                        }
                    }
                }},
            {'toolSpec':
                {
                    "name": "get_weather",
                    "description": "Get the current weather in a given location",
                    "inputSchema": {
                        "json": {
                            "type": "object",
                            "properties": {
                                "location": {
                                    "type": "string",
                                    "description": "The city and state, e.g. San Francisco, CA"
                                },
                                "unit": {
                                    "type": "string",
                                    "enum": ["celsius", "fahrenheit"],
                                    "description": "The unit of temperature, either \"celsius\" or \"fahrenheit\""
                                }
                            },
                            "required": ["location"]
                        }
                    }
                }
                }],
     'toolChoice': {'any': {}}}
)
```
which results in
```python
{'tools': [{'toolSpec': {'name': 'Answer',
    'description': 'Your answer',
    'inputSchema': {'json': {'type': 'object',
      'properties': {'answer': {'type': 'string',
        'description': 'Your answer'}},
      'required': ['answer']}}}},
  {'toolSpec': {'name': 'get_weather',
    'description': 'Get the current weather in a given location',
    'inputSchema': {'json': {'type': 'object',
      'properties': {'location': {'type': 'string',
        'description': 'The city and state, e.g. San Francisco, CA'},
       'unit': {'type': 'string',
        'enum': ['celsius', 'fahrenheit'],
        'description': 'The unit of temperature, either "celsius" or "fahrenheit"'}},
      'required': ['location']}}}}],
 'toolChoice': {'any': {}}}
```