### PR TITLE
Fix ChatBedrock integration with Amazon Bedrock model

### DIFF
--- a/libs/aws/langchain_aws/__init__.py
+++ b/libs/aws/langchain_aws/__init__.py
@@ -49,5 +49,5 @@ __all__ = [
     "NeptuneGraph",
     "InMemoryVectorStore",
     "InMemorySemanticCache",
-    "BedrockRerank"
+    "BedrockRerank",
 ]

--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -641,11 +641,14 @@ class ChatBedrock(BaseChatModel, BedrockBase):
                 return get_token_ids_anthropic(text)
             else:
                 warnings.warn(
-                    f"Falling back to default token method due to missing or incompatible `anthropic` installation "
-                    f"(needs <=0.38.0).\n\nIf using `anthropic>0.38.0`, it is recommended to provide the model "
-                    f"class with a custom_get_token_ids method implementing a more accurate tokenizer for Anthropic. "
-                    f"For get_num_tokens, as another alternative, you can implement your own token counter method "
-                    f"using the ChatAnthropic or AnthropicLLM classes."
+                    "Falling back to default token method due to missing or "
+                    "incompatible `anthropic` installation "
+                    "(needs <=0.38.0).\n\nIf using `anthropic>0.38.0`, "
+                    "it is recommended to provide the model class with a "
+                    "custom_get_token_ids method implementing a more accurate "
+                    "tokenizer for Anthropic. For get_num_tokens, as another "
+                    "alternative, you can implement your own token counter method "
+                    "using the ChatAnthropic or AnthropicLLM classes."
                 )
         return super().get_token_ids(text)
 

--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -875,7 +875,7 @@ class ChatBedrock(BaseChatModel, BedrockBase):
         return ChatBedrockConverse(
             client=self.client,
             model=self.model_id,
-            region_name=self.region_name or os.getenv("AWS_REGION"),
+            region_name=self.region_name,
             credentials_profile_name=self.credentials_profile_name,
             aws_access_key_id=self.aws_access_key_id,
             aws_secret_access_key=self.aws_secret_access_key,

--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -875,7 +875,7 @@ class ChatBedrock(BaseChatModel, BedrockBase):
         return ChatBedrockConverse(
             client=self.client,
             model=self.model_id,
-            region_name=self.region_name,
+            region_name=self.region_name or os.getenv("AWS_REGION"),
             credentials_profile_name=self.credentials_profile_name,
             aws_access_key_id=self.aws_access_key_id,
             aws_secret_access_key=self.aws_secret_access_key,

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -303,8 +303,8 @@ class ChatBedrockConverse(BaseChatModel):
     region_name: Optional[str] = None
     """The aws region, e.g., `us-west-2`. 
     
-    Falls back to AWS_DEFAULT_REGION env variable or region specified in ~/.aws/config 
-    in case it is not provided here.
+    Falls back to AWS_REGION or AWS_DEFAULT_REGION env variable or region specified in 
+    ~/.aws/config in case it is not provided here.
     """
 
     credentials_profile_name: Optional[str] = Field(default=None, exclude=True)
@@ -481,6 +481,7 @@ class ChatBedrockConverse(BaseChatModel):
 
                 self.region_name = (
                     self.region_name
+                    or os.getenv("AWS_REGION")
                     or os.getenv("AWS_DEFAULT_REGION")
                     or session.region_name
                 )

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -1035,7 +1035,7 @@ def _format_tools(
             spec = convert_to_openai_tool(tool)["function"]
             spec["inputSchema"] = {"json": spec.pop("parameters")}
             formatted_tools.append({"toolSpec": spec})
-        
+
         tool_spec = formatted_tools[-1]["toolSpec"]
         tool_spec["description"] = tool_spec.get("description") or tool_spec["name"]
     return formatted_tools

--- a/libs/aws/langchain_aws/document_compressors/rerank.py
+++ b/libs/aws/langchain_aws/document_compressors/rerank.py
@@ -6,7 +6,6 @@ from langchain_core.callbacks.manager import Callbacks
 from langchain_core.documents import BaseDocumentCompressor, Document
 from langchain_core.utils import from_env
 from pydantic import ConfigDict, Field, model_validator
-from typing_extensions import Self
 
 
 class BedrockRerank(BaseDocumentCompressor):
@@ -61,7 +60,7 @@ class BedrockRerank(BaseDocumentCompressor):
             query: The query to use for reranking.
             documents: A sequence of documents to rerank.
             top_n: The number of top-ranked results to return. Defaults to self.top_n.
-            additional_model_request_fields: A dictionary of additional fields to pass to the model.
+            additional_model_request_fields: Additional fields to pass to the model.
 
         Returns:
             List[Dict[str, Any]]: A list of ranked documents with relevance scores.

--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -484,7 +484,7 @@ class BedrockBase(BaseLanguageModel, ABC):
     client: Any = Field(default=None, exclude=True)  #: :meta private:
 
     region_name: Optional[str] = Field(default=None, alias="region")
-    """The aws region e.g., `us-west-2`. Fallsback to AWS_DEFAULT_REGION env variable
+    """The aws region e.g., `us-west-2`. Fallsback to AWS_REGION or AWS_DEFAULT_REGION env variable
     or region specified in ~/.aws/config in case it is not provided here.
     """
 
@@ -677,6 +677,7 @@ class BedrockBase(BaseLanguageModel, ABC):
 
             self.region_name = (
                 self.region_name
+                or os.getenv("AWS_REGION")
                 or os.getenv("AWS_DEFAULT_REGION")
                 or session.region_name
             )

--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -484,8 +484,8 @@ class BedrockBase(BaseLanguageModel, ABC):
     client: Any = Field(default=None, exclude=True)  #: :meta private:
 
     region_name: Optional[str] = Field(default=None, alias="region")
-    """The aws region e.g., `us-west-2`. Fallsback to AWS_REGION or AWS_DEFAULT_REGION env variable
-    or region specified in ~/.aws/config in case it is not provided here.
+    """The aws region e.g., `us-west-2`. Fallsback to AWS_REGION or AWS_DEFAULT_REGION 
+    env variable or region specified in ~/.aws/config in case it is not provided here.
     """
 
     credentials_profile_name: Optional[str] = Field(default=None, exclude=True)
@@ -1314,10 +1314,13 @@ class BedrockLLM(LLM, BedrockBase):
                 return get_token_ids_anthropic(text)
             else:
                 warnings.warn(
-                    f"Falling back to default token method due to missing or incompatible `anthropic` installation "
-                    f"(needs <=0.38.0).\n\nFor `anthropic>0.38.0`, it is recommended to provide the model "
-                    f"class with a custom_get_token_ids method implementing a more accurate tokenizer for Anthropic. "
-                    f"For get_num_tokens, as another alternative, you can implement your own token counter method "
-                    f"using the ChatAnthropic or AnthropicLLM classes."
+                    "Falling back to default token method due to missing or "
+                    "incompatible `anthropic` installation "
+                    "(needs <=0.38.0).\n\nIf using `anthropic>0.38.0`, "
+                    "it is recommended to provide the model class with a "
+                    "custom_get_token_ids method implementing a more accurate "
+                    "tokenizer for Anthropic. For get_num_tokens, as another "
+                    "alternative, you can implement your own token counter method "
+                    "using the ChatAnthropic or AnthropicLLM classes."
                 )
         return super().get_token_ids(text)

--- a/libs/aws/langchain_aws/utils.py
+++ b/libs/aws/langchain_aws/utils.py
@@ -10,7 +10,7 @@ def enforce_stop_tokens(text: str, stop: List[str]) -> str:
 
 
 def anthropic_tokens_supported() -> bool:
-    """Check if we have all requirements for Anthropic count_tokens() and get_tokenizer()."""
+    """Check if all requirements for Anthropic count_tokens() are met."""
     try:
         import anthropic
     except ImportError:

--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
@@ -55,7 +55,7 @@ class TestBedrockNovaStandard(ChatModelIntegrationTests):
 
     @property
     def chat_model_params(self) -> dict:
-        return {"model": "us.amazon.nova-pro-v1:0", "region_name": "us-east-1"}
+        return {"model": "us.amazon.nova-pro-v1:0"}
 
     @property
     def standard_chat_model_params(self) -> dict:
@@ -242,22 +242,3 @@ def test_guardrails() -> None:
     )
     assert response.response_metadata["stopReason"] == "guardrail_intervened"
     assert response.response_metadata["trace"] is not None
-
-
-def test_chat_bedrock_converse_with_region_name() -> None:
-    model = ChatBedrockConverse(
-        model="us.amazon.nova-pro-v1:0", region_name="us-east-1", temperature=0
-    )
-    response = model.invoke("Create a list of 3 pop songs")
-    assert isinstance(response, BaseModel)
-    assert response.content is not None
-
-
-def test_chat_bedrock_converse_with_aws_region_env() -> None:
-    import os
-
-    os.environ["AWS_REGION"] = "us-east-1"
-    model = ChatBedrockConverse(model="us.amazon.nova-pro-v1:0", temperature=0)
-    response = model.invoke("Create a list of 3 pop songs")
-    assert isinstance(response, BaseModel)
-    assert response.content is not None

--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
@@ -55,7 +55,7 @@ class TestBedrockNovaStandard(ChatModelIntegrationTests):
 
     @property
     def chat_model_params(self) -> dict:
-        return {"model": "us.amazon.nova-pro-v1:0"}
+        return {"model": "us.amazon.nova-pro-v1:0", "region_name": "us-east-1"}
 
     @property
     def standard_chat_model_params(self) -> dict:
@@ -242,3 +242,22 @@ def test_guardrails() -> None:
     )
     assert response.response_metadata["stopReason"] == "guardrail_intervened"
     assert response.response_metadata["trace"] is not None
+
+
+def test_chat_bedrock_converse_with_region_name() -> None:
+    model = ChatBedrockConverse(
+        model="us.amazon.nova-pro-v1:0", region_name="us-east-1", temperature=0
+    )
+    response = model.invoke("Create a list of 3 pop songs")
+    assert isinstance(response, BaseModel)
+    assert response.content is not None
+
+
+def test_chat_bedrock_converse_with_aws_region_env() -> None:
+    import os
+
+    os.environ["AWS_REGION"] = "us-east-1"
+    model = ChatBedrockConverse(model="us.amazon.nova-pro-v1:0", temperature=0)
+    response = model.invoke("Create a list of 3 pop songs")
+    assert isinstance(response, BaseModel)
+    assert response.content is not None

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
@@ -18,6 +18,7 @@ from langchain_aws.chat_models.bedrock import (
     _merge_messages,
 )
 from langchain_aws.function_calling import convert_to_anthropic_tool
+from unittest import mock
 
 
 def test__merge_messages() -> None:
@@ -496,35 +497,16 @@ def test__get_provider(model_id, provider, expected_provider, expectation) -> No
         assert llm._get_provider() == expected_provider
 
 
+@mock.patch.dict(os.environ, {"AWS_REGION": "us-west-1"})
 def test_chat_bedrock_different_regions() -> None:
-    regions = ["us-east-1", "us-west-2", "ap-south-2"]
-    for region in regions:
-        llm = ChatBedrock(model_id="anthropic.claude-3-sonnet-20240229-v1:0", region_name=region)
-        assert llm.region_name == region
+    region = "ap-south-2"
+    llm = ChatBedrock(
+        model_id="anthropic.claude-3-sonnet-20240229-v1:0", region_name=region
+    )
+    assert llm.region_name == region
 
 
+@mock.patch.dict(os.environ, {"AWS_REGION": "ap-south-2"})
 def test_chat_bedrock_environment_variable() -> None:
-    regions = ["us-east-1", "us-west-2", "ap-south-2"]
-    for region in regions:
-        os.environ["AWS_REGION"] = region
-        llm = ChatBedrock(model_id="anthropic.claude-3-sonnet-20240229-v1:0")
-        assert llm.region_name == region
-
-
-def test_chat_bedrock_scenarios() -> None:
-    scenarios = [
-        {"model_id": "anthropic.claude-3-sonnet-20240229-v1:0", "temperature": 0.5},
-        {"model_id": "anthropic.claude-3-sonnet-20240229-v1:0", "max_tokens": 50},
-        {
-            "model_id": "anthropic.claude-3-sonnet-20240229-v1:0",
-            "temperature": 0.5,
-            "max_tokens": 50,
-        },
-    ]
-    for scenario in scenarios:
-        llm = ChatBedrock(region_name="us-west-2", **scenario)
-        assert llm.model_id == scenario["model_id"]
-        if "temperature" in scenario:
-            assert llm.temperature == scenario["temperature"]
-        if "max_tokens" in scenario:
-            assert llm.max_tokens == scenario["max_tokens"]
+    llm = ChatBedrock(model_id="anthropic.claude-3-sonnet-20240229-v1:0")
+    assert llm.region_name == "ap-south-2"

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
@@ -5,6 +5,7 @@
 import os
 from contextlib import nullcontext
 from typing import Any, Callable, Dict, Literal, Type, cast
+from unittest import mock
 
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
@@ -18,7 +19,6 @@ from langchain_aws.chat_models.bedrock import (
     _merge_messages,
 )
 from langchain_aws.function_calling import convert_to_anthropic_tool
-from unittest import mock
 
 
 def test__merge_messages() -> None:
@@ -341,6 +341,7 @@ def openai_function() -> Dict:
         },
     }
 
+
 @pytest.fixture()
 def tool_with_empty_description() -> Dict:
     return {
@@ -358,6 +359,7 @@ def tool_with_empty_description() -> Dict:
             "required": ["arg1", "arg2"],
         },
     }
+
 
 def test_convert_to_anthropic_tool(
     pydantic: Type[BaseModel],
@@ -391,6 +393,7 @@ def test_convert_to_anthropic_tool(
     expected["description"] = expected["name"]
     actual = convert_to_anthropic_tool(tool_with_empty_description)
     assert actual == expected
+
 
 class GetWeather(BaseModel):
     """Get the current weather in a given location"""

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
@@ -2,6 +2,7 @@
 
 """Test chat model integration."""
 
+import os
 from contextlib import nullcontext
 from typing import Any, Callable, Dict, Literal, Type, cast
 
@@ -493,3 +494,37 @@ def test__get_provider(model_id, provider, expected_provider, expectation) -> No
     llm = ChatBedrock(model_id=model_id, provider=provider, region_name="us-west-2")
     with expectation:
         assert llm._get_provider() == expected_provider
+
+
+def test_chat_bedrock_different_regions() -> None:
+    regions = ["us-east-1", "us-west-2", "ap-south-2"]
+    for region in regions:
+        llm = ChatBedrock(model_id="anthropic.claude-3-sonnet-20240229-v1:0", region_name=region)
+        assert llm.region_name == region
+
+
+def test_chat_bedrock_environment_variable() -> None:
+    regions = ["us-east-1", "us-west-2", "ap-south-2"]
+    for region in regions:
+        os.environ["AWS_REGION"] = region
+        llm = ChatBedrock(model_id="anthropic.claude-3-sonnet-20240229-v1:0")
+        assert llm.region_name == region
+
+
+def test_chat_bedrock_scenarios() -> None:
+    scenarios = [
+        {"model_id": "anthropic.claude-3-sonnet-20240229-v1:0", "temperature": 0.5},
+        {"model_id": "anthropic.claude-3-sonnet-20240229-v1:0", "max_tokens": 50},
+        {
+            "model_id": "anthropic.claude-3-sonnet-20240229-v1:0",
+            "temperature": 0.5,
+            "max_tokens": 50,
+        },
+    ]
+    for scenario in scenarios:
+        llm = ChatBedrock(region_name="us-west-2", **scenario)
+        assert llm.model_id == scenario["model_id"]
+        if "temperature" in scenario:
+            assert llm.temperature == scenario["temperature"]
+        if "max_tokens" in scenario:
+            assert llm.max_tokens == scenario["max_tokens"]

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -3,6 +3,7 @@
 import base64
 import os
 from typing import Dict, List, Tuple, Type, Union, cast
+from unittest import mock
 
 import pytest
 from langchain_core.language_models import BaseChatModel
@@ -27,7 +28,6 @@ from langchain_aws.chat_models.bedrock_converse import (
     _snake_to_camel,
     _snake_to_camel_keys,
 )
-from unittest import mock
 
 
 class TestBedrockStandard(ChatModelUnitTests):

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -1,6 +1,7 @@
 """Test chat model integration."""
 
 import base64
+import os
 from typing import Dict, List, Tuple, Type, Union, cast
 
 import pytest
@@ -503,3 +504,39 @@ def test__extract_response_metadata() -> None:
     }
     response_metadata = _extract_response_metadata(response)
     assert response_metadata["metrics"]["latencyMs"] == [191]
+
+
+def test_chat_bedrock_converse_different_regions() -> None:
+    regions = ["us-east-1", "us-west-2", "ap-south-2"]
+    for region in regions:
+        llm = ChatBedrockConverse(
+            model="anthropic.claude-3-sonnet-20240229-v1:0", region_name=region
+        )
+        assert llm.region_name == region
+
+
+def test_chat_bedrock_converse_environment_variable() -> None:
+    regions = ["us-east-1", "us-west-2", "ap-south-2"]
+    for region in regions:
+        os.environ["AWS_REGION"] = region
+        llm = ChatBedrockConverse(model="anthropic.claude-3-sonnet-20240229-v1:0")
+        assert llm.region_name == region
+
+
+def test_chat_bedrock_converse_scenarios() -> None:
+    scenarios = [
+        {"model": "anthropic.claude-3-sonnet-20240229-v1:0", "temperature": 0.5},
+        {"model": "anthropic.claude-3-sonnet-20240229-v1:0", "max_tokens": 50},
+        {
+            "model": "anthropic.claude-3-sonnet-20240229-v1:0",
+            "temperature": 0.5,
+            "max_tokens": 50,
+        },
+    ]
+    for scenario in scenarios:
+        llm = ChatBedrockConverse(region_name="us-west-2", **scenario)
+        assert llm.model_id == scenario["model"]
+        if "temperature" in scenario:
+            assert llm.temperature == scenario["temperature"]
+        if "max_tokens" in scenario:
+            assert llm.max_tokens == scenario["max_tokens"]

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -27,6 +27,7 @@ from langchain_aws.chat_models.bedrock_converse import (
     _snake_to_camel,
     _snake_to_camel_keys,
 )
+from unittest import mock
 
 
 class TestBedrockStandard(ChatModelUnitTests):
@@ -506,37 +507,16 @@ def test__extract_response_metadata() -> None:
     assert response_metadata["metrics"]["latencyMs"] == [191]
 
 
+@mock.patch.dict(os.environ, {"AWS_REGION": "us-west-1"})
 def test_chat_bedrock_converse_different_regions() -> None:
-    regions = ["us-east-1", "us-west-2", "ap-south-2"]
-    for region in regions:
-        llm = ChatBedrockConverse(
-            model="anthropic.claude-3-sonnet-20240229-v1:0", region_name=region
-        )
-        assert llm.region_name == region
+    region = "ap-south-2"
+    llm = ChatBedrockConverse(
+        model="anthropic.claude-3-sonnet-20240229-v1:0", region_name=region
+    )
+    assert llm.region_name == region
 
 
+@mock.patch.dict(os.environ, {"AWS_REGION": "ap-south-2"})
 def test_chat_bedrock_converse_environment_variable() -> None:
-    regions = ["us-east-1", "us-west-2", "ap-south-2"]
-    for region in regions:
-        os.environ["AWS_REGION"] = region
-        llm = ChatBedrockConverse(model="anthropic.claude-3-sonnet-20240229-v1:0")
-        assert llm.region_name == region
-
-
-def test_chat_bedrock_converse_scenarios() -> None:
-    scenarios = [
-        {"model": "anthropic.claude-3-sonnet-20240229-v1:0", "temperature": 0.5},
-        {"model": "anthropic.claude-3-sonnet-20240229-v1:0", "max_tokens": 50},
-        {
-            "model": "anthropic.claude-3-sonnet-20240229-v1:0",
-            "temperature": 0.5,
-            "max_tokens": 50,
-        },
-    ]
-    for scenario in scenarios:
-        llm = ChatBedrockConverse(region_name="us-west-2", **scenario)
-        assert llm.model_id == scenario["model"]
-        if "temperature" in scenario:
-            assert llm.temperature == scenario["temperature"]
-        if "max_tokens" in scenario:
-            assert llm.max_tokens == scenario["max_tokens"]
+    llm = ChatBedrockConverse(model="anthropic.claude-3-sonnet-20240229-v1:0")
+    assert llm.region_name == "ap-south-2"

--- a/libs/aws/tests/unit_tests/document_compressors/test_rerank.py
+++ b/libs/aws/tests/unit_tests/document_compressors/test_rerank.py
@@ -11,16 +11,20 @@ def reranker() -> BedrockRerank:
     reranker = BedrockRerank(
         model_arn="arn:aws:bedrock:us-west-2::foundation-model/amazon.rerank-v1:0",
         region_name="us-east-1",
-        )
+    )
     reranker.client = MagicMock()
     return reranker
 
+
 @patch("boto3.Session")
-def test_initialize_client(mock_boto_session: MagicMock, reranker: BedrockRerank) -> None:
+def test_initialize_client(
+    mock_boto_session: MagicMock, reranker: BedrockRerank
+) -> None:
     session_instance = MagicMock()
     mock_boto_session.return_value = session_instance
     session_instance.client.return_value = MagicMock()
     assert reranker.client is not None
+
 
 @patch("langchain_aws.document_compressors.rerank.BedrockRerank.rerank")
 def test_rerank(mock_rerank: MagicMock, reranker: BedrockRerank) -> None:
@@ -28,7 +32,7 @@ def test_rerank(mock_rerank: MagicMock, reranker: BedrockRerank) -> None:
         {"index": 0, "relevance_score": 0.9},
         {"index": 1, "relevance_score": 0.8},
     ]
-    
+
     documents = [Document(page_content="Doc 1"), Document(page_content="Doc 2")]
     query = "Example Query"
     results = reranker.rerank(documents, query)
@@ -39,13 +43,14 @@ def test_rerank(mock_rerank: MagicMock, reranker: BedrockRerank) -> None:
     assert results[1]["index"] == 1
     assert results[1]["relevance_score"] == 0.8
 
+
 @patch("langchain_aws.document_compressors.rerank.BedrockRerank.rerank")
 def test_compress_documents(mock_rerank: MagicMock, reranker: BedrockRerank) -> None:
     mock_rerank.return_value = [
         {"index": 0, "relevance_score": 0.95},
         {"index": 1, "relevance_score": 0.85},
     ]
-    
+
     documents = [Document(page_content="Content 1"), Document(page_content="Content 2")]
     query = "Relevant query"
     compressed_docs = reranker.compress_documents(documents, query)

--- a/libs/aws/tests/unit_tests/retrievers/test_bedrock.py
+++ b/libs/aws/tests/unit_tests/retrievers/test_bedrock.py
@@ -335,7 +335,7 @@ def test_retriever_no_retrieval_config_invoke_with_score(
             ],
             [
                 Document(
-                    page_content='[{"columnName": "someName1", "columnValue": "someValue1"}, '
+                    page_content='[{"columnName": "someName1", "columnValue": "someValue1"}, ' # noqa: E501
                     '{"columnName": "someName2", "columnValue": "someValue2"}]',
                     metadata={
                         "score": 1,
@@ -345,7 +345,7 @@ def test_retriever_no_retrieval_config_invoke_with_score(
                     },
                 ),
                 Document(
-                    page_content='[{"columnName": "someName1", "columnValue": "someValue1"}, '
+                    page_content='[{"columnName": "someName1", "columnValue": "someValue1"}, ' # noqa: E501
                     '{"columnName": "someName2", "columnValue": "someValue2"}]',
                     metadata={
                         "score": 0.5,


### PR DESCRIPTION
Fixes #308

Update the `ChatBedrock` class to handle the `region_name` parameter correctly.

* Modify `libs/aws/langchain_aws/chat_models/bedrock.py` to ensure the `region_name` parameter is passed to the `ChatBedrockConverse` class and add logic to take `region_name` from `AWS_REGION` environment variable if not provided.
* Add test cases in `libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py` to confirm that `ChatBedrockConverse` works with the `amazon.nova-pro-v1:0` model and takes `region_name` from `AWS_REGION` environment variable if not provided.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/langchain-ai/langchain-aws/pull/339?shareId=7fd95976-2f6d-4f1b-9585-7dc4c9d665d7).