### PR TITLE
Fix: Call `on_llm_new_token` during streaming

### DIFF
--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -943,6 +943,21 @@ class BedrockBase(BaseLanguageModel, ABC):
         ):
             yield chunk
 
+            token = None
+
+            if isinstance(chunk, GenerationChunk):
+                token = chunk.text
+            elif isinstance(chunk, AIMessageChunk):
+                token = chunk.content
+
+            if run_manager is not None and asyncio.iscoroutinefunction(
+                run_manager.on_llm_new_token
+            ):
+                await run_manager.on_llm_new_token(token, chunk=chunk)
+            elif run_manager is not None:
+                run_manager.on_llm_new_token(token, chunk=chunk)  # type: ignore[unused-coroutine]
+
+
 
 class BedrockLLM(LLM, BedrockBase):
     """Bedrock models.

--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -481,7 +481,7 @@ class BedrockBase(BaseLanguageModel, ABC):
 
     provider: Optional[str] = None
     """The model provider, e.g., amazon, cohere, ai21, etc. When not supplied, provider
-    is extracted from the first part of the model_id e.g. 'amazon' in 
+    is extracted from the first part of the model_id e.g. 'amazon' in
     'amazon.titan-text-express-v1'. This value should be provided for model ids that do
     not have the provider in them, e.g., custom and provisioned models that have an ARN
     associated with them."""
@@ -869,6 +869,18 @@ class BedrockBase(BaseLanguageModel, ABC):
             # verify and raise callback error if any middleware intervened
             if not isinstance(chunk, AIMessageChunk):
                 self._get_bedrock_services_signal(chunk.generation_info)  # type: ignore[arg-type]
+
+            if run_manager is not None:
+                token = None
+
+                if isinstance(chunk, GenerationChunk):
+                    token = chunk.text
+                elif isinstance(chunk, AIMessageChunk):
+                    token = chunk.content
+
+                if token:
+                    run_manager.on_llm_new_token(token, chunk=chunk)
+
 
     async def _aprepare_input_and_invoke_stream(
         self,

--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -878,8 +878,7 @@ class BedrockBase(BaseLanguageModel, ABC):
                 elif isinstance(chunk, AIMessageChunk):
                     token = chunk.content
 
-                if token:
-                    run_manager.on_llm_new_token(token, chunk=chunk)
+                run_manager.on_llm_new_token(token, chunk=chunk)
 
 
     async def _aprepare_input_and_invoke_stream(


### PR DESCRIPTION
# Description

This previous [PR](https://github.com/langchain-ai/langchain-aws/pull/119/files#diff-7b555324692cbefa47fc582ade684c4faa5d083023137e2839f37aff0401aa4eL832) removed the call to `run_manager.on_llm_new_token` and can break client relying on this callback.
This PR adds this back.