### PR TITLE
Add ToolMessage's status to bedrock message for ChatBedrockConverse

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -562,9 +562,14 @@ def _messages_to_bedrock(
             else:
                 curr = {"role": "user", "content": []}
 
-            # TODO: Add status once we have ToolMessage.status support.
             curr["content"].append(
-                {"toolResult": {"content": content, "toolUseId": msg.tool_call_id}}
+                {
+                    "toolResult": {
+                        "content": content,
+                        "toolUseId": msg.tool_call_id,
+                        "status": msg.status,
+                    }
+                }
             )
             bedrock_messages.append(curr)
         else:

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -224,6 +224,7 @@ def test__messages_to_bedrock() -> None:
                     "toolResult": {
                         "toolUseId": "tool_call3",
                         "content": [{"text": "tool_res3"}],
+                        "status": "success",
                     }
                 },
                 {"guardContent": {"text": {"text": "hu5"}}},


### PR DESCRIPTION
With this pull request, the `status` field of `ToolMessage` is now being passed to the `converse` api. 