### PR TITLE
Fix Bedrock token count and IDs for Anthropic models

### DIFF
--- a/libs/aws/langchain_aws/chains/graph_qa/neptune_cypher.py
+++ b/libs/aws/langchain_aws/chains/graph_qa/neptune_cypher.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import Any, Optional, Union
+from typing import Optional, Union
 
 from langchain_core.language_models import BaseLanguageModel
 from langchain_core.prompts.base import BasePromptTemplate

--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -637,7 +637,7 @@ class ChatBedrock(BaseChatModel, BedrockBase):
             else:
                 warnings.warn(
                     f"Falling back to default token method due to conflicts with the Anthropic API: {bad_deps}"
-                    f"\n\nFor Anthropic SDK versions > 0.38.0, it is recommended to provide the chat model class with a"
+                    f"\n\nFor Anthropic SDK versions > 0.38.0, it is recommended to provide the model class with a"
                     f" custom_get_token_ids method that implements a more accurate tokenizer for Anthropic. "
                     f"For get_num_tokens, as another alternative, you can implement your own token counter method "
                     f"using the ChatAnthropic or AnthropicLLM classes."

--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -622,26 +622,30 @@ class ChatBedrock(BaseChatModel, BedrockBase):
         return final_output
 
     def get_num_tokens(self, text: str) -> int:
-        if self._model_is_anthropic and check_anthropic_tokens_dependencies():
-            return get_num_tokens_anthropic(text)
-        else:
-            if self._model_is_anthropic:
+        if self._model_is_anthropic:
+            bad_deps = check_anthropic_tokens_dependencies()
+            if not bad_deps:
+                return get_num_tokens_anthropic(text)
+            else:
                 logger.debug(
-                    "Falling back to default token counting due to incompatible or missing Anthropic dependencies. "
-                    "To fix this, ensure that you have anthropic<=0.38.0, httpx<=0.27.2, and Python<=3.12 installed."
+                    "Falling back to default token counting due to incompatible/missing Anthropic dependencies:"
                 )
-            return super().get_num_tokens(text)
+                for x in bad_deps:
+                    logger.debug(x)
+        return super().get_num_tokens(text)
 
     def get_token_ids(self, text: str) -> List[int]:
-        if self._model_is_anthropic and check_anthropic_tokens_dependencies():
-            return get_token_ids_anthropic(text)
-        else:
-            if self._model_is_anthropic:
+        if self._model_is_anthropic:
+            bad_deps = check_anthropic_tokens_dependencies()
+            if not bad_deps:
+                return get_token_ids_anthropic(text)
+            else:
                 logger.debug(
-                    "Falling back to default token ids retrieval due to incompatible or missing Anthropic dependencies."
-                    " To fix this, ensure that you have anthropic<=0.38.0, httpx<=0.27.2, and Python<=3.12 installed."
+                    "Falling back to default token ids retrieval due to incompatible/missing Anthropic dependencies:"
                 )
-            return super().get_token_ids(text)
+                for x in bad_deps:
+                    logger.debug(x)
+        return super().get_token_ids(text)
 
     def set_system_prompt_with_tools(self, xml_tools_system_prompt: str) -> None:
         """Workaround to bind. Sets the system prompt with tools"""

--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -623,21 +623,19 @@ class ChatBedrock(BaseChatModel, BedrockBase):
 
     def get_num_tokens(self, text: str) -> int:
         if self._model_is_anthropic and not self.custom_get_token_ids:
-            bad_deps = anthropic_tokens_supported()
-            if not bad_deps:
+            if anthropic_tokens_supported():
                 return get_num_tokens_anthropic(text)
         return super().get_num_tokens(text)
 
     def get_token_ids(self, text: str) -> List[int]:
         if self._model_is_anthropic and not self.custom_get_token_ids:
-            bad_deps = anthropic_tokens_supported()
-            if not bad_deps:
+            if anthropic_tokens_supported():
                 return get_token_ids_anthropic(text)
             else:
                 warnings.warn(
-                    f"Falling back to default token method due to conflicts with the Anthropic API: {bad_deps}"
-                    f"\n\nFor Anthropic SDK versions > 0.38.0, it is recommended to provide the model class with a"
-                    f" custom_get_token_ids method that implements a more accurate tokenizer for Anthropic. "
+                    f"Falling back to default token method due to missing or incompatible `anthropic` installation "
+                    f"(needs <=0.38.0).\n\nIf using `anthropic>0.38.0`, it is recommended to provide the model "
+                    f"class with a custom_get_token_ids method implementing a more accurate tokenizer for Anthropic. "
                     f"For get_num_tokens, as another alternative, you can implement your own token counter method "
                     f"using the ChatAnthropic or AnthropicLLM classes."
                 )

--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -622,9 +622,12 @@ class ChatBedrock(BaseChatModel, BedrockBase):
         return final_output
 
     def get_num_tokens(self, text: str) -> int:
-        if self._model_is_anthropic and not self.custom_get_token_ids:
-            if anthropic_tokens_supported():
-                return get_num_tokens_anthropic(text)
+        if (
+            self._model_is_anthropic
+            and not self.custom_get_token_ids
+            and anthropic_tokens_supported()
+        ):
+            return get_num_tokens_anthropic(text)
         return super().get_num_tokens(text)
 
     def get_token_ids(self, text: str) -> List[int]:

--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -1313,10 +1313,10 @@ class BedrockLLM(LLM, BedrockBase):
                 return get_token_ids_anthropic(text)
             else:
                 warnings.warn(
-                    f"Falling back to default token method due to incompatibilities with the Anthropic API: {bad_deps}"
-                    f"For anthropic versions > 0.38.0, it is recommended to provide a custom_get_token_ids "
-                    f"method to the chat model class that implements the appropriate tokenizer for Anthropic. "
-                    f"Alternately, you can implement your own token counter method using the ChatAnthropic "
-                    f"or AnthropicLLM classes."
+                    f"Falling back to default token method due to conflicts with the Anthropic API: {bad_deps}"
+                    f"\n\nFor Anthropic SDK versions > 0.38.0, it is recommended to provide the model class with a"
+                    f" custom_get_token_ids method that implements a more accurate tokenizer for Anthropic. "
+                    f"For get_num_tokens, as another alternative, you can implement your own token counter method "
+                    f"using the ChatAnthropic or AnthropicLLM classes."
                 )
         return super().get_token_ids(text)

--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -1300,23 +1300,28 @@ class BedrockLLM(LLM, BedrockBase):
         return "".join([chunk.text for chunk in chunks])
 
     def get_num_tokens(self, text: str) -> int:
-        if self._model_is_anthropic and check_anthropic_tokens_dependencies():
-            return get_num_tokens_anthropic(text)
-        else:
-            if self._model_is_anthropic:
+        if self._model_is_anthropic:
+            bad_deps = check_anthropic_tokens_dependencies()
+            if not bad_deps:
+                return get_num_tokens_anthropic(text)
+            else:
                 logger.debug(
-                    "Falling back to default token counting due to incompatible or missing Anthropic dependencies. "
-                    "To fix this, ensure that you have anthropic<=0.38.0, httpx<=0.27.2, and Python<=3.12 installed."
+                    "Falling back to default token counting due to incompatible/missing Anthropic dependencies:"
                 )
-            return super().get_num_tokens(text)
+                for x in bad_deps:
+                    logger.debug(x)
+
+        return super().get_num_tokens(text)
 
     def get_token_ids(self, text: str) -> List[int]:
-        if self._model_is_anthropic and check_anthropic_tokens_dependencies():
-            return get_token_ids_anthropic(text)
-        else:
-            if self._model_is_anthropic:
+        if self._model_is_anthropic:
+            bad_deps = check_anthropic_tokens_dependencies()
+            if not bad_deps:
+                return get_token_ids_anthropic(text)
+            else:
                 logger.debug(
-                    "Falling back to default token ids retrieval due to incompatible or missing Anthropic dependencies."
-                    " To fix this, ensure that you have anthropic<=0.38.0, httpx<=0.27.2, and Python<=3.12 installed."
+                    "Falling back to default token ids retrieval due to incompatible/missing Anthropic dependencies:"
                 )
-            return super().get_token_ids(text)
+                for x in bad_deps:
+                    logger.debug(x)
+        return super().get_token_ids(text)

--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -1303,21 +1303,19 @@ class BedrockLLM(LLM, BedrockBase):
 
     def get_num_tokens(self, text: str) -> int:
         if self._model_is_anthropic and not self.custom_get_token_ids:
-            bad_deps = anthropic_tokens_supported()
-            if not bad_deps:
+            if anthropic_tokens_supported():
                 return get_num_tokens_anthropic(text)
         return super().get_num_tokens(text)
 
     def get_token_ids(self, text: str) -> List[int]:
         if self._model_is_anthropic and not self.custom_get_token_ids:
-            bad_deps = anthropic_tokens_supported()
-            if not bad_deps:
+            if anthropic_tokens_supported():
                 return get_token_ids_anthropic(text)
             else:
                 warnings.warn(
-                    f"Falling back to default token method due to conflicts with the Anthropic API: {bad_deps}"
-                    f"\n\nFor Anthropic SDK versions > 0.38.0, it is recommended to provide the model class with a"
-                    f" custom_get_token_ids method that implements a more accurate tokenizer for Anthropic. "
+                    f"Falling back to default token method due to missing or incompatible `anthropic` installation "
+                    f"(needs <=0.38.0).\n\nFor `anthropic>0.38.0`, it is recommended to provide the model "
+                    f"class with a custom_get_token_ids method implementing a more accurate tokenizer for Anthropic. "
                     f"For get_num_tokens, as another alternative, you can implement your own token counter method "
                     f"using the ChatAnthropic or AnthropicLLM classes."
                 )

--- a/libs/aws/langchain_aws/utils.py
+++ b/libs/aws/langchain_aws/utils.py
@@ -10,25 +10,38 @@ def enforce_stop_tokens(text: str, stop: List[str]) -> str:
     return re.split("|".join(stop), text, maxsplit=1)[0]
 
 
-def check_anthropic_tokens_dependencies() -> bool:
+def check_anthropic_tokens_dependencies() -> List[str]:
     """Check if we have all requirements for Anthropic count_tokens() and get_tokenizer()."""
+    bad_deps = []
+
+    python_version = sys.version_info
+    if python_version > (3, 12):
+        bad_deps.append(f"Python 3.12 or earlier required, found {'.'.join(map(str, python_version[:3]))})")
+
+    bad_anthropic = None
     try:
         import anthropic
-        import httpx
+        anthropic_version = version.parse(anthropic.__version__)
+        if anthropic_version > version.parse("0.38.0"):
+            bad_anthropic = anthropic_version
     except ImportError:
-        return False
+        bad_anthropic = "none installed"
 
-    anthropic_version = version.parse(anthropic.__version__)
-    httpx_version = version.parse(httpx.__version__)
-    python_version = sys.version_info
-    if (
-        anthropic_version > version.parse("0.38.0") or
-        httpx_version > version.parse("0.27.2") or
-        python_version > (3, 12)
-    ):
-        return False
+    bad_httpx = None
+    try:
+        import httpx
+        httpx_version = version.parse(httpx.__version__)
+        if httpx_version > version.parse("0.27.2"):
+            bad_httpx = httpx_version
+    except ImportError:
+        bad_httpx = "none installed"
 
-    return True
+    if bad_anthropic:
+        bad_deps.append(f"anthropic<=0.38.0 required, found {bad_anthropic}.")
+    if bad_httpx:
+        bad_deps.append(f"httpx<=0.27.2 required, found {bad_httpx}.")
+
+    return bad_deps
 
 
 def _get_anthropic_client() -> Any:

--- a/libs/aws/langchain_aws/utils.py
+++ b/libs/aws/langchain_aws/utils.py
@@ -1,4 +1,6 @@
 import re
+import sys
+from packaging import version
 from typing import Any, List
 
 
@@ -7,15 +9,29 @@ def enforce_stop_tokens(text: str, stop: List[str]) -> str:
     return re.split("|".join(stop), text, maxsplit=1)[0]
 
 
-def _get_anthropic_client() -> Any:
+def check_anthropic_tokens_dependencies() -> bool:
+    """Check if we have all requirements for Anthropic count_tokens() and get_tokenizer()."""
     try:
         import anthropic
+        import httpx
     except ImportError:
-        raise ImportError(
-            "Could not import anthropic python package. "
-            "This is needed in order to accurately tokenize the text "
-            "for anthropic models. Please install it with `pip install anthropic`."
-        )
+        return False
+
+    anthropic_version = version.parse(anthropic.__version__)
+    httpx_version = version.parse(httpx.__version__)
+    python_version = sys.version_info
+    if (
+        anthropic_version > version.parse("0.38.0") or
+        httpx_version > version.parse("0.27.2") or
+        python_version > (3, 12)
+    ):
+        return False
+
+    return True
+
+
+def _get_anthropic_client() -> Any:
+    import anthropic
     return anthropic.Anthropic()
 
 

--- a/libs/aws/langchain_aws/utils.py
+++ b/libs/aws/langchain_aws/utils.py
@@ -1,5 +1,4 @@
 import re
-import sys
 from typing import Any, List
 
 from packaging import version
@@ -10,14 +9,9 @@ def enforce_stop_tokens(text: str, stop: List[str]) -> str:
     return re.split("|".join(stop), text, maxsplit=1)[0]
 
 
-def check_anthropic_tokens_dependencies() -> List[str]:
+def anthropic_tokens_supported() -> List[str]:
     """Check if we have all requirements for Anthropic count_tokens() and get_tokenizer()."""
     bad_deps = []
-
-    python_version = sys.version_info
-    if python_version > (3, 12):
-        bad_deps.append(f"Python 3.12 or earlier required, found {'.'.join(map(str, python_version[:3]))})")
-
     bad_anthropic = None
     try:
         import anthropic

--- a/libs/aws/langchain_aws/utils.py
+++ b/libs/aws/langchain_aws/utils.py
@@ -16,20 +16,17 @@ def anthropic_tokens_supported() -> bool:
     except ImportError:
         return False
 
-    anthropic_version = version.parse(anthropic.__version__)
-    if anthropic_version > version.parse("0.38.0"):
+    if version.parse(anthropic.__version__) > version.parse("0.38.0"):
         return False
-    else:
-        httpx_import_msg = "httpx<=0.27.2 is required."
-        try:
-            import httpx
-        except ImportError:
-            raise ImportError(httpx_import_msg)
-        httpx_version = version.parse(httpx.__version__)
-        if httpx_version > version.parse("0.27.2"):
-            raise ImportError(httpx_import_msg)
-        else:
-            return True
+
+    try:
+        import httpx
+        if version.parse(httpx.__version__)  > version.parse("0.27.2"):
+            raise ImportError()
+    except ImportError:
+        raise ImportError("httpx<=0.27.2 is required.")
+
+    return True
 
 
 def _get_anthropic_client() -> Any:

--- a/libs/aws/langchain_aws/utils.py
+++ b/libs/aws/langchain_aws/utils.py
@@ -1,7 +1,8 @@
 import re
 import sys
-from packaging import version
 from typing import Any, List
+
+from packaging import version
 
 
 def enforce_stop_tokens(text: str, stop: List[str]) -> str:

--- a/libs/aws/langchain_aws/utils.py
+++ b/libs/aws/langchain_aws/utils.py
@@ -9,33 +9,27 @@ def enforce_stop_tokens(text: str, stop: List[str]) -> str:
     return re.split("|".join(stop), text, maxsplit=1)[0]
 
 
-def anthropic_tokens_supported() -> List[str]:
+def anthropic_tokens_supported() -> bool:
     """Check if we have all requirements for Anthropic count_tokens() and get_tokenizer()."""
-    bad_deps = []
-    bad_anthropic = None
     try:
         import anthropic
-        anthropic_version = version.parse(anthropic.__version__)
-        if anthropic_version > version.parse("0.38.0"):
-            bad_anthropic = anthropic_version
     except ImportError:
-        bad_anthropic = "none installed"
+        return False
 
-    bad_httpx = None
-    try:
-        import httpx
+    anthropic_version = version.parse(anthropic.__version__)
+    if anthropic_version > version.parse("0.38.0"):
+        return False
+    else:
+        httpx_import_msg = "httpx<=0.27.2 is required."
+        try:
+            import httpx
+        except ImportError:
+            raise ImportError(httpx_import_msg)
         httpx_version = version.parse(httpx.__version__)
         if httpx_version > version.parse("0.27.2"):
-            bad_httpx = httpx_version
-    except ImportError:
-        bad_httpx = "none installed"
-
-    if bad_anthropic:
-        bad_deps.append(f"anthropic<=0.38.0 required, found {bad_anthropic}.")
-    if bad_httpx:
-        bad_deps.append(f"httpx<=0.27.2 required, found {bad_httpx}.")
-
-    return bad_deps
+            raise ImportError(httpx_import_msg)
+        else:
+            return True
 
 
 def _get_anthropic_client() -> Any:

--- a/libs/aws/langchain_aws/utils.py
+++ b/libs/aws/langchain_aws/utils.py
@@ -21,7 +21,8 @@ def anthropic_tokens_supported() -> bool:
 
     try:
         import httpx
-        if version.parse(httpx.__version__)  > version.parse("0.27.2"):
+
+        if version.parse(httpx.__version__) > version.parse("0.27.2"):
             raise ImportError()
     except ImportError:
         raise ImportError("httpx<=0.27.2 is required.")
@@ -31,6 +32,7 @@ def anthropic_tokens_supported() -> bool:
 
 def _get_anthropic_client() -> Any:
     import anthropic
+
     return anthropic.Anthropic()
 
 

--- a/libs/aws/tests/unit_tests/retrievers/test_bedrock.py
+++ b/libs/aws/tests/unit_tests/retrievers/test_bedrock.py
@@ -494,9 +494,7 @@ def test_when_get_content_from_result_then_get_expected_content(
     search_result_input, expected_output
 ):
     assert (
-        AmazonKnowledgeBasesRetriever._get_content_from_result(
-            search_result_input
-        )
+        AmazonKnowledgeBasesRetriever._get_content_from_result(search_result_input)
         == expected_output
     )
 
@@ -518,9 +516,7 @@ def test_when_get_content_from_result_with_invalid_content_then_raise_error(
     search_result_input,
 ):
     with pytest.raises(ValueError):
-        AmazonKnowledgeBasesRetriever._get_content_from_result(
-            search_result_input
-        )
+        AmazonKnowledgeBasesRetriever._get_content_from_result(search_result_input)
 
 
 def set_return_value_and_query(


### PR DESCRIPTION
Fixes #314

The `get_num_tokens()` and `get_token_ids()` methods of `BedrockLLM` and `ChatBedrock` currently fail when used with Anthropic models and `anthropic>=0.39.0` installed. 

In such scenarios, this PR fixes `get_num_tokens()` and `get_token_ids()` by falling back to the base class implementations [in `BaseLanguageModel`](https://python.langchain.com/api_reference/core/language_models/langchain_core.language_models.base.BaseLanguageModel.html#langchain_core.language_models.base.BaseLanguageModel.get_num_tokens) and [in `BaseChatModel`](https://python.langchain.com/api_reference/core/language_models/langchain_core.language_models.chat_models.BaseChatModel.html#langchain_core.language_models.chat_models.BaseChatModel.get_num_tokens), which use the HuggingFace [GPT2 Tokenizer](https://huggingface.co/docs/transformers/en/model_doc/gpt2#transformers.GPT2TokenizerFast). 

If `anthropic<=0.38.0` (and other requirements) are present instead, the Anthropic SDK token methods will continue to be used as normal.

**Note about tokenizer accuracy:** 

The GPT2 and Anthropic SDK tokenizers (see [here](https://github.com/anthropics/anthropic-sdk-python/pull/726/files#diff-9595fafc42ceb1044adb6f4f2a93774f58704ee22b6f9d40ad9d0a336c118d39L540-L542)) both may produce inaccurate token estimates for Claude 3 and 3.5 models. To obtain a more accurate estimate, Anthropic recommends using the new [Count Message Tokens API](https://docs.anthropic.com/en/api/messages-count-tokens). For example:
```
import os
import anthropic

os.environ["ANTHROPIC_API_KEY"] = "<your-api-key>"
anthropic.Anthropic().messages.count_tokens(
    model="claude-3-5-sonnet-20241022",
    messages=[
        {"role": "user", "content": "Hello, world"}
    ]
)
```

As another alternative, you can implement your own token counter method, and pass this using [`custom_get_token_ids`](https://python.langchain.com/api_reference/core/language_models/langchain_core.language_models.base.BaseLanguageModel.html#langchain_core.language_models.base.BaseLanguageModel.custom_get_token_ids) when initializing the model. This will override both the GPT2 and Anthropic tokenizers.



