### PR TITLE
Adding request metadata support

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -845,6 +845,7 @@ class ChatBedrock(BaseChatModel, BedrockBase):
                 "additional_model_request_fields",
                 "additional_model_response_field_paths",
                 "performance_config",
+                "request_metadata",
             )
         }
         if self.max_tokens:

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -404,6 +404,9 @@ class ChatBedrockConverse(BaseChatModel):
         """,
     )
 
+    request_metadata: Optional[Dict[str, str]] = None
+    """Key-Value pairs that you can use to filter invocation logs."""
+
     model_config = ConfigDict(
         extra="forbid",
         populate_by_name=True,
@@ -635,6 +638,7 @@ class ChatBedrockConverse(BaseChatModel):
         additionalModelResponseFieldPaths: Optional[List[str]] = None,
         guardrailConfig: Optional[dict] = None,
         performanceConfig: Optional[Mapping[str, Any]] = None,
+        requestMetadata: Optional[dict] = None,
     ) -> Dict[str, Any]:
         if not inferenceConfig:
             inferenceConfig = {
@@ -658,6 +662,7 @@ class ChatBedrockConverse(BaseChatModel):
                 or self.additional_model_response_field_paths,
                 "guardrailConfig": guardrailConfig or self.guardrail_config,
                 "performanceConfig": performanceConfig or self.performance_config,
+                "requestMetadata": requestMetadata or self.request_metadata,
             }
         )
 


### PR DESCRIPTION
Adding request metadata support for Converse API through ChatBedrock and ChatBedrockConverse

### Usage through ChatBedrock with converse flag as `True`:

```
ChatBedrock(
        model_id="us.anthropic.claude-3-5-sonnet-20241022-v2:0",  
        region_name="us-east-1",
        temperature=0.15,
        max_tokens=100,
        beta_use_converse_api=True,
        model_kwargs={"request_metadata":{"priority": "High"}}
    )
```

### Using ChatBedrockConverse:

```
ChatBedrockConverse(
        model_id="anthropic.claude-3-haiku-20240307-v1:0",
        region_name="us-east-1",
        request_metadata={"priority": "High"}
    )
```