### PR TITLE
Move yield of metrics chunk after generation chunk (#216)

### DIFF
--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -366,7 +366,17 @@ class LLMInputOutputAdapter:
             ):
                 return
 
-            elif (
+            generation_chunk = _stream_response_to_generation_chunk(
+                chunk_obj,
+                provider=provider,
+                output_key=output_key,
+                messages_api=messages_api,
+                coerce_content_to_string=coerce_content_to_string,
+            )
+            if generation_chunk:
+                yield generation_chunk
+
+            if (
                 provider == "mistral"
                 and chunk_obj.get(output_key, [{}])[0].get("stop_reason", "") == "stop"
             ):
@@ -380,18 +390,6 @@ class LLMInputOutputAdapter:
             elif messages_api and (chunk_obj.get("type") == "message_stop"):
                 yield _get_invocation_metrics_chunk(chunk_obj)
                 return
-
-            generation_chunk = _stream_response_to_generation_chunk(
-                chunk_obj,
-                provider=provider,
-                output_key=output_key,
-                messages_api=messages_api,
-                coerce_content_to_string=coerce_content_to_string,
-            )
-            if generation_chunk:
-                yield generation_chunk
-            else:
-                continue
 
     @classmethod
     async def aprepare_output_stream(


### PR DESCRIPTION
_backport of fix into v0.1 branch_

Move yield of metrics chunk after generation chunk (#216)
- when using mistral and streaming is enabled,the final chunk includes a stop_reason. There is nothing to say this final chunk doesn't also include some generated text. The existing implementation would result in that final chunk never getting sent back
- this update moves the yield of the metrics chunk after the generation chunk
- also included a change to include invocation metrics for cohere models

Closes #215

(cherry picked from commit e2c2f7c790cb3c83631e6bb72300eba4b61bef2b)