### PR TITLE
Removing version ceiling for boto3.

### DIFF
--- a/libs/aws/poetry.lock
+++ b/libs/aws/poetry.lock
@@ -1894,4 +1894,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "d6c6fc32b29e7971a803c00d24244ed76b0c84945c4ee738d93da8d9dec5ec3e"
+content-hash = "06bab61161d3947863dce618853099886f8a55eecad7cf8016dd9ec052d6d218"

--- a/libs/aws/pyproject.toml
+++ b/libs/aws/pyproject.toml
@@ -13,7 +13,7 @@ license = "MIT"
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
 langchain-core = ">=0.3.0,<0.4"
-boto3 = ">=1.34.131,<1.35.0"
+boto3 = ">=1.34.131"
 numpy = [
      {version = "^1", python = "<3.12"},
      {version = "^1.26.0", python = ">=3.12"}


### PR DESCRIPTION
Removes version ceiling currently set at v1.35 for boto3.