### PR TITLE
[#169] Fix the broken in operator in bedrock knowledge base retriever.

### DIFF
--- a/libs/aws/langchain_aws/retrievers/bedrock.py
+++ b/libs/aws/langchain_aws/retrievers/bedrock.py
@@ -162,7 +162,9 @@ class AmazonKnowledgeBasesRetriever(BaseRetriever):
         response = self.client.retrieve(
             retrievalQuery={"text": query.strip()},
             knowledgeBaseId=self.knowledge_base_id,
-            retrievalConfiguration=self.retrieval_config.model_dump(exclude_none=True),
+            retrievalConfiguration=self.retrieval_config.model_dump(
+                exclude_none=True, by_alias=True
+            ),
         )
         results = response["retrievalResults"]
         documents = []


### PR DESCRIPTION
Fixed the issue mentioned in https://github.com/langchain-ai/langchain-aws/issues/169
Added unit test that would expose the bug in source code
Tested with my service code and it works with the change