### PR TITLE
aws[patch]: fix initialization of BedrockLLM without client

### DIFF
--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -959,7 +959,8 @@ class BedrockLLM(LLM, BedrockBase):
     """
 
     @model_validator(mode="after")
-    def validate_environment_llm(self) -> Self:
+    def validate_environment(self) -> Self:
+        super().validate_environment()
         model_id = self.model_id
         if model_id.startswith("anthropic.claude-3"):
             raise ValueError(

--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -959,7 +959,7 @@ class BedrockLLM(LLM, BedrockBase):
     """
 
     @model_validator(mode="after")
-    def validate_environment(self) -> Self:
+    def validate_environment_llm(self) -> Self:
         model_id = self.model_id
         if model_id.startswith("anthropic.claude-3"):
             raise ValueError(

--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -959,8 +959,7 @@ class BedrockLLM(LLM, BedrockBase):
     """
 
     @model_validator(mode="after")
-    def validate_environment(self) -> Self:
-        super().validate_environment()
+    def validate_environment_llm(self) -> Self:
         model_id = self.model_id
         if model_id.startswith("anthropic.claude-3"):
             raise ValueError(

--- a/libs/aws/tests/integration_tests/llms/test_bedrock.py
+++ b/libs/aws/tests/integration_tests/llms/test_bedrock.py
@@ -1,5 +1,6 @@
 from langchain_aws import BedrockLLM
 
+
 def test_bedrock_llm():
     llm = BedrockLLM(model_id="anthropic.claude-v2:1")
     response = llm.invoke("Hello")

--- a/libs/aws/tests/integration_tests/llms/test_bedrock.py
+++ b/libs/aws/tests/integration_tests/llms/test_bedrock.py
@@ -1,0 +1,7 @@
+from langchain_aws import BedrockLLM
+
+def test_bedrock_llm():
+    llm = BedrockLLM(model_id="anthropic.claude-v2:1")
+    response = llm.invoke("Hello")
+    assert isinstance(response, str)
+    assert len(response) > 0

--- a/libs/aws/tests/integration_tests/llms/test_bedrock.py
+++ b/libs/aws/tests/integration_tests/llms/test_bedrock.py
@@ -1,7 +1,7 @@
 from langchain_aws import BedrockLLM
 
 
-def test_bedrock_llm():
+def test_bedrock_llm() -> None:
     llm = BedrockLLM(model_id="anthropic.claude-v2:1")
     response = llm.invoke("Hello")
     assert isinstance(response, str)


### PR DESCRIPTION
`BedrockLLM.validate_environment` shadows its parent `BedrockBase.validate_environment`, so the latter appears not to run.

Resolves https://github.com/langchain-ai/langchain-aws/issues/196