### PR TITLE
removed unecessary debug statements

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -529,7 +529,7 @@ class ChatBedrock(BaseChatModel, BedrockBase):
             return self._as_converse._generate(
                 messages, stop=stop, run_manager=run_manager, **kwargs
             )
-        logger.info(f"The input message: {messages}")
+
         completion = ""
         llm_output: Dict[str, Any] = {}
         tool_calls: List[ToolCall] = []

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -511,19 +511,14 @@ class ChatBedrockConverse(BaseChatModel):
         **kwargs: Any,
     ) -> ChatResult:
         """Top Level call"""
-        logger.info(f"The input message: {messages}")
         bedrock_messages, system = _messages_to_bedrock(messages)
-        logger.debug(f"input message to bedrock: {bedrock_messages}")
-        logger.debug(f"System message to bedrock: {system}")
         params = self._converse_params(
             stop=stop, **_snake_to_camel_keys(kwargs, excluded_keys={"inputSchema"})
         )
-        logger.debug(f"Input params: {params}")
         logger.info("Using Bedrock Converse API to generate response")
         response = self.client.converse(
             messages=bedrock_messages, system=system, **params
         )
-        logger.debug(f"Response from Bedrock: {response}")
         response_message = _parse_response(response)
         return ChatResult(generations=[ChatGeneration(message=response_message)])
 

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -512,13 +512,17 @@ class ChatBedrockConverse(BaseChatModel):
     ) -> ChatResult:
         """Top Level call"""
         bedrock_messages, system = _messages_to_bedrock(messages)
+        logger.debug(f"input message to bedrock: {bedrock_messages}")
+        logger.debug(f"System message to bedrock: {system}")
         params = self._converse_params(
             stop=stop, **_snake_to_camel_keys(kwargs, excluded_keys={"inputSchema"})
         )
+        logger.debug(f"Input params: {params}")
         logger.info("Using Bedrock Converse API to generate response")
         response = self.client.converse(
             messages=bedrock_messages, system=system, **params
         )
+        logger.debug(f"Response from Bedrock: {response}")
         response_message = _parse_response(response)
         return ChatResult(generations=[ChatGeneration(message=response_message)])
 

--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -827,6 +827,7 @@ class BedrockBase(BaseLanguageModel, ABC):
                 request_options["trace"] = "ENABLED"
 
         try:
+            logger.debug(f"Request body sent to bedrock: {request_options}")
             logger.info("Using Bedrock Invoke API to generate response")
             response = self.client.invoke_model(**request_options)
 
@@ -837,6 +838,7 @@ class BedrockBase(BaseLanguageModel, ABC):
                 usage_info,
                 stop_reason,
             ) = LLMInputOutputAdapter.prepare_output(provider, response).values()
+            logger.debug(f"Response received from Bedrock: {response}")
         except Exception as e:
             logging.error(f"Error raised by bedrock service: {e}")
             if run_manager is not None:

--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -827,7 +827,6 @@ class BedrockBase(BaseLanguageModel, ABC):
                 request_options["trace"] = "ENABLED"
 
         try:
-            logger.debug(f"Request body sent to bedrock: {request_options}")
             logger.info("Using Bedrock Invoke API to generate response")
             response = self.client.invoke_model(**request_options)
 
@@ -838,7 +837,6 @@ class BedrockBase(BaseLanguageModel, ABC):
                 usage_info,
                 stop_reason,
             ) = LLMInputOutputAdapter.prepare_output(provider, response).values()
-            logger.debug(f"Response received from Bedrock: {response}")
         except Exception as e:
             logging.error(f"Error raised by bedrock service: {e}")
             if run_manager is not None:


### PR DESCRIPTION
The bedrock chat model has several logging statements that seem to be left over from someone debugging the code. Some of them result in the entire prompt being logged to the console, cluttering logging of applications leveraging the module. This PR removes said logging statements.