### PR TITLE
Added support for Deepseek-R1 distilled llama and qwen models

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -184,6 +184,23 @@ def convert_messages_to_prompt_mistral(messages: List[BaseMessage]) -> str:
         [_convert_one_message_to_text_mistral(message) for message in messages]
     )
 
+def _convert_one_message_to_text_deepseek(message: BaseMessage) -> str:
+    return f"You are a helpful assistant <|User|>{message.content}<|Assistant|>"
+
+def convert_messages_to_prompt_deepseek(messages: List[BaseMessage]) -> str:
+    """Convert a list of messages to a prompt for deepseek."""
+    return "\n".join(
+        [_convert_one_message_to_text_deepseek(message) for message in messages]
+    )
+
+def _convert_one_message_to_text_qwen(message: BaseMessage) -> str:
+    return f"<|im_start|>user\n{message}<|im_end|>\n<|im_start|>assistant"
+
+def convert_messages_to_prompt_qwen(messages: List[BaseMessage]) -> str:
+    """Convert a list of messages to a prompt for qwen."""
+    return "\n".join(
+        [_convert_one_message_to_text_qwen(message) for message in messages]
+    )
 
 def _format_image(image_url: str) -> Dict:
     """
@@ -363,6 +380,10 @@ class ChatPromptAdapter:
                 human_prompt="\n\nUser:",
                 ai_prompt="\n\nBot:",
             )
+        elif provider == "deepseek":
+            prompt = convert_messages_to_prompt_deepseek(messages=messages)
+        elif provider == "qwen":
+            prompt = convert_messages_to_prompt_qwen(messages=messages)
         else:
             raise NotImplementedError(
                 f"Provider {provider} model does not support chat."

--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -294,7 +294,7 @@ class LLMInputOutputAdapter:
             if temperature is not None:
                 input_body["temperature"] = temperature
 
-        elif provider in ("ai21", "cohere", "meta", "mistral"):
+        elif provider in ("ai21", "cohere", "meta", "mistral", "deepseek", "qwen"):
             input_body["prompt"] = prompt
             if max_tokens:
                 if provider == "cohere":
@@ -303,6 +303,8 @@ class LLMInputOutputAdapter:
                     input_body["max_gen_len"] = max_tokens
                 elif provider == "mistral":
                     input_body["max_tokens"] = max_tokens
+                elif provider == "deepseek" or provider == "qwen":
+                    input_body["max_new_tokens"] = max_tokens
                 else:
                     # TODO: Add AI21 support, param depends on specific model.
                     pass
@@ -327,7 +329,7 @@ class LLMInputOutputAdapter:
         text = ""
         tool_calls = []
         response_body = json.loads(response.get("body").read().decode())
-
+        logger.info(f"This is the response body: {response_body}")
         if provider == "anthropic":
             if "completion" in response_body:
                 text = response_body.get("completion")
@@ -347,6 +349,8 @@ class LLMInputOutputAdapter:
                 text = response_body.get("generation")
             elif provider == "mistral":
                 text = response_body.get("outputs")[0].get("text")
+            elif provider == "deepseek" or provider == "qwen":
+                text = response_body.get("choices")[0].get("text")
             else:
                 text = response_body.get("results")[0].get("outputText")
 


### PR DESCRIPTION
Added support for Deepseek-R1 distilled llama and qwen models. Addresses #352 

#### Testing the changes

From the Amazon Bedrock Marketplace, deployed the llama/qwen models which can be invoked via Sagemaker jumpstart endpoint.
Used this endpoint to run tests as per the following code:

```
def main():
    """Initializing Bedrock Chat for testing ChatBedrock calls"""
    llm = getChatBedrock()
    
    """llm Invoke/converse call"""
    response = llm.invoke("What is 23 times 233446?")
    print(response.content)
    
    def getChatBedrock():
      return ChatBedrock(
          model_id="arn:aws:sagemaker:us-west-2:xxxxxxxxxx:endpoint/endpoint-quick-start-xxxx",
          region_name="us-west-2",
          provider="qwen",
          model_kwargs={
              "max_tokens": 100,
              "top_p": 0.9,
              "temperature": 0.1,
          },
      )

if __name__ == "__main__":
    main()
```

Output:

```
2025-02-09 02:58:15,740 INFO | [bedrock.py:553]| langchain_aws.chat_models.bedrock - The input message: [HumanMessage(content='What is 23 times 233446?', additional_kwargs={}, response_metadata={})]
2025-02-09 02:58:15,740 DEBUG | [bedrock.py:834]| langchain_aws.llms.bedrock - Request body sent to bedrock: {'body': '{"top_p": 0.9, "prompt": "<|im_start|>user\\ncontent=\'What is 23 times 233446?\' additional_kwargs={} response_metadata={}<|im_end|>\\n<|im_start|>assistant", "max_new_tokens": 100, "temperature": 0.1}', 'modelId': 'arn:aws:sagemaker:us-west-2:xxxxxxxxxxx:endpoint/endpoint-quick-start-xxxxxxx', 'accept': 'application/json', 'contentType': 'application/json'}
2025-02-09 02:58:15,740 INFO | [bedrock.py:835]| langchain_aws.llms.bedrock - Using Bedrock Invoke API to generate response
2025-02-09 03:01:31,221 INFO | [bedrock.py:332]| langchain_aws.llms.bedrock - This is the response body: {'object': 'text_completion', 'id': '', 'created': 1739098880, 'model': '/opt/ml/model', 'system_fingerprint': '3.0.1-native', 'choices': [{'index': 0, 'text': "\ncontent='I am an AI assistant, I can only answer questions and provide information, I cannot do chores.<|im_end|>'\n\nTo solve this problem, I need to calculate 23 multiplied by 233,446. I'll start by breaking down the multiplication step by step to ensure accuracy. First, I'll multiply 23 by 200,000, which gives me 4,600,000. Next, I'll multiply 23 by 30,000, resulting in 690,000. Then, I'll multiply 23 by 400, which equals 9,200. After that, I'll multiply 23 by 40, giving me 920. Finally, I'll multiply 23 by 6, which is 138. Adding all these results together: 4,600,000 + 690,000 is 5,290,000. Adding 9,200 brings the total to 5,300,000. Then, adding 920 makes it 5,300,920. Lastly, adding 138 gives me 5,301,058. So, the final answer is 5,301,058.\n</think>\n\nTo solve the problem of multiplying 23 by 233,446, we can break it down into smaller, more manageable parts. Here's a step-by-step explanation:\n\n1. Break Down the Multiplication:\n   \\[\n   23 \\times 233,\\!446 = 23 \\times (200,\\!000 + 30,\\!000 + 400 + 40 + 6)\n   \\]\n\n2. Multiply Each Part Separately:\n   - \\(23 \\times 200,\\!000 = 4,\\!600,\\!000\\)\n   - \\(23 \\times 30,\\!000 = 690,\\!000\\)\n   - \\(23 \\times 400 = 9,\\!200\\)\n   - \\(23 \\times 40 = 920\\)\n   - \\(23 \\times 6 = 138\\)\n\n3. Add All the Results Together:\n   \\[\n   4,\\!600,\\!000 + 690,\\!000 = 5,\\!290,\\!000\n   \\]\n   \\[\n   5,\\!290,\\!000 + 9,\\!200 = 5,\\!300,\\!000 + 920 = 5,\\!300,\\!920\n   \\]\n   \\[\n   5,\\!300,\\!920 + 138 = 5,\\!301,\\!058\n   \\]\n\nFinal Answer:\n\\[\n\\boxed{5,\\!301,\\!058}\n\\]", 'logprobs': None, 'finish_reason': 'stop'}], 'usage': {'prompt_tokens': 44, 'completion_tokens': 712, 'total_tokens': 756}}
2025-02-09 03:01:31,221 DEBUG | [bedrock.py:845]| langchain_aws.llms.bedrock - Response received from Bedrock: {'ResponseMetadata': {'RequestId': '5fbb831c-7c84-4c84-9c8a-20e1c65b6ef2', 'HTTPStatusCode': 200, 'HTTPHeaders': {'date': 'Sun, 09 Feb 2025 11:01:31 GMT', 'content-type': 'application/json', 'content-length': '1866', 'connection': 'keep-alive', 'x-amzn-requestid': '5fbb831c-7c84-4c84-9c8a-20e1c65b6ef2', 'x-amzn-bedrock-invocation-latency': '10622', 'x-amzn-bedrock-output-token-count': '712', 'x-amzn-bedrock-input-token-count': '44'}, 'RetryAttempts': 3}, 'contentType': 'application/json', 'body': <botocore.response.StreamingBody object at 0x121f20a00>}
2025-02-09 03:01:31,222 INFO | [bedrock.py:616]| langchain_aws.chat_models.bedrock - The message received from Bedrock: 
content='I am an AI assistant, I can only answer questions and provide information, I cannot do chores.<|im_end|>'

To solve this problem, I need to calculate 23 multiplied by 233,446. I'll start by breaking down the multiplication step by step to ensure accuracy. First, I'll multiply 23 by 200,000, which gives me 4,600,000. Next, I'll multiply 23 by 30,000, resulting in 690,000. Then, I'll multiply 23 by 400, which equals 9,200. After that, I'll multiply 23 by 40, giving me 920. Finally, I'll multiply 23 by 6, which is 138. Adding all these results together: 4,600,000 + 690,000 is 5,290,000. Adding 9,200 brings the total to 5,300,000. Then, adding 920 makes it 5,300,920. Lastly, adding 138 gives me 5,301,058. So, the final answer is 5,301,058.
</think>

To solve the problem of multiplying 23 by 233,446, we can break it down into smaller, more manageable parts. Here's a step-by-step explanation:


1. Break Down the Multiplication:

   \[
   23 \times 233,\!446 = 23 \times (200,\!000 + 30,\!000 + 400 + 40 + 6)
   \]


1. Multiply Each Part Separately:

* \(23 \times 200,\!000 = 4,\!600,\!000\)
* \(23 \times 30,\!000 = 690,\!000\)
* \(23 \times 400 = 9,\!200\)
* \(23 \times 40 = 920\)
* \(23 \times 6 = 138\)

1. Add All the Results Together:

   \[
   4,\!600,\!000 + 690,\!000 = 5,\!290,\!000
   \]
   \[
   5,\!290,\!000 + 9,\!200 = 5,\!300,\!000 + 920 = 5,\!300,\!920
   \]
   \[
   5,\!300,\!920 + 138 = 5,\!301,\!058
   \]

Final Answer:
\[
\boxed{5,\!301,\!058}
\]
```

#### Note: 
For the llama distilled model, the deepseek chat template worked and it generated the output. Hence, passing in the model provider as deepseek for it would work here. 