### PR TITLE
feat(community): Add support for Bedrock cross-region inference models

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -53,14 +53,17 @@ from langchain_aws.function_calling import ToolsOutputParser
 
 _BM = TypeVar("_BM", bound=BaseModel)
 _DictOrPydanticClass = Union[Dict[str, Any], Type[_BM], Type]
-# supported regions for bedrock
-# ref: https://docs.aws.amazon.com/general/latest/gr/bedrock.html#bedrock_region
+
 AWS_REGIONS = [
     "us",
-    "ap",
-    "ca",
-    "eu",
     "sa",
+    "me",
+    "il",
+    "eu",
+    "cn",
+    "ca",
+    "ap",
+    "af",
     "us-gov",
 ]
 

--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -42,14 +42,16 @@ ASSISTANT_PROMPT = "\n\nAssistant:"
 ALTERNATION_ERROR = (
     "Error: Prompt must alternate between '\n\nHuman:' and '\n\nAssistant:'."
 )
-# supported regions for bedrock
-# ref: https://docs.aws.amazon.com/general/latest/gr/bedrock.html#bedrock_region
 AWS_REGIONS = [
     "us",
-    "ap",
-    "ca",
-    "eu",
     "sa",
+    "me",
+    "il",
+    "eu",
+    "cn",
+    "ca",
+    "ap",
+    "af",
     "us-gov",
 ]
 


### PR DESCRIPTION
Merged for `LangChainJS`: https://github.com/langchain-ai/langchainjs/pull/6682
Closed PR as the `Bedrock` is deprecated in `langchain-core`: https://github.com/langchain-ai/langchain/pull/26038

Hey, I recently I switched using to Bedrock Inference models.

With Inference models, Amazon introduced a new prefix which is a region code. If the `modelId` previously was `anthropic.claude-3-5-sonnet-20240620-v1:0` now, with the change it's `eu.anthropic.claude-3-5-sonnet-20240620-v1:0`

This PR adds:
- Support for each AWS Bedrock supported regions.
- Support streaming for inference models in Converse API

Fixes #186 