### PR TITLE
Added version ceiling for anthropic token count.

### DIFF
--- a/libs/aws/langchain_aws/utils.py
+++ b/libs/aws/langchain_aws/utils.py
@@ -10,6 +10,18 @@ def enforce_stop_tokens(text: str, stop: List[str]) -> str:
 def _get_anthropic_client() -> Any:
     try:
         import anthropic
+        from packaging import version
+
+        max_supported_version = version.parse("0.38.0")
+        anthropic_version = version.parse(anthropic.__version__)
+
+        if anthropic_version > max_supported_version:
+            raise NotImplementedError(
+                "Currently installed anthropic version {anthropic_version} is not "
+                "supported. Please use ChatAnthropic.get_num_tokens_from_messages "
+                "instead."
+            )
+
     except ImportError:
         raise ImportError(
             "Could not import anthropic python package. "


### PR DESCRIPTION
## Description
Current `get_num_tokens` method in ChatBedrock utilizes a legacy Anthropic API `count_tokens`, support for which has been dropped by Anthropic in their latest release v0.39.0. This PR adds a version ceiling for the anthropic client, only supporting token count for anthropic client versions 0.38.0 and lower. Users who have a need to use token counting in their applications should follow these steps.

1. Stop using the `get_num_tokens` from the **ChatBedrock** class.
2. Start using `get_num_tokens_from_messages` from the **ChatAnthropic** class.

Here is some sample code that follows this strategy.

```python
from langchain_core.messages import HumanMessage
from langchain_aws import ChatBedrock
from langchain_anthropic import ChatAnthropic

def main():
    messages = [
        HumanMessage("What is the capital of France?")
    ]

    llm = ChatBedrock(
        model="anthropic.claude-3-5-sonnet-20241022-v2:0"
    )

    token_counter_model = ChatAnthropic(
        model="claude-3-5-sonnet-20241022"
    )

    token_count = token_counter_model.get_num_tokens_from_messages(messages)
    print(f"token count is {token_count}")

    if token_count < 100:
        print(llm.invoke(messages))
    else:
        print(
            "Warning: Trim to smaller prompt to reduce token count."
        )

if __name__ == "__main__":
    main()
```

## References
**Anthropic Documentation for count_tokens API**
https://docs.anthropic.com/en/api/messages-count-tokens

**Dropped support for count_tokens in AnthropicLLM**
https://github.com/langchain-ai/langchain/blob/master/libs/partners/anthropic/langchain_anthropic/llms.py#L375

**New implementation in ChatAnthropic**
https://github.com/langchain-ai/langchain/blob/master/libs/partners/anthropic/langchain_anthropic/chat_models.py#L1117