### PR TITLE
Use `logger.exception` to log errors inside exception handlers and avoid logging from the root logger

### DIFF
--- a/libs/aws/langchain_aws/agents/base.py
+++ b/libs/aws/langchain_aws/agents/base.py
@@ -18,6 +18,8 @@ from langchain_core.runnables import RunnableConfig, RunnableSerializable, ensur
 from langchain_core.tools import BaseTool
 from pydantic import model_validator
 
+logger = logging.getLogger(__name__)
+
 _DEFAULT_ACTION_GROUP_NAME = "DEFAULT_AG_"
 _TEST_AGENT_ALIAS_ID = "TSTALIASID"
 
@@ -161,7 +163,7 @@ def _create_bedrock_agent(
 
     create_agent_response = bedrock_client.create_agent(**create_agent_request)
     request_id = create_agent_response.get("ResponseMetadata", {}).get("RequestId", "")
-    logging.info(f"Create bedrock agent call successful with request id: {request_id}")
+    logger.info(f"Create bedrock agent call successful with request id: {request_id}")
     agent_id = create_agent_response["agent"]["agentId"]
     create_agent_start_time = time.time()
     while time.time() - create_agent_start_time < 10:
@@ -175,7 +177,7 @@ def _create_bedrock_agent(
         else:
             time.sleep(2)
 
-    logging.error(f"Failed to create bedrock agent {agent_id}")
+    logger.error(f"Failed to create bedrock agent {agent_id}")
     raise Exception(f"Failed to create bedrock agent {agent_id}")
 
 
@@ -488,7 +490,7 @@ class BedrockAgentsRunnable(RunnableSerializable[Dict, OutputType]):
                 )
                 _prepare_agent(bedrock_client, agent_id)
             except Exception as exception:
-                logging.error(f"Error in create agent call: {exception}")
+                logger.exception("Error in create agent call")
                 raise exception
 
         return cls(

--- a/libs/aws/langchain_aws/embeddings/bedrock.py
+++ b/libs/aws/langchain_aws/embeddings/bedrock.py
@@ -10,6 +10,8 @@ from langchain_core.runnables.config import run_in_executor
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 from typing_extensions import Self
 
+logger = logging.getLogger(__name__)
+
 
 class BedrockEmbeddings(BaseModel, Embeddings):
     """Bedrock embedding models.
@@ -174,7 +176,7 @@ class BedrockEmbeddings(BaseModel, Embeddings):
             response_body = json.loads(response.get("body").read())
             return response_body
         except Exception as e:
-            logging.error(f"Error raised by inference endpoint: {e}")
+            logger.exception("Error raised by inference endpoint")
             raise e
 
     def _normalize_vector(self, embeddings: List[float]) -> List[float]:

--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -841,7 +841,7 @@ class BedrockBase(BaseLanguageModel, ABC):
             ) = LLMInputOutputAdapter.prepare_output(provider, response).values()
             logger.debug(f"Response received from Bedrock: {response}")
         except Exception as e:
-            logging.error(f"Error raised by bedrock service: {e}")
+            logger.exception("Error raised by bedrock service")
             if run_manager is not None:
                 run_manager.on_llm_error(e)
             raise e
@@ -968,7 +968,7 @@ class BedrockBase(BaseLanguageModel, ABC):
             response = self.client.invoke_model_with_response_stream(**request_options)
 
         except Exception as e:
-            logging.error(f"Error raised by bedrock service: {e}")
+            logger.exception("Error raised by bedrock service")
             if run_manager is not None:
                 run_manager.on_llm_error(e)
             raise e

--- a/libs/aws/langchain_aws/llms/sagemaker_endpoint.py
+++ b/libs/aws/langchain_aws/llms/sagemaker_endpoint.py
@@ -12,6 +12,8 @@ from langchain_core.outputs import GenerationChunk
 from pydantic import ConfigDict, model_validator
 from typing_extensions import Self
 
+logger = logging.getLogger(__name__)
+
 INPUT_TYPE = TypeVar("INPUT_TYPE", bound=Union[str, List[str]])
 OUTPUT_TYPE = TypeVar("OUTPUT_TYPE", bound=Union[str, List[List[float]], Iterator])
 
@@ -356,7 +358,7 @@ class SagemakerEndpoint(LLM):
                         run_manager.on_llm_new_token(chunk.text)
 
         except Exception as e:
-            logging.error(f"Error raised by streaming inference endpoint: {e}")
+            logger.exception("Error raised by streaming inference endpoint")
             if run_manager is not None:
                 run_manager.on_llm_error(e)
             raise e
@@ -412,7 +414,7 @@ class SagemakerEndpoint(LLM):
         try:
             response = self.client.invoke_endpoint(**invocation_params)
         except Exception as e:
-            logging.error(f"Error raised by inference endpoint: {e}")
+            logger.exception("Error raised by inference endpoint")
             if run_manager is not None:
                 run_manager.on_llm_error(e)
             raise e


### PR DESCRIPTION
## Rationale

- Not using the root logger lets the end user better control logging for specific packages and modules, e.g. by configuring `langchain_aws.llms.bedrock` to log at the `ERROR` level, but `langchain_aws.llms.bedrock` at the `DEBUG` level.
- Using `logger.exception` adds exception info to the [log record](https://docs.python.org/3/library/logging.html#logrecord-attributes). This is particularly useful if you want to use a library like [python-json-logger](https://pypi.org/project/python-json-logger/) or [structlog](https://github.com/hynek/structlog), where the exception info could be nicely formatted into an array/object.