### PR TITLE
Add support for latency optimized performanceConfig

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -844,6 +844,7 @@ class ChatBedrock(BaseChatModel, BedrockBase):
                 "top_p",
                 "additional_model_request_fields",
                 "additional_model_response_field_paths",
+                "performance_config",
             )
         }
         if self.max_tokens:

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -393,6 +393,16 @@ class ChatBedrockConverse(BaseChatModel):
     ('auto') if a 'nova' model is used, empty otherwise.
     """
 
+    performance_config: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="""Performance configuration settings for latency optimization.
+        
+        Example:
+            performance_config={'latency': 'optimized'}
+        If not provided, defaults to standard latency.
+        """,
+    )
+
     model_config = ConfigDict(
         extra="forbid",
         populate_by_name=True,
@@ -623,6 +633,7 @@ class ChatBedrockConverse(BaseChatModel):
         additionalModelRequestFields: Optional[dict] = None,
         additionalModelResponseFieldPaths: Optional[List[str]] = None,
         guardrailConfig: Optional[dict] = None,
+        performanceConfig: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         if not inferenceConfig:
             inferenceConfig = {
@@ -645,6 +656,7 @@ class ChatBedrockConverse(BaseChatModel):
                 "additionalModelResponseFieldPaths": additionalModelResponseFieldPaths
                 or self.additional_model_response_field_paths,
                 "guardrailConfig": guardrailConfig or self.guardrail_config,
+                "performanceConfig": performanceConfig or self.performance_config,
             }
         )
 

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -10,6 +10,7 @@ from typing import (
     Iterator,
     List,
     Literal,
+    Mapping,
     Optional,
     Sequence,
     Tuple,
@@ -393,7 +394,7 @@ class ChatBedrockConverse(BaseChatModel):
     ('auto') if a 'nova' model is used, empty otherwise.
     """
 
-    performance_config: Optional[Dict[str, Any]] = Field(
+    performance_config: Optional[Mapping[str, Any]] = Field(
         default=None,
         description="""Performance configuration settings for latency optimization.
         
@@ -633,7 +634,7 @@ class ChatBedrockConverse(BaseChatModel):
         additionalModelRequestFields: Optional[dict] = None,
         additionalModelResponseFieldPaths: Optional[List[str]] = None,
         guardrailConfig: Optional[dict] = None,
-        performanceConfig: Optional[Dict[str, Any]] = None,
+        performanceConfig: Optional[Mapping[str, Any]] = None,
     ) -> Dict[str, Any]:
         if not inferenceConfig:
             inferenceConfig = {


### PR DESCRIPTION
AWS Bedrock recently introduced support for latency optimization that greatly speeds up tokens/second response times for certain models being rolled out. This PR adds the ability to pass the config through langchain to make use of the faster model calls.

AWS Docs:
- https://docs.aws.amazon.com/bedrock/latest/userguide/latency-optimized-inference.html

Example usage compared to boto3
```python
# BOTO3
client = boto3.client("bedrock-runtime")
response = client.converse(
    modelId=model_id,
    messages=[{"role": "user", "content": [{"text": query}]}],
    performanceConfig={"latency": "optimized"|"standard"},
)

# LANGCHAIN
client = ChatBedrockConverse(
    model_id=model_id,
    performance_config={"latency": "optimized"|"standard"},
)
response = client.invoke(query)
```


Benchmarks I tried locally after the change. Langchain performance closely matches the same configuration in raw boto3 calls (with the exception of some overhead it appears)

![benchmark_results](https://github.com/user-attachments/assets/cda76538-7cda-4160-8c32-57d529972d04)
