### PR TITLE
Feat/add sonnet 3.7 thinking support (non-streaming + stream)

### DIFF
--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -787,7 +787,6 @@ class BedrockBase(BaseLanguageModel, ABC):
 
         provider = self._get_provider()
         params = {**_model_kwargs, **kwargs}
-
         # Add thinking configuration if it exists
         if hasattr(self, "thinking") and self.thinking:
             params["thinking"] = self.thinking


### PR DESCRIPTION
# Add Claude 3.7 Sonnet Thinking Mode Support

## Description
Added support for Claude 3.7 Sonnet's new thinking mode capability, which allows the model to show its reasoning process before providing the final answer.

## Changes
- Added `thinking` field to `ChatBedrock` class
- Updated response handling to process thinking content
- Added support for both streaming and non-streaming responses with thinking mode

## Example Usage
```python
model = ChatBedrock(
    model_id="us.anthropic.claude-3-7-sonnet-20250219-v1:0",
    model_kwargs={
        "anthropic_version": "bedrock-2023-05-31",
        "max_tokens": 24000,
        "thinking": {
            "type": "enabled",
            "budget_tokens": 16000
        }
    }
)