### PR TITLE
Adding back numpy to fix release errors.

### DIFF
--- a/libs/aws/poetry.lock
+++ b/libs/aws/poetry.lock
@@ -2129,4 +2129,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "02dbd15a2883499f2ff5ea12eea5809c046f6670a29bc53fee480ee0b02a5fe2"
+content-hash = "4dd8839d57d081ef3bcdcd6454b81b63af0034fafc699cbf0b27b8e150298739"

--- a/libs/aws/pyproject.toml
+++ b/libs/aws/pyproject.toml
@@ -15,6 +15,10 @@ python = ">=3.9,<4.0"
 langchain-core = ">=0.3.15,<0.4"
 boto3 = ">=1.35.74"
 pydantic = ">=2,<3"
+numpy = [
+  { version = "^1", python = "<3.12" },
+  { version = ">=1.26.0,<3", python = ">=3.12" },
+]
 
 [tool.poetry.group.test]
 optional = true


### PR DESCRIPTION
Adds back numpy as dependency which was removed in #282. This is causing release errors, due to dependency of numpy in the Bedrock embeddings. 