### PR TITLE
Fix claude 3.7 thinking mode invoke text response

### DIFF
--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -335,6 +335,8 @@ class LLMInputOutputAdapter:
                 content = response_body.get("content")
                 if len(content) == 1 and content[0]["type"] == "text":
                     text = content[0]["text"]
+                elif len(content) == 2 and content[1]["type"] == "text":
+                    text = content[1]["text"]
                 elif any(block["type"] == "tool_use" for block in content):
                     tool_calls = extract_tool_calls(content)
 


### PR DESCRIPTION
Response looks like:
response_body: {'id': 'msg_', 'type': 'message', 'role': 'assistant', 'model': 'claude-3-7-sonnet-20250219', 'content': [{'type': 'thinking', 'thinking': '', 'signature': ''}, {'type': 'text', 'text': ""}], 'stop_reason': 'end_turn', 'stop_sequence': None, 'usage': {'input_tokens':, 'cache_creation_input_tokens': 0, 'cache_read_input_tokens': 0, 'output_tokens':}}

This is just to unblock using Claude 3.7 thinking mode with langchain bedrock.