### PR TITLE
Fix ChatBedrock docs for guardrails

### DIFF
--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -524,19 +524,20 @@ class BedrockBase(BaseLanguageModel, ABC):
     """
     An optional dictionary to configure guardrails for Bedrock.
 
-    This field 'guardrails' consists of two keys: 'id' and 'version',
-    which should be strings, but are initialized to None. It's used to
-    determine if specific guardrails are enabled and properly set.
+    This field 'guardrails' consists of two keys: 'guardrailId' and
+    'guardrailVersion', which should be strings, but are initialized to None.
+    It's used to determine if specific guardrails are enabled and properly set.
 
     Type:
-        Optional[Mapping[str, str]]: A mapping with 'id' and 'version' keys.
+        Optional[Mapping[str, str]]: A mapping with 'guardrailId' and
+        'guardrailVersion' keys.
 
     Example:
     llm = Bedrock(model_id="<model_id>", client=<bedrock_client>,
                   model_kwargs={},
                   guardrails={
-                        "id": "<guardrail_id>",
-                        "version": "<guardrail_version>"})
+                        "guardrailId": "<guardrail_id>",
+                        "guardrailVersion": "<guardrail_version>"})
 
     To enable tracing for guardrails, set the 'trace' key to True and pass a callback handler to the
     'run_manager' parameter of the 'generate', '_call' methods.
@@ -545,8 +546,8 @@ class BedrockBase(BaseLanguageModel, ABC):
     llm = Bedrock(model_id="<model_id>", client=<bedrock_client>,
                   model_kwargs={},
                   guardrails={
-                        "id": "<guardrail_id>",
-                        "version": "<guardrail_version>",
+                        "guardrailId": "<guardrail_id>",
+                        "guardrailVersion": "<guardrail_version>",
                         "trace": True},
                 callbacks=[BedrockAsyncCallbackHandler()])
 


### PR DESCRIPTION
The guardrails attributes were changed in https://github.com/langchain-ai/langchain-aws/pull/26 . However, the docstring had the old parameter keys. It looks like this causes the example on https://api.python.langchain.com/en/latest/chat_models/langchain_aws.chat_models.bedrock.ChatBedrock.html#langchain_aws.chat_models.bedrock.ChatBedrock.guardrails to be wrong.

![image](https://github.com/user-attachments/assets/3f567897-345e-4ec0-b9ff-c48ae70a6a78)
