### PR TITLE
[#169] Fix the broken in operator in bedrock knowledge base retriever.

### DIFF
--- a/libs/aws/langchain_aws/retrievers/bedrock.py
+++ b/libs/aws/langchain_aws/retrievers/bedrock.py
@@ -158,7 +158,10 @@ class AmazonKnowledgeBasesRetriever(BaseRetriever):
         response = self.client.retrieve(
             retrievalQuery={"text": query.strip()},
             knowledgeBaseId=self.knowledge_base_id,
-            retrievalConfiguration=self.retrieval_config.dict(exclude_none=True),
+            retrievalConfiguration=self.retrieval_config.dict(
+                exclude_none=True,
+                by_alias=True,
+            ),
         )
         results = response["retrievalResults"]
         documents = []


### PR DESCRIPTION
Backport the fix for #169 to v0.1 branch.