### PR TITLE
chatbedrock[patch]: remove redundant token counts

### DIFF
--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -23,7 +23,6 @@ from langchain_core.callbacks import (
 )
 from langchain_core.language_models import LLM, BaseLanguageModel, LangSmithParams
 from langchain_core.messages import AIMessageChunk, ToolCall
-from langchain_core.messages.ai import UsageMetadata
 from langchain_core.messages.tool import tool_call, tool_call_chunk
 from langchain_core.outputs import Generation, GenerationChunk, LLMResult
 from langchain_core.pydantic_v1 import Extra, Field, root_validator
@@ -96,14 +95,8 @@ def _stream_response_to_generation_chunk(
     if messages_api:
         msg_type = stream_response.get("type")
         if msg_type == "message_start":
-            input_tokens = stream_response["message"]["usage"]["input_tokens"]
             return AIMessageChunk(
                 content="" if coerce_content_to_string else [],
-                usage_metadata=UsageMetadata(
-                    input_tokens=input_tokens,
-                    output_tokens=0,
-                    total_tokens=input_tokens,
-                ),
             )
         elif (
             msg_type == "content_block_start"
@@ -148,14 +141,8 @@ def _stream_response_to_generation_chunk(
                     tool_call_chunks=[tc_chunk],  # type: ignore
                 )
         elif msg_type == "message_delta":
-            output_tokens = stream_response["usage"]["output_tokens"]
             return AIMessageChunk(
                 content="",
-                usage_metadata=UsageMetadata(
-                    input_tokens=0,
-                    output_tokens=output_tokens,
-                    total_tokens=output_tokens,
-                ),
                 response_metadata={
                     "stop_reason": stream_response["delta"]["stop_reason"],
                     "stop_sequence": stream_response["delta"]["stop_sequence"],

--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock.py
@@ -84,6 +84,26 @@ def test_chat_bedrock_streaming() -> None:
 
 
 @pytest.mark.scheduled
+def test_chat_bedrock_token_counts() -> None:
+    chat = ChatBedrock(  # type: ignore[call-arg]
+        model_id="anthropic.claude-3-sonnet-20240229-v1:0",
+        model_kwargs={"temperature": 0},
+    )
+    invoke_response = chat.invoke("hi", max_tokens=6)
+    assert isinstance(invoke_response, AIMessage)
+    assert invoke_response.usage_metadata is not None
+    assert invoke_response.usage_metadata["output_tokens"] <= 6
+
+    stream = chat.stream("hi", max_tokens=6)
+    stream_response = next(stream)
+    for chunk in stream:
+        stream_response += chunk
+    assert isinstance(stream_response, AIMessage)
+    assert stream_response.usage_metadata is not None
+    assert stream_response.usage_metadata["output_tokens"] <= 6
+
+
+@pytest.mark.scheduled
 def test_chat_bedrock_streaming_llama3() -> None:
     """Test that streaming correctly streams message chunks"""
     chat = ChatBedrock(  # type: ignore[call-arg]


### PR DESCRIPTION
Input and output tokens are counted twice for anthropic models:

- Once [during the stream](https://github.com/langchain-ai/langchain-aws/blob/e86b5517428ae7307c444974a98d1d3804395c19/libs/aws/langchain_aws/llms/bedrock.py#L88), as for anthropic models they are reported in `message_start` and `message_delta` chunks;
- Once at `message_stop`, where they are reported in a [amazon-bedrock-invocationMetrics](https://github.com/langchain-ai/langchain-aws/blob/e86b5517428ae7307c444974a98d1d3804395c19/libs/aws/langchain_aws/llms/bedrock.py#L224) field.

Here we remove the counts during the stream, preferring the final reported `invocationMetrics`.

Problem appears to be with claude models. Inspected counts before/after the change with:
```
"anthropic.claude-3-sonnet-20240229-v1:0"
"anthropic.claude-3-5-sonnet-20240620-v1:0"
"meta.llama3-8b-instruct-v1:0"
"mistral.mistral-7b-instruct-v0:2"
```