### PR TITLE
fix: `TypeError: Object of type datetime is not JSON serializable`

### DIFF
--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -802,7 +802,7 @@ class BedrockBase(BaseLanguageModel, ABC):
                 max_tokens=self.max_tokens,
                 temperature=self.temperature,
             )
-        body = json.dumps(input_body)
+        body = json.dumps(input_body, default=str)
         accept = "application/json"
         contentType = "application/json"
 


### PR DESCRIPTION
This defaults to string when serializing the input body. In particular it was having issues serializing datetime objects. They now get serialized to a string appropriately instead of causing an exception to be raised.