### PR TITLE
Fixes image type, adds document type for ChatBedrockConverse

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -747,7 +747,9 @@ def _anthropic_to_bedrock(
         elif block["type"] == "image":
             # Assume block is already in bedrock format.
             if "image" in block:
-                bedrock_content.append(block)
+                bedrock_content.append({
+                    "image": block["image"]
+                })
             else:
                 bedrock_content.append(
                     {
@@ -764,6 +766,11 @@ def _anthropic_to_bedrock(
             bedrock_content.append(
                 {"image": _format_openai_image_url(block["imageUrl"]["url"])}
             )
+        elif block["type"] == "document":
+            # Assume block in bedrock document format
+            bedrock_content.append({
+                "document": block["document"]
+            })
         elif block["type"] == "tool_use":
             bedrock_content.append(
                 {
@@ -812,6 +819,13 @@ def _bedrock_to_anthropic(content: List[Dict[str, Any]]) -> List[Dict[str, Any]]
                         "type": "base64",
                         "data": _bytes_to_b64_str(block["image"]["source"]["bytes"]),
                     },
+                }
+            )
+        elif "document" in block:
+            anthropic_content.append(
+                {
+                    "type": "document",
+                    "document": block
                 }
             )
         elif "tool_result" in block:

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -622,7 +622,7 @@ def _messages_to_bedrock(
         if isinstance(msg, HumanMessage):
             # If there's a human, tool, human message sequence, the
             # tool message will be merged with the first human message, so the second
-            # human message will now be preceeded by a human message and should also
+            # human message will now be preceded by a human message and should also
             # be merged with it.
             if bedrock_messages and bedrock_messages[-1]["role"] == "user":
                 bedrock_messages[-1]["content"].extend(content)
@@ -817,8 +817,6 @@ def _bedrock_to_anthropic(content: List[Dict[str, Any]]) -> List[Dict[str, Any]]
                     },
                 }
             )
-        elif "document" in block:
-            anthropic_content.append({"type": "document", "document": block})
         elif "tool_result" in block:
             anthropic_content.append(
                 {

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -747,9 +747,7 @@ def _anthropic_to_bedrock(
         elif block["type"] == "image":
             # Assume block is already in bedrock format.
             if "image" in block:
-                bedrock_content.append({
-                    "image": block["image"]
-                })
+                bedrock_content.append({"image": block["image"]})
             else:
                 bedrock_content.append(
                     {
@@ -768,9 +766,7 @@ def _anthropic_to_bedrock(
             )
         elif block["type"] == "document":
             # Assume block in bedrock document format
-            bedrock_content.append({
-                "document": block["document"]
-            })
+            bedrock_content.append({"document": block["document"]})
         elif block["type"] == "tool_use":
             bedrock_content.append(
                 {
@@ -822,12 +818,7 @@ def _bedrock_to_anthropic(content: List[Dict[str, Any]]) -> List[Dict[str, Any]]
                 }
             )
         elif "document" in block:
-            anthropic_content.append(
-                {
-                    "type": "document",
-                    "document": block
-                }
-            )
+            anthropic_content.append({"type": "document", "document": block})
         elif "tool_result" in block:
             anthropic_content.append(
                 {

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -161,6 +161,33 @@ def test__messages_to_bedrock() -> None:
                 {"type": "guard_content", "text": "hu6"},
             ]
         ),
+        HumanMessage(
+            content=[
+                {
+                    "type": "document", 
+                    "document": {
+                        "format": "pdf",
+                        "name": "doc1",
+                        "source": {
+                            "bytes": b"doc1_data"
+                        }
+                    }
+                }
+            ]
+        ),
+        HumanMessage(
+            content=[
+                {
+                    "type": "image",
+                    "image": {
+                        "format": "jpeg",
+                        "source": {
+                            "bytes": b"image_data"
+                        }
+                    }
+                }
+            ]
+        )
     ]
     expected_messages = [
         {"role": "user", "content": [{"text": "hu1"}, {"text": "hu2"}]},
@@ -229,8 +256,25 @@ def test__messages_to_bedrock() -> None:
                 },
                 {"guardContent": {"text": {"text": "hu5"}}},
                 {"guardContent": {"text": {"text": "hu6"}}},
+                {
+                    "document": {
+                        "format": "pdf",
+                        "name": "doc1",
+                        "source": {
+                            "bytes": b"doc1_data"
+                        }
+                    }
+                },
+                {
+                    "image": {
+                        "format": "jpeg",
+                        "source": {
+                            "bytes": b"image_data"
+                        }
+                    }
+                }
             ],
-        },
+        }
     ]
     expected_system = [
         {"text": "sys1"},

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -164,14 +164,12 @@ def test__messages_to_bedrock() -> None:
         HumanMessage(
             content=[
                 {
-                    "type": "document", 
+                    "type": "document",
                     "document": {
                         "format": "pdf",
                         "name": "doc1",
-                        "source": {
-                            "bytes": b"doc1_data"
-                        }
-                    }
+                        "source": {"bytes": b"doc1_data"},
+                    },
                 }
             ]
         ),
@@ -179,15 +177,10 @@ def test__messages_to_bedrock() -> None:
             content=[
                 {
                     "type": "image",
-                    "image": {
-                        "format": "jpeg",
-                        "source": {
-                            "bytes": b"image_data"
-                        }
-                    }
+                    "image": {"format": "jpeg", "source": {"bytes": b"image_data"}},
                 }
             ]
-        )
+        ),
     ]
     expected_messages = [
         {"role": "user", "content": [{"text": "hu1"}, {"text": "hu2"}]},
@@ -260,21 +253,12 @@ def test__messages_to_bedrock() -> None:
                     "document": {
                         "format": "pdf",
                         "name": "doc1",
-                        "source": {
-                            "bytes": b"doc1_data"
-                        }
+                        "source": {"bytes": b"doc1_data"},
                     }
                 },
-                {
-                    "image": {
-                        "format": "jpeg",
-                        "source": {
-                            "bytes": b"image_data"
-                        }
-                    }
-                }
+                {"image": {"format": "jpeg", "source": {"bytes": b"image_data"}}},
             ],
-        }
+        },
     ]
     expected_system = [
         {"text": "sys1"},


### PR DESCRIPTION
## Description
This PR fixes the image type supported by Bedrock Anthropic and other models. It also adds a new type for supporting documents.

### Image sample code
```python
from langchain_core.messages import HumanMessage
from langchain_aws import ChatBedrock

llm = ChatBedrock(
    model_id="anthropic.claude-3-sonnet-20240229-v1:0",
    beta_use_converse_api=True
)

# Convert image to bytes
image_path = "images/random-image.jpg"
image_bytes = None
with open(image_path, "rb") as f:
    image_bytes = f.read()

messages = [
    HumanMessage(
        content=[
            {
                "type": "image",
                "image": {
                    "format": "jpeg",
                    "source": {
                        "bytes": image_bytes
                    }
                }
            },
            "What is this image about?"
        ]
    )
]

llm.invoke(messages)
```

### Document sample code
```python
from langchain_core.messages import HumanMessage
from langchain_aws import ChatBedrock

llm = ChatBedrock(
    model_id="anthropic.claude-3-sonnet-20240229-v1:0",
    beta_use_converse_api=True
)

# Convert document to bytes
doc_path = "documents/random-doc.pdf"
doc_bytes = None
with open(doc_path, "rb") as f:
    doc_bytes = f.read()

messages = [
    HumanMessage(
        content=[
            {
                "type": "document",
                "document": {
                    "format": "pdf",
                    "name": "random-doc",
                    "source": {
                        "bytes": doc_bytes
                    }
                }
            },
            "What is this document about?"
        ]
    )
]

llm.invoke(messages)
```



Related to https://github.com/langchain-ai/langchain-aws/issues/75
Fixes https://github.com/langchain-ai/langchain-aws/issues/132