### PR TITLE
Remove xfail from passing integration tests.

### DIFF
--- a/libs/aws/tests/integration_tests/chat_models/test_standard.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_standard.py
@@ -26,21 +26,6 @@ class TestBedrockStandard(ChatModelIntegrationTests):
     def test_stop_sequence(self, model: BaseChatModel) -> None:
         super().test_stop_sequence(model)
 
-    @pytest.mark.xfail(reason="Not yet implemented.")
-    def test_tool_message_histories_string_content(self, model: BaseChatModel) -> None:
-        super().test_tool_message_histories_string_content(model)
-
-    @pytest.mark.xfail(reason="Not yet implemented.")
-    def test_tool_message_histories_list_content(self, model: BaseChatModel) -> None:
-        super().test_tool_message_histories_list_content(model)
-
-    @pytest.mark.xfail(reason="Not yet implemented.")
-    def test_structured_few_shot_examples(
-        self,
-        model: BaseChatModel,
-    ) -> None:
-        super().test_structured_few_shot_examples(model)
-
 
 class TestBedrockUseConverseStandard(ChatModelIntegrationTests):
     @property


### PR DESCRIPTION
Some of the tests marked `xfail` are passing in my local testing. Enabling them, so these run during the release.

```shell
tests/integration_tests/chat_models/test_standard.py::TestBedrockStandard::test_tool_message_histories_string_content PASSED
tests/integration_tests/chat_models/test_standard.py::TestBedrockStandard::test_tool_message_histories_list_content PASSED
tests/integration_tests/chat_models/test_standard.py::TestBedrockStandard::test_structured_few_shot_examples PASSED
```