### PR TITLE
Fix streaming functionality with Bedrock guardrails (#176)

### DIFF
--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -144,8 +144,8 @@ def _stream_response_to_generation_chunk(
             return AIMessageChunk(
                 content="",
                 response_metadata={
-                    "stop_reason": stream_response["delta"]["stop_reason"],
-                    "stop_sequence": stream_response["delta"]["stop_sequence"],
+                    "stop_reason": stream_response["delta"].get("stop_reason"),
+                    "stop_sequence": stream_response["delta"].get("stop_sequence"),
                 },
             )
         else:


### PR DESCRIPTION
This PR addresses an issue where the streaming functionality in ChatBedrock breaks when Bedrock guardrails are applied. The problem was caused by a KeyError in the `_stream_response_to_generation_chunk` method when trying to access the 'stop_sequence' key, which may not always be present in the response structure when guardrails are active.

## Changes
- Modified the `_stream_response_to_generation_chunk` method in `llms/bedrock.py` to use the `get()` method when accessing dictionary keys that may not always be present.


## Testing
- Tested the streaming functionality with and without Bedrock guardrails applied.
- Verified that the streaming works correctly in both scenarios without raising KeyErrors.
