### PR TITLE
Update Streaming Validator for AWS Bedrock Models

### DIFF
--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -474,15 +474,13 @@ def test_standard_tracing_params() -> None:
     "model_id, disable_streaming",
     [
         ("us.anthropic.claude-3-7-sonnet-20250219-v1:0", False),
-        # As of 2025-02-09, Anthropic, Cohere, AI21, Meta and Mistral models support streaming:
         ("anthropic.claude-3-5-sonnet-20240620-v1:0", False),
         ("us.anthropic.claude-3-haiku-20240307-v1:0", False),
         ("cohere.command-r-v1:0", False),
-        ("meta.llama3-1-405b-instruct-v1:0", False),
-        ("us.meta.llama3-3-70b-instruct-v1:0", False),  # Added test case
-        # Amazon models support streaming only when model_id contains specific keywords:
+        ("meta.llama3-1-405b-instruct-v1:0", "tool_calling"),
+        ("us.meta.llama3-3-70b-instruct-v1:0", "tool_calling"),
         ("us.amazon.nova-lite-v1:0", False),
-        ("us.amazon.nonstreaming-model-v1:0", "tool_calling"),
+        ("us.amazon.nonstreaming-model-v1:0", True),
     ],
 )
 def test_set_disable_streaming(

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -474,10 +474,15 @@ def test_standard_tracing_params() -> None:
     "model_id, disable_streaming",
     [
         ("us.anthropic.claude-3-7-sonnet-20250219-v1:0", False),
+        # As of 2025-02-09, Anthropic, Cohere, AI21, Meta and Mistral models support streaming:
         ("anthropic.claude-3-5-sonnet-20240620-v1:0", False),
         ("us.anthropic.claude-3-haiku-20240307-v1:0", False),
         ("cohere.command-r-v1:0", False),
-        ("meta.llama3-1-405b-instruct-v1:0", "tool_calling"),
+        ("meta.llama3-1-405b-instruct-v1:0", False),
+        ("us.meta.llama3-3-70b-instruct-v1:0", False),  # Added test case
+        # Amazon models support streaming only when model_id contains specific keywords:
+        ("us.amazon.nova-lite-v1:0", False),
+        ("us.amazon.nonstreaming-model-v1:0", "tool_calling"),
     ],
 )
 def test_set_disable_streaming(


### PR DESCRIPTION
This pull request updates the streaming validator logic in our AWS Bedrock integration to align with the latest AWS documentation. According to the [AWS Bedrock Models Documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html), models from Anthropic, Cohere, AI21 Labs, Meta, and Mistral support streaming mode, while only specific Amazon models (those with IDs containing keywords like "nova-lite", "nova-micro", "nova-pro", "titan-text-express", "titan-text-lite", or "titan-text-premier") support streaming.

#### Changes Made

- **Streaming Validator Update:**  
  Modified the `set_disable_streaming` validator in `ChatBedrockConverse` to:
  - Recognize Meta, AI21 Labs, and Mistral models as having streaming enabled.
  - For Amazon models, enable streaming only when the model ID contains one of the approved keywords.

- **Integration Tests Update:**  
  - Enhanced the parameterized test for streaming mode (`test_set_disable_streaming`) to include additional cases, including the new test case for `"us.meta.llama3-3-70b-instruct-v1:0"`.
  - Ensured that models supporting streaming correctly have `disable_streaming` set to `False`, while models without streaming support set this flag to `"tool_calling"`.

#### Benefits

- **Alignment with AWS Official Documentation:**  
  This update ensures that our integration behaves as expected based on the official [AWS Bedrock Models Documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html).

- **Improved User Experience:**  
  Users leveraging AWS Bedrock models will now have the correct streaming behavior, avoiding unexpected validation errors.

#### Related Issue

- This PR addresses the concerns raised in [Issue #354](https://github.com/langchain-ai/langchain-aws/issues/354).

Please review the changes and provide any feedback or additional suggestions.