### PR TITLE
chore: update github actions monthly with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      action-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
This change will use dependabot to check for updates to any of the GitHub actions this project uses and submit pull requests with version bumps.