### PR TITLE
[Fix] added missed client parameter in ChatBedrock

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -855,6 +855,7 @@ class ChatBedrock(BaseChatModel, BedrockBase):
         if self.temperature is not None:
             kwargs["temperature"] = self.temperature
         return ChatBedrockConverse(
+            client=self.client,
             model=self.model_id,
             region_name=self.region_name,
             credentials_profile_name=self.credentials_profile_name,

--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
@@ -1,7 +1,6 @@
 """Standard LangChain interface tests"""
 
 from typing import Literal, Type
-from unittest.mock import Mock
 import pytest
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import HumanMessage
@@ -56,33 +55,6 @@ class TestBedrockNovaStandard(ChatModelIntegrationTests):
     @property
     def chat_model_params(self) -> dict:
         return {"model": "us.amazon.nova-pro-v1:0"}
-
-    @property
-    def standard_chat_model_params(self) -> dict:
-        return {"max_tokens": 300, "stop": []}
-
-    @property
-    def tool_choice_value(self) -> str:
-        return "auto"
-
-    @pytest.mark.xfail(reason="Tool choice 'Any' not supported.")
-    def test_structured_few_shot_examples(self, model: BaseChatModel) -> None:
-        super().test_structured_few_shot_examples(model)
-
-    @pytest.mark.xfail(reason="Human messages following AI messages not supported.")
-    def test_tool_message_histories_list_content(self, model: BaseChatModel) -> None:
-        super().test_tool_message_histories_list_content(model)
-
-
-class TestBedrockNovaStandardWithClient(ChatModelIntegrationTests):
-    @property
-    def chat_model_class(self) -> Type[BaseChatModel]:
-        return ChatBedrockConverse
-
-    @property
-    def chat_model_params(self) -> dict:
-        client = Mock()
-        return {"client": client, "model": "us.amazon.nova-pro-v1:0"}
 
     @property
     def standard_chat_model_params(self) -> dict:

--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
@@ -1,7 +1,7 @@
 """Standard LangChain interface tests"""
 
 from typing import Literal, Type
-
+from unittest.mock import Mock
 import pytest
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import HumanMessage
@@ -56,6 +56,33 @@ class TestBedrockNovaStandard(ChatModelIntegrationTests):
     @property
     def chat_model_params(self) -> dict:
         return {"model": "us.amazon.nova-pro-v1:0"}
+
+    @property
+    def standard_chat_model_params(self) -> dict:
+        return {"max_tokens": 300, "stop": []}
+
+    @property
+    def tool_choice_value(self) -> str:
+        return "auto"
+
+    @pytest.mark.xfail(reason="Tool choice 'Any' not supported.")
+    def test_structured_few_shot_examples(self, model: BaseChatModel) -> None:
+        super().test_structured_few_shot_examples(model)
+
+    @pytest.mark.xfail(reason="Human messages following AI messages not supported.")
+    def test_tool_message_histories_list_content(self, model: BaseChatModel) -> None:
+        super().test_tool_message_histories_list_content(model)
+
+
+class TestBedrockNovaStandardWithClient(ChatModelIntegrationTests):
+    @property
+    def chat_model_class(self) -> Type[BaseChatModel]:
+        return ChatBedrockConverse
+
+    @property
+    def chat_model_params(self) -> dict:
+        client = Mock()
+        return {"client": client, "model": "us.amazon.nova-pro-v1:0"}
 
     @property
     def standard_chat_model_params(self) -> dict:

--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
@@ -1,6 +1,7 @@
 """Standard LangChain interface tests"""
 
 from typing import Literal, Type
+
 import pytest
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import HumanMessage

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -36,6 +36,7 @@ class TestBedrockStandard(ChatModelUnitTests):
     @property
     def chat_model_params(self) -> dict:
         return {
+            "client": None,
             "model": "anthropic.claude-3-sonnet-20240229-v1:0",
             "region_name": "us-west-1",
         }


### PR DESCRIPTION
Update the ChatBedrock class to accept the user initiated Bedrock client.