### PR TITLE
correctly raise ValueError for ChatBedrock models that don't support structured_output

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -387,7 +387,7 @@ class ChatBedrock(BaseChatModel, BedrockBase):
 
     system_prompt_with_tools: str = ""
     beta_use_converse_api: bool = False
-    """Use the new Bedrock ``converse`` API which provides a standardized interface to 
+    """Use the new Bedrock ``converse`` API which provides a standardized interface to
     all Bedrock models. Support still in beta. See ChatBedrockConverse docs for more."""
 
     @property
@@ -784,7 +784,7 @@ class ChatBedrock(BaseChatModel, BedrockBase):
                 schema, include_raw=include_raw, **kwargs
             )
         if "claude-3" not in self._get_model():
-            ValueError(
+            raise ValueError(
                 f"Structured output is not supported for model {self._get_model()}"
             )
 

--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock.py
@@ -247,6 +247,16 @@ def test_structured_output() -> None:
 
 
 @pytest.mark.scheduled
+def test_unsupported_structured_output() -> None:
+    chat = ChatBedrock(
+        model_id="meta.llama3-8b-instruct-v1:0",
+        model_kwargs={"temperature": 0.001},
+    )  # type: ignore[call-arg]
+    with pytest.raises(ValueError):
+        _ = chat.with_structured_output(AnswerWithJustification)
+
+
+@pytest.mark.scheduled
 def test_tool_use_call_invoke() -> None:
     chat = ChatBedrock(
         model_id="anthropic.claude-3-sonnet-20240229-v1:0",


### PR DESCRIPTION
small addendum to an old PR: ttps://github.com/langchain-ai/langchain-aws/pull/70