### PR TITLE
Fix model_id validation in ChatBedrock

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -410,7 +410,7 @@ class ChatBedrock(BaseChatModel, BedrockBase):
     @model_validator(mode="before")
     @classmethod
     def set_beta_use_converse_api(cls, values: Dict) -> Any:
-        model_id = values.get("model_id", values.get("model"))
+        model_id = values.get("model_id", values.get("model")) or ""
 
         if "beta_use_converse_api" not in values:
             values["beta_use_converse_api"] = "nova" in model_id

--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -412,7 +412,7 @@ class ChatBedrock(BaseChatModel, BedrockBase):
     def set_beta_use_converse_api(cls, values: Dict) -> Any:
         model_id = values.get("model_id", values.get("model"))
 
-        if model_id is not None and "beta_use_converse_api" not in values:
+        if model_id and "beta_use_converse_api" not in values:
             values["beta_use_converse_api"] = "nova" in model_id
         return values
 

--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -410,9 +410,9 @@ class ChatBedrock(BaseChatModel, BedrockBase):
     @model_validator(mode="before")
     @classmethod
     def set_beta_use_converse_api(cls, values: Dict) -> Any:
-        model_id = values.get("model_id", values.get("model")) or ""
+        model_id = values.get("model_id", values.get("model"))
 
-        if "beta_use_converse_api" not in values:
+        if model_id is not None and "beta_use_converse_api" not in values:
             values["beta_use_converse_api"] = "nova" in model_id
         return values
 


### PR DESCRIPTION
Fixed a minor regression in v0.2.9. Runs of `ChatBedrock` with missing or NoneType `model_id` get caught in the new `beta_use_converse_api` parameter check, which throws an ambiguous TypeError. 

This change restores the original behavior where ValidationError is thrown for absent `model_id`.