### PR TITLE
Add Issue and CR Template.

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,38 @@
+# Issue or Problem
+
+Include all relevant information, how to reproduce the issue
+ and any analysis you have about the problem. Put links
+ to relevant documents and include screenshots as necessary.
+
+# Related Issues
+
+Include all the related issues that you have researched prior
+to opening this issue ticket. If any other issue was closed
+previously without resolution, please include here and describe
+what has changed since the other issue.
+
+Relevant to # (issue)
+
+# Type of Issue
+
+- [ ] Regression
+- [ ] New feature
+- [ ] Not implemented functionality
+- [ ] Incorrectly implemented functionality
+- [ ] Usability
+- [ ] Other
+
+# Issue Checklist
+
+- [ ] I have attached minimal reproducible code
+- [ ] I am attaching details about my specific configuration where the failure is noticed
+- [ ] I am not attaching any confidential data that cannot be public
+
+# Issue Configuration
+
+- Please list any environment variables that need to be set
+  for this to be reproduced.
+- Please list any configuration changes that need to be present
+  for this to be reproduced.
+- Python Version:
+- OS/Distribution:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,64 @@
+# Issue or Problem Addressed
+
+If there is a GitHub issue that describes this problem, only include a link
+to the issue.
+
+If not, please create a GitHub issue. Include all relevant information, how
+to reproduce the issue and any analysis you have about the problem. Put links
+ to relevant documents and include screenshots as necessary.
+
+# Description
+
+Describe how this PR fixes the mentioned Issue. Please include relevant
+motivation and context. Please list any dependencies that need to go in
+before this change can be tested and merged.
+
+Fixes # (issue)
+
+# Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Deprecation (existing functionality will cease working in the future)
+- [ ] Breaking Change (remove deprecated functionality once enough deprecation notice is given)
+- [ ] Documentation change (This change requires a documentation update)
+
+# How Has This Been Tested?
+
+Please describe the tests that you ran to verify your changes. Please
+Provide instructions so we can reproduce. Please list any relevant details
+for your build and test configuration.
+
+## List of Tests Added
+
+- [ ] TestA
+- [ ] TestB
+
+## Test Procedure
+
+- [ ] `make tests`
+- [ ] `make integration_tests`
+- [ ] Any other manual test mechanism
+
+## Test Configuration
+
+- Please list any environment variables that need to be set
+  for this test to work.
+- Please list any configuration changes that need to be present
+  for this test to work.
+- Python Version:
+- OS/Distribution:
+
+# Review Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have no changes that break existing user workflows. If so, I am providing a deprecation path
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published in downstream modules


### PR DESCRIPTION
# Issue or Problem Addressed

I am addressing the problem of ensuring we have a way to report issues and create pull requests
with more information. Since my first [pull request](https://github.com/langchain-ai/langchain-aws/pull/302) did not have a good description, I decided to add a template that addresses this issue.

## Known Limitations

Issue templates may restrict customers from free-form reporting of problems; 

# Description

This PR adds two templates: [Pull Request](.github/pull_request_template.md) and [Issue](.github/issue_template.md). This Pull Request itself uses the template I had included in the PR.

No other dependent PRs exist for this to go in.

# Type of change

Please delete options that are not relevant.

- [X] Documentation change (This change requires a documentation update)

# How Has This Been Tested?

I have tried to include Screenshots that show how this was tested.

<img width="702" alt="Screenshot 2024-12-10 at 2 14 01 PM" src="https://github.com/user-attachments/assets/558af52d-0cd6-45a9-a5f7-0bf445679e2b">
<img width="918" alt="Screenshot 2024-12-10 at 2 15 31 PM" src="https://github.com/user-attachments/assets/122c71df-f356-471f-8a3f-155c29327c73">

## List of Tests Added

N/A

## Test Procedure

- Open Issue > Take Sreenshot
- Create Pull Request > Take Screenshot

## Test Configuration

- Python: `3.12.4`
- OS/Distribution: `Darwin 80a997319da4 23.6.0 Darwin Kernel Version 23.6.0`

# Review Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works

