### PR TITLE
Adding bedrock metadata filter and search type parameters

### DIFF
--- a/libs/aws/langchain_aws/retrievers/bedrock.py
+++ b/libs/aws/langchain_aws/retrievers/bedrock.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Literal, Optional, Tuple, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 
 import boto3
 from botocore.client import Config

--- a/libs/aws/langchain_aws/retrievers/bedrock.py
+++ b/libs/aws/langchain_aws/retrievers/bedrock.py
@@ -158,7 +158,6 @@ class AmazonKnowledgeBasesRetriever(BaseRetriever):
         response = self.client.retrieve(
             retrievalQuery={"text": query.strip()},
             knowledgeBaseId=self.knowledge_base_id,
-            nextToken=None,
             retrievalConfiguration=self.retrieval_config.dict(),
         )
         results = response["retrievalResults"]

--- a/libs/aws/langchain_aws/retrievers/bedrock.py
+++ b/libs/aws/langchain_aws/retrievers/bedrock.py
@@ -158,7 +158,7 @@ class AmazonKnowledgeBasesRetriever(BaseRetriever):
         response = self.client.retrieve(
             retrievalQuery={"text": query.strip()},
             knowledgeBaseId=self.knowledge_base_id,
-            retrievalConfiguration=self.retrieval_config.dict(),
+            retrievalConfiguration=self.retrieval_config.dict(exclude_none=True),
         )
         results = response["retrievalResults"]
         documents = []

--- a/libs/aws/langchain_aws/retrievers/bedrock.py
+++ b/libs/aws/langchain_aws/retrievers/bedrock.py
@@ -15,9 +15,9 @@ class SearchFilter(BaseModel):
 
     andAll: Optional[List["SearchFilter"]] = None
     equals: Optional[Dict[str, Union[Dict, List, int, float, str, bool, None]]] = None
-    greaterThan: Optional[Dict[str, Union[Dict, List, int, float, str, bool, None]]] = (
-        None
-    )
+    greaterThan: Optional[
+        Dict[str, Union[Dict, List, int, float, str, bool, None]]
+    ] = None
     greaterThanOrEquals: Optional[
         Dict[str, Union[Dict, List, int, float, str, bool, None]]
     ] = None
@@ -31,16 +31,16 @@ class SearchFilter(BaseModel):
     listContains: Optional[
         Dict[str, Union[Dict, List, int, float, str, bool, None]]
     ] = None
-    notEquals: Optional[Dict[str, Union[Dict, List, int, float, str, bool, None]]] = (
-        None
-    )
+    notEquals: Optional[
+        Dict[str, Union[Dict, List, int, float, str, bool, None]]
+    ] = None
     notIn: Optional[Dict[str, Union[Dict, List, int, float, str, bool, None]]] = Field(
         None, alias="notIn"
     )
     orAll: Optional[List["SearchFilter"]] = None
-    startsWith: Optional[Dict[str, Union[Dict, List, int, float, str, bool, None]]] = (
-        None
-    )
+    startsWith: Optional[
+        Dict[str, Union[Dict, List, int, float, str, bool, None]]
+    ] = None
     stringContains: Optional[
         Dict[str, Union[Dict, List, int, float, str, bool, None]]
     ] = None
@@ -67,33 +67,33 @@ class RetrievalConfig(BaseModel, extra="allow"):  # type: ignore[call-arg]
 class AmazonKnowledgeBasesRetriever(BaseRetriever):
     """`Amazon Bedrock Knowledge Bases` retrieval.
 
-    See https://aws.amazon.com/bedrock/knowledge-bases for more info.
+        See https://aws.amazon.com/bedrock/knowledge-bases for more info.
 
-    Args:
-        knowledge_base_id: Knowledge Base ID.
-        region_name: The aws region e.g., `us-west-2`.
-            Fallback to AWS_DEFAULT_REGION env variable or region specified in
-            ~/.aws/config.
-        credentials_profile_name: The name of the profile in the ~/.aws/credentials
-            or ~/.aws/config files, which has either access keys or role information
-            specified. If not specified, the default credential profile or, if on an
-            EC2 instance, credentials from IMDS will be used.
-        client: boto3 client for bedrock agent runtime.
-        retrieval_config: Configuration for retrieval.
+        Args:
+            knowledge_base_id: Knowledge Base ID.
+            region_name: The aws region e.g., `us-west-2`.
+                Fallback to AWS_DEFAULT_REGION env variable or region specified in
+                ~/.aws/config.
+            credentials_profile_name: The name of the profile in the ~/.aws/credentials
+                or ~/.aws/config files, which has either access keys or role information
+                specified. If not specified, the default credential profile or, if on an
+                EC2 instance, credentials from IMDS will be used.
+            client: boto3 client for bedrock agent runtime.
+            retrieval_config: Configuration for retrieval.
 
-    Example:
-        .. code-block:: python
+        Example:
+            .. code-block:: python
 
-            from langchain_community.retrievers import AmazonKnowledgeBasesRetriever
+                from langchain_community.retrievers import AmazonKnowledgeBasesRetriever
 
-            retriever = AmazonKnowledgeBasesRetriever(
-                knowledge_base_id="<knowledge-base-id>",
-                retrieval_config={
-                    "vectorSearchConfiguration": {
-                        "numberOfResults": 4
-                    }
-                },
-            )
+    retriever = AmazonKnowledgeBasesRetriever(
+        knowledge_base_id="<knowledge-base-id>",
+        retrieval_config={
+            "vectorSearchConfiguration": {
+                "numberOfResults": 4
+            }
+        },
+    )
     """
 
     knowledge_base_id: str

--- a/libs/aws/langchain_aws/retrievers/bedrock.py
+++ b/libs/aws/langchain_aws/retrievers/bedrock.py
@@ -10,13 +10,7 @@ from langchain_core.retrievers import BaseRetriever
 from typing_extensions import Annotated
 
 FilterValue = Union[Dict[str, Any], List[Any], int, float, str, bool, None]
-
-
-class Criterion(BaseModel):
-    """A model to encapsulate a filter criterion with a key and its value."""
-
-    key: str
-    value: FilterValue
+Filter = Dict[str, FilterValue]
 
 
 class SearchFilter(BaseModel):
@@ -24,17 +18,17 @@ class SearchFilter(BaseModel):
 
     andAll: Optional[List["SearchFilter"]] = None
     orAll: Optional[List["SearchFilter"]] = None
-    equals: Optional[Criterion] = None
-    greaterThan: Optional[Criterion] = None
-    greaterThanOrEquals: Optional[Criterion] = None
-    in_: Optional[Criterion] = Field(None, alias="in")
-    lessThan: Optional[Criterion] = None
-    lessThanOrEquals: Optional[Criterion] = None
-    listContains: Optional[Criterion] = None
-    notEquals: Optional[Criterion] = None
-    notIn: Optional[Criterion] = Field(None, alias="notIn")
-    startsWith: Optional[Criterion] = None
-    stringContains: Optional[Criterion] = None
+    equals: Optional[Filter] = None
+    greaterThan: Optional[Filter] = None
+    greaterThanOrEquals: Optional[Filter] = None
+    in_: Optional[Filter] = Field(None, alias="in")
+    lessThan: Optional[Filter] = None
+    lessThanOrEquals: Optional[Filter] = None
+    listContains: Optional[Filter] = None
+    notEquals: Optional[Filter] = None
+    notIn: Optional[Filter] = Field(None, alias="notIn")
+    startsWith: Optional[Filter] = None
+    stringContains: Optional[Filter] = None
 
     class Config:
         allow_population_by_field_name = True


### PR DESCRIPTION
### Description

This pull request enhances the functionality of the`AmazonKnowledgeBasesRetriever` class by adding optional parameters for the following features (already implemented in [boto3](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedrock-agent-runtime/client/retrieve.html)):

- added `filter` parameter in `VectorSearchConfig` to filter on metadata tags.
- added `overrideSearchType` in `VectorSearchConfig` to override the default search type to be able to choose between 'Default', 'Hybrid' or 'Semantic'

Here an example answer before the change:
```
retriever = AmazonKnowledgeBasesRetriever(
    knowledge_base_id="KNOWLEDGE_BASE_ID,
    retrieval_config={
        "vectorSearchConfiguration": {
            "numberOfResults": 4
        }
    },
)
```

And now after the change:

```
retriever = AmazonKnowledgeBasesRetriever(
    knowledge_base_id="KNOWLEDGE_BASE_ID,
    retrieval_config={
        "vectorSearchConfiguration": {
            "numberOfResults": 4,
            "filter": {
                "equals": {"key": "type", "TAG1"}
            },
            "overrideSearchType": "HYBRID"
        }
    },
)
```

### Change
- added `SearchFilter` class to handle parameter filtering
- added `filter` parameter in `VectorSearchConfig`
- added `overrideSearchType` in `VectorSearchConfig` 

### Motivation
This will allow users to better use the full capacity of Bedrock Knowledge Base.

### Additional Notes
- This change maintains backwards compatibility with existing usage.
- The `nextToken` feature when with very long results has not been implemented.