### PR TITLE
aws: xfail meta async test for converse

### DIFF
--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
@@ -91,10 +91,17 @@ class TestBedrockMetaStandard(ChatModelIntegrationTests):
     # but this test consistently seem to return single quoted input values {input: '3'}
     # instead of {input: 3} failing the test. Upon checking with tools with non-numeric
     # inputs, tool calling seems to work as expected with Bedrock and Llama models.
+    # Same problem with tool_calling_async, below.
     @pytest.mark.xfail(
         reason="Bedrock Meta models tend to return string values for integer inputs ."
     )
     def test_tool_calling(self, model: BaseChatModel) -> None:
+        super().test_tool_calling(model)
+
+    @pytest.mark.xfail(
+        reason="Bedrock Meta models tend to return string values for integer inputs ."
+    )
+    def test_tool_calling_async(self, model: BaseChatModel) -> None:
         super().test_tool_calling(model)
 
     @pytest.mark.xfail(reason="Meta models don't support tool_choice.")

--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
@@ -101,8 +101,8 @@ class TestBedrockMetaStandard(ChatModelIntegrationTests):
     @pytest.mark.xfail(
         reason="Bedrock Meta models tend to return string values for integer inputs ."
     )
-    def test_tool_calling_async(self, model: BaseChatModel) -> None:
-        super().test_tool_calling(model)
+    async def test_tool_calling_async(self, model: BaseChatModel) -> None:
+        await super().test_tool_calling_async(model)
 
     @pytest.mark.xfail(reason="Meta models don't support tool_choice.")
     def test_tool_calling_with_no_arguments(self, model: BaseChatModel) -> None:


### PR DESCRIPTION
Recently added an async variant of the tool calling test.

This appears to be a known issue for the Meta provider (see https://github.com/langchain-ai/langchain-aws/pull/274).