### PR TITLE
bedrock converse[patch]: support streaming in with_structured_output

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -513,8 +513,8 @@ class ChatBedrockConverse(BaseChatModel):
         llm = self.bind_tools([schema], tool_choice=tool_choice)
         if isinstance(schema, type) and is_basemodel_subclass(schema):
             output_parser: OutputParserLike = PydanticToolsParser(
-                tools=[schema],  # type: ignore[list-item]
-                first_tool_only=True,  # type: ignore[list-item]
+                tools=[schema],
+                first_tool_only=True,
             )
         else:
             tool_name = convert_to_openai_tool(schema)["function"]["name"]

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -12,6 +12,7 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
+    Type,
     TypeVar,
     Union,
     cast,
@@ -35,15 +36,21 @@ from langchain_core.messages import (
 from langchain_core.messages.ai import AIMessageChunk, UsageMetadata
 from langchain_core.messages.tool import tool_call as create_tool_call
 from langchain_core.messages.tool import tool_call_chunk
+from langchain_core.output_parsers import JsonOutputKeyToolsParser, PydanticToolsParser
+from langchain_core.output_parsers.base import OutputParserLike
 from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
 from langchain_core.pydantic_v1 import BaseModel, Extra, Field, root_validator
 from langchain_core.runnables import Runnable, RunnableMap, RunnablePassthrough
 from langchain_core.tools import BaseTool
 from langchain_core.utils import get_from_dict_or_env
-from langchain_core.utils.function_calling import convert_to_openai_function
+from langchain_core.utils.function_calling import (
+    convert_to_openai_function,
+    convert_to_openai_tool,
+)
 from langchain_core.utils.pydantic import TypeBaseModel, is_basemodel_subclass
 
-from langchain_aws.function_calling import ToolsOutputParser
+_BM = TypeVar("_BM", bound=BaseModel)
+_DictOrPydanticClass = Union[Dict[str, Any], Type[_BM], Type]
 
 
 class ChatBedrockConverse(BaseChatModel):
@@ -491,7 +498,7 @@ class ChatBedrockConverse(BaseChatModel):
 
     def with_structured_output(
         self,
-        schema: Union[Dict, TypeBaseModel],
+        schema: _DictOrPydanticClass,
         *,
         include_raw: bool = False,
         **kwargs: Any,
@@ -505,11 +512,15 @@ class ChatBedrockConverse(BaseChatModel):
             tool_choice = None
         llm = self.bind_tools([schema], tool_choice=tool_choice)
         if isinstance(schema, type) and is_basemodel_subclass(schema):
-            output_parser = ToolsOutputParser(
-                first_tool_only=True, pydantic_schemas=[schema]
+            output_parser: OutputParserLike = PydanticToolsParser(
+                tools=[schema],  # type: ignore[list-item]
+                first_tool_only=True,  # type: ignore[list-item]
             )
         else:
-            output_parser = ToolsOutputParser(first_tool_only=True, args_only=True)
+            tool_name = convert_to_openai_tool(schema)["function"]["name"]
+            output_parser = JsonOutputKeyToolsParser(
+                key_name=tool_name, first_tool_only=True
+            )
 
         if include_raw:
             parser_assign = RunnablePassthrough.assign(

--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
@@ -89,17 +89,17 @@ def test_structured_output_streaming() -> None:
     assert chunk_count > 1
 
     # Pydantic
-    class AnswerWithJustification(BaseModel):
+    class AnAnswerWithJustification(BaseModel):
         """An answer to the user question along with justification for the answer."""
 
         answer: Annotated[str, ...]
         justification: Annotated[str, ...]
 
-    chat = model.with_structured_output(AnswerWithJustification)
+    chat = model.with_structured_output(AnAnswerWithJustification)
     chunk_count = 0
     for chunk in chat.stream(query):
         chunk_count = chunk_count + 1
-        assert isinstance(chunk, AnswerWithJustification)
+        assert isinstance(chunk, AnAnswerWithJustification)
     assert chunk_count > 1
 
 

--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
@@ -1,13 +1,13 @@
 """Standard LangChain interface tests"""
 
-from typing import Annotated, Literal, Type
+from typing import Literal, Type
 
 import pytest
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import HumanMessage
 from langchain_core.pydantic_v1 import BaseModel, Field
 from langchain_standard_tests.integration_tests import ChatModelIntegrationTests
-from typing_extensions import TypedDict
+from typing_extensions import Annotated, TypedDict
 
 from langchain_aws import ChatBedrockConverse
 

--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
@@ -1,12 +1,13 @@
 """Standard LangChain interface tests"""
 
-from typing import Literal, Type
+from typing import Annotated, Literal, Type
 
 import pytest
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import HumanMessage
 from langchain_core.pydantic_v1 import BaseModel, Field
 from langchain_standard_tests.integration_tests import ChatModelIntegrationTests
+from typing_extensions import TypedDict
 
 from langchain_aws import ChatBedrockConverse
 
@@ -62,6 +63,44 @@ def test_structured_output_snake_case() -> None:
     chat = model.with_structured_output(ClassifyQuery)
     for chunk in chat.stream("How big are cats?"):
         assert isinstance(chunk, ClassifyQuery)
+
+
+def test_structured_output_streaming() -> None:
+    model = ChatBedrockConverse(
+        model="anthropic.claude-3-5-sonnet-20240620-v1:0", temperature=0
+    )
+    query = (
+        "What weighs more, a pound of bricks or a pound of feathers? "
+        "Limit your response to 20 words."
+    )
+
+    # TypedDict
+    class AnswerWithJustification(TypedDict):
+        """An answer to the user question along with justification for the answer."""
+
+        answer: Annotated[str, ...]
+        justification: Annotated[str, ...]
+
+    chat = model.with_structured_output(AnswerWithJustification)
+    chunk_count = 0
+    for chunk in chat.stream(query):
+        chunk_count = chunk_count + 1
+        assert isinstance(chunk, dict)
+    assert chunk_count > 1
+
+    # Pydantic
+    class AnswerWithJustification(BaseModel):
+        """An answer to the user question along with justification for the answer."""
+
+        answer: Annotated[str, ...]
+        justification: Annotated[str, ...]
+
+    chat = model.with_structured_output(AnswerWithJustification)
+    chunk_count = 0
+    for chunk in chat.stream(query):
+        chunk_count = chunk_count + 1
+        assert isinstance(chunk, AnswerWithJustification)
+    assert chunk_count > 1
 
 
 @pytest.mark.skip(reason="Needs guardrails setup to run.")


### PR DESCRIPTION
As pointed out in https://github.com/langchain-ai/langchain-aws/issues/134#issuecomment-2271433237, some Bedrock models that support streaming tool calls do not properly stream structured output. This is due to our implementation of `with_structured_output`. Here we update the output parsing for models that support streaming tool calls.