### PR TITLE
Add support for Anthropic Claude 3.7 Sonnet thinking

### DIFF
--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -30,13 +30,14 @@ from langchain_core.outputs import Generation, GenerationChunk, LLMResult
 from langchain_core.utils import secret_from_env
 from pydantic import ConfigDict, Field, SecretStr, model_validator
 from typing_extensions import Self
+
 from langchain_aws.function_calling import _tools_in_params
 from langchain_aws.utils import (
-    thinking_in_params,
     anthropic_tokens_supported,
     enforce_stop_tokens,
     get_num_tokens_anthropic,
     get_token_ids_anthropic,
+    thinking_in_params,
 )
 
 logger = logging.getLogger(__name__)

--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -30,9 +30,9 @@ from langchain_core.outputs import Generation, GenerationChunk, LLMResult
 from langchain_core.utils import secret_from_env
 from pydantic import ConfigDict, Field, SecretStr, model_validator
 from typing_extensions import Self
-
 from langchain_aws.function_calling import _tools_in_params
 from langchain_aws.utils import (
+    thinking_in_params,
     anthropic_tokens_supported,
     enforce_stop_tokens,
     get_num_tokens_anthropic,
@@ -146,6 +146,16 @@ def _stream_response_to_generation_chunk(
                     content=[content_block],
                     tool_call_chunks=[tc_chunk],  # type: ignore
                 )
+            elif stream_response["delta"]["type"] == "thinking_delta":
+                content_block = stream_response["delta"]
+                content_block["index"] = stream_response["index"]
+                content_block["type"] = "thinking"
+                return AIMessageChunk(content=[content_block])
+            elif stream_response["delta"]["type"] == "signature_delta":
+                content_block = stream_response["delta"]
+                content_block["index"] = stream_response["index"]
+                content_block["type"] = "thinking"
+                return AIMessageChunk(content=[content_block])
         elif msg_type == "message_delta":
             return AIMessageChunk(
                 content="",
@@ -273,9 +283,60 @@ class LLMInputOutputAdapter:
         input_body = {**model_kwargs}
         if provider == "anthropic":
             if messages:
+                # Check if we're using extended thinking
+                thinking_enabled = thinking_in_params(model_kwargs)
+
                 if tools:
                     input_body["tools"] = tools
                 input_body["anthropic_version"] = "bedrock-2023-05-31"
+
+                # Special handling for tool results with thinking
+                if thinking_enabled:
+                    # Check if we have a tool_result in the last user message
+                    # and need to ensure the previous assistant message starts with thinking
+                    if (
+                        len(messages) >= 2
+                        and messages[-1]["role"] == "user"
+                        and messages[-2]["role"] == "assistant"
+                    ):
+                        # Check if the last user message contains tool_result
+                        last_user_msg = messages[-1].get("content", [])
+                        tool_result = False
+                        if isinstance(last_user_msg, list):
+                            tool_result = any(
+                                item.get("type") == "tool_result"
+                                for item in last_user_msg
+                                if isinstance(item, dict)
+                            )
+
+                        if tool_result:
+                            # Make sure the assistant message has thinking first
+                            asst_content = messages[-2].get("content", [])
+                            if isinstance(asst_content, list) and asst_content:
+                                # Find thinking blocks and move them to the front if needed
+                                thinking_blocks = [
+                                    block
+                                    for block in asst_content
+                                    if isinstance(block, dict)
+                                    and block.get("type")
+                                    in ["thinking", "redacted_thinking"]
+                                ]
+                                if thinking_blocks and asst_content[0].get(
+                                    "type"
+                                ) not in ["thinking", "redacted_thinking"]:
+                                    # Reorder to put thinking blocks first
+                                    new_content = thinking_blocks.copy()
+                                    new_content.extend(
+                                        [
+                                            block
+                                            for block in asst_content
+                                            if isinstance(block, dict)
+                                            and block.get("type")
+                                            not in ["thinking", "redacted_thinking"]
+                                        ]
+                                    )
+                                    messages[-2]["content"] = new_content
+
                 input_body["messages"] = messages
                 if system:
                     input_body["system"] = system
@@ -328,16 +389,35 @@ class LLMInputOutputAdapter:
     def prepare_output(cls, provider: str, response: Any) -> dict:
         text = ""
         tool_calls = []
+        thinking = {}
         response_body = json.loads(response.get("body").read().decode())
 
         if provider == "anthropic":
             if "completion" in response_body:
                 text = response_body.get("completion")
             elif "content" in response_body:
-                content = response_body.get("content")
-                if len(content) == 1 and content[0]["type"] == "text":
-                    text = content[0]["text"]
-                elif any(block["type"] == "tool_use" for block in content):
+                content = response_body.get("content", [])
+                # Extract text content
+                text_blocks = [
+                    block["text"] for block in content if block.get("type") == "text"
+                ]
+                if text_blocks:
+                    text = "".join(text_blocks)
+
+                # Extract thinking content
+                thinking_blocks = [
+                    block for block in content if block.get("type") == "thinking"
+                ]
+                if thinking_blocks:
+                    # Get the first thinking block (there's typically just one)
+                    thinking_block = thinking_blocks[0]
+                    thinking = {
+                        "text": thinking_block.get("thinking", ""),
+                        "signature": thinking_block.get("signature", ""),
+                    }
+
+                # Extract tool calls if present
+                if any(block.get("type") == "tool_use" for block in content):
                     tool_calls = extract_tool_calls(content)
 
         else:
@@ -359,6 +439,7 @@ class LLMInputOutputAdapter:
         completion_tokens = int(headers.get("x-amzn-bedrock-output-token-count", 0))
         return {
             "text": text,
+            "thinking": thinking,
             "tool_calls": tool_calls,
             "body": response_body,
             "usage": {
@@ -789,6 +870,36 @@ class BedrockBase(BaseLanguageModel, ABC):
 
         provider = self._get_provider()
         params = {**_model_kwargs, **kwargs}
+
+        # Pre-process for thinking with tool use
+        if messages and "claude-3" in self._get_model() and thinking_in_params(params):
+            # We need to ensure thinking blocks are first in assistant messages
+            # Process each message in the sequence
+            for i, message in enumerate(messages):
+                if message.get("role") == "assistant" and i > 0:
+                    content = message.get("content", [])
+                    if isinstance(content, list) and content:
+                        # Find any thinking blocks
+                        thinking_blocks = [
+                            j
+                            for j, item in enumerate(content)
+                            if isinstance(item, dict)
+                            and item.get("type") in ["thinking", "redacted_thinking"]
+                        ]
+
+                        # If thinking blocks exist but aren't first, reorder
+                        if thinking_blocks and thinking_blocks[0] > 0:
+                            # Extract thinking blocks
+                            thinking_content = [content[j] for j in thinking_blocks]
+                            # Extract non-thinking blocks
+                            other_content = [
+                                item
+                                for j, item in enumerate(content)
+                                if j not in thinking_blocks
+                            ]
+                            # Reorder with thinking first
+                            message["content"] = thinking_content + other_content
+
         if "claude-3" in self._get_model() and _tools_in_params(params):
             input_body = LLMInputOutputAdapter.prepare_input(
                 provider=provider,
@@ -838,6 +949,7 @@ class BedrockBase(BaseLanguageModel, ABC):
 
             (
                 text,
+                thinking,
                 tool_calls,
                 body,
                 usage_info,
@@ -852,8 +964,11 @@ class BedrockBase(BaseLanguageModel, ABC):
 
         if stop is not None:
             text = enforce_stop_tokens(text, stop)
-
-        llm_output = {"usage": usage_info, "stop_reason": stop_reason}
+        llm_output = {
+            "usage": usage_info,
+            "stop_reason": stop_reason,
+            "thinking": thinking,
+        }
 
         # Verify and raise a callback error if any intervention occurs or a signal is
         # sent from a Bedrock service,
@@ -949,6 +1064,9 @@ class BedrockBase(BaseLanguageModel, ABC):
                     max_tokens=self.max_tokens,
                     temperature=self.temperature,
                 )
+            elif thinking_in_params(params):
+                coerce_content_to_string = False
+
         body = json.dumps(input_body)
 
         request_options = {

--- a/libs/aws/langchain_aws/utils.py
+++ b/libs/aws/langchain_aws/utils.py
@@ -48,3 +48,8 @@ def get_token_ids_anthropic(text: str) -> List[int]:
     tokenizer = client.get_tokenizer()
     encoded_text = tokenizer.encode(text)
     return encoded_text.ids
+
+
+def thinking_in_params(params: dict) -> bool:
+    """Check if the thinking parameter is enabled in the request."""
+    return params.get("thinking", {}).get("type") == "enabled"

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
@@ -513,3 +513,174 @@ def test_chat_bedrock_different_regions() -> None:
 def test_chat_bedrock_environment_variable() -> None:
     llm = ChatBedrock(model_id="anthropic.claude-3-sonnet-20240229-v1:0")
     assert llm.region_name == "ap-south-2"
+
+
+def test__format_anthropic_messages_with_thinking_blocks() -> None:
+    """Test that thinking blocks are correctly formatted and preserved in messages."""
+    system = SystemMessage("System instruction")  # type: ignore[misc]
+    human = HumanMessage("What is the weather in NYC?")  # type: ignore[misc]
+    ai = AIMessage(  # type: ignore[misc]
+        "",
+        additional_kwargs={
+            "thinking": {
+                "text": "I need to check the weather in NYC.",
+                "signature": "SIG123",
+            }
+        },
+        tool_calls=[{"name": "get_weather", "id": "1", "args": {"city": "nyc"}}],
+    )
+    tool = ToolMessage(  # type: ignore[misc]
+        "It might be cloudy in nyc",
+        tool_call_id="1",
+    )
+
+    messages = [system, human, ai, tool]
+    expected_system, expected_messages = (
+        "System instruction",
+        [
+            {"role": "user", "content": "What is the weather in NYC?"},
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "thinking",
+                        "thinking": "I need to check the weather in NYC.",
+                        "signature": "SIG123",
+                    },
+                    {
+                        "type": "tool_use",
+                        "name": "get_weather",
+                        "id": "1",
+                        "input": {"city": "nyc"},
+                    },
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "content": "It might be cloudy in nyc",
+                        "tool_use_id": "1",
+                    }
+                ],
+            },
+        ],
+    )
+
+    actual_system, actual_messages = _format_anthropic_messages(messages)
+    assert expected_system == actual_system
+    assert expected_messages == actual_messages
+
+
+def test__format_anthropic_messages_with_thinking_in_content_blocks() -> None:
+    """Test that thinking blocks in content are correctly ordered (first) in messages."""
+    system = SystemMessage("System instruction")  # type: ignore[misc]
+    human = HumanMessage("What is the weather in NYC?")  # type: ignore[misc]
+
+    # Create AIMessage with content list that has thinking block not at the start
+    ai = AIMessage(  # type: ignore[misc]
+        [
+            {"type": "text", "text": "Let me check the weather."},
+            {
+                "type": "thinking",
+                "thinking": "I should use the get_weather tool.",
+                "signature": "SIG456",
+            },
+            {
+                "type": "tool_use",
+                "id": "tool1",
+                "name": "get_weather",
+                "input": {"city": "nyc"},
+            },
+        ],
+    )
+    tool = ToolMessage("It might be cloudy in nyc", tool_call_id="tool1")  # type: ignore[misc]
+
+    messages = [system, human, ai, tool]
+    expected_system, expected_messages = (
+        "System instruction",
+        [
+            {"role": "user", "content": "What is the weather in NYC?"},
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "thinking",
+                        "thinking": "I should use the get_weather tool.",
+                        "signature": "SIG456",
+                    },
+                    {"type": "text", "text": "Let me check the weather."},
+                    {
+                        "type": "tool_use",
+                        "id": "tool1",
+                        "name": "get_weather",
+                        "input": {"city": "nyc"},
+                    },
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "content": "It might be cloudy in nyc",
+                        "tool_use_id": "tool1",
+                    }
+                ],
+            },
+        ],
+    )
+
+    actual_system, actual_messages = _format_anthropic_messages(messages)
+    assert expected_system == actual_system
+
+    # Verify thinking blocks are placed first in the content array
+    assert actual_messages[1]["content"][0]["type"] == "thinking"
+    assert expected_messages == actual_messages
+
+
+def test__format_anthropic_messages_after_tool_use_no_thinking() -> None:
+    """Test message formatting for assistant responses after tool use (which shouldn't have thinking)."""
+    system = SystemMessage("System instruction")  # type: ignore[misc]
+    human = HumanMessage("What is the weather in NYC?")  # type: ignore[misc]
+
+    # First assistant turn with thinking and tool use
+    assistant1 = AIMessage(  # type: ignore[misc]
+        "",
+        additional_kwargs={
+            "thinking": {
+                "text": "I need to check the weather in NYC.",
+                "signature": "SIG123",
+            }
+        },
+        tool_calls=[{"name": "get_weather", "id": "1", "args": {"city": "nyc"}}],
+    )
+
+    # Tool result from user
+    tool_result = ToolMessage("It might be cloudy in nyc", tool_call_id="1")  # type: ignore[misc]
+
+    # Final assistant response without thinking
+    assistant2 = AIMessage("Based on the data, it's cloudy in NYC.")  # type: ignore[misc]
+
+    messages = [system, human, assistant1, tool_result, assistant2]
+    _, actual_messages = _format_anthropic_messages(messages)
+
+    # Check that the final assistant message has no thinking blocks
+    assert len(actual_messages) == 4  # system isn't included in the array
+    assert actual_messages[3]["role"] == "assistant"
+
+    # The content should be a list with a single text block
+    assert isinstance(actual_messages[3]["content"], list)
+    assert len(actual_messages[3]["content"]) == 1
+    assert actual_messages[3]["content"][0]["type"] == "text"
+    assert (
+        actual_messages[3]["content"][0]["text"]
+        == "Based on the data, it's cloudy in NYC."
+    )
+
+    # Verify no thinking blocks in the final message
+    assert not any(
+        block.get("type") in ["thinking", "redacted_thinking"]
+        for block in actual_messages[3]["content"]
+    )

--- a/libs/aws/tests/unit_tests/llms/test_bedrock.py
+++ b/libs/aws/tests/unit_tests/llms/test_bedrock.py
@@ -481,3 +481,165 @@ def test_standard_tracing_params():
         "ls_model_type": "llm",
         "ls_model_name": "foo",
     }
+
+
+@pytest.fixture
+def anthropic_response_with_thinking():
+    body = MagicMock()
+    body.read.return_value = json.dumps(
+        {
+            "content": [
+                {
+                    "type": "thinking",
+                    "thinking": "Let me think through this step by step...",
+                    "signature": "SIGNATURE123",
+                },
+                {"type": "text", "text": "This is the output text."},
+            ]
+        }
+    ).encode()
+    response = dict(
+        body=body,
+        ResponseMetadata={
+            "HTTPHeaders": {
+                "x-amzn-bedrock-input-token-count": "10",
+                "x-amzn-bedrock-output-token-count": "30",
+            }
+        },
+    )
+    return response
+
+
+@pytest.fixture
+def anthropic_response_with_thinking_and_tool_use():
+    body = MagicMock()
+    body.read.return_value = json.dumps(
+        {
+            "content": [
+                {
+                    "type": "thinking",
+                    "thinking": "I need to use a tool to answer this question...",
+                    "signature": "SIGNATURE456",
+                },
+                {"type": "text", "text": "Let me check that for you."},
+                {
+                    "type": "tool_use",
+                    "id": "tool_1",
+                    "name": "get_weather",
+                    "input": {"city": "nyc"},
+                },
+            ],
+            "stop_reason": "tool_use",
+        }
+    ).encode()
+    response = dict(
+        body=body,
+        ResponseMetadata={
+            "HTTPHeaders": {
+                "x-amzn-bedrock-input-token-count": "15",
+                "x-amzn-bedrock-output-token-count": "40",
+            }
+        },
+    )
+    return response
+
+
+@pytest.fixture
+def anthropic_response_after_tool_use():
+    body = MagicMock()
+    body.read.return_value = json.dumps(
+        {
+            "content": [
+                {"type": "text", "text": "Based on the data, it's cloudy in NYC."},
+            ],
+            "stop_reason": "end_turn",
+        }
+    ).encode()
+    response = dict(
+        body=body,
+        ResponseMetadata={
+            "HTTPHeaders": {
+                "x-amzn-bedrock-input-token-count": "60",
+                "x-amzn-bedrock-output-token-count": "20",
+            }
+        },
+    )
+    return response
+
+
+def test_prepare_output_with_thinking(anthropic_response_with_thinking):
+    """Test that thinking blocks are extracted properly from the response."""
+    result = LLMInputOutputAdapter.prepare_output(
+        "anthropic", anthropic_response_with_thinking
+    )
+
+    # Check that the text content was extracted correctly
+    assert result["text"] == "This is the output text."
+
+    # Check that the thinking block was extracted correctly
+    assert "thinking" in result
+    assert isinstance(result["thinking"], dict)
+    assert result["thinking"]["text"] == "Let me think through this step by step..."
+    assert result["thinking"]["signature"] == "SIGNATURE123"
+
+    # Check that token counts are correct
+    assert result["usage"]["prompt_tokens"] == 10
+    assert result["usage"]["completion_tokens"] == 30
+    assert result["usage"]["total_tokens"] == 40
+
+
+def test_prepare_output_with_thinking_and_tool_use(
+    anthropic_response_with_thinking_and_tool_use,
+):
+    """Test that thinking blocks and tool use are extracted properly from the response."""
+    result = LLMInputOutputAdapter.prepare_output(
+        "anthropic", anthropic_response_with_thinking_and_tool_use
+    )
+
+    # Check that the text content was extracted correctly
+    assert result["text"] == "Let me check that for you."
+
+    # Check that the thinking block was extracted correctly
+    assert "thinking" in result
+    assert isinstance(result["thinking"], dict)
+    assert (
+        result["thinking"]["text"] == "I need to use a tool to answer this question..."
+    )
+    assert result["thinking"]["signature"] == "SIGNATURE456"
+
+    # Check that tool calls are extracted correctly
+    assert "tool_calls" in result
+    assert len(result["tool_calls"]) == 1
+    assert result["tool_calls"][0]["name"] == "get_weather"
+    assert result["tool_calls"][0]["args"] == {"city": "nyc"}
+    assert result["tool_calls"][0]["id"] == "tool_1"
+
+    # Check that stop reason is correctly extracted
+    assert result["stop_reason"] == "tool_use"
+
+    # Check that token counts are correct
+    assert result["usage"]["prompt_tokens"] == 15
+    assert result["usage"]["completion_tokens"] == 40
+    assert result["usage"]["total_tokens"] == 55
+
+
+def test_prepare_output_after_tool_use(anthropic_response_after_tool_use):
+    """Test that responses after tool use (which don't have thinking blocks) are handled correctly."""
+    result = LLMInputOutputAdapter.prepare_output(
+        "anthropic", anthropic_response_after_tool_use
+    )
+
+    # Check that the text content was extracted correctly
+    assert result["text"] == "Based on the data, it's cloudy in NYC."
+
+    # Check that thinking is an empty dictionary when no thinking blocks are present
+    assert "thinking" in result
+    assert result["thinking"] == {}
+
+    # Check that stop reason is correctly extracted
+    assert result["stop_reason"] == "end_turn"
+
+    # Check that token counts are correct
+    assert result["usage"]["prompt_tokens"] == 60
+    assert result["usage"]["completion_tokens"] == 20
+    assert result["usage"]["total_tokens"] == 80


### PR DESCRIPTION
# Add support for Anthropic Claude 3.7 Sonnet thinking capability

## Description
This PR adds comprehensive support for Anthropic Claude 3.7 Sonnet's "thinking" feature, which allows the model to expose its reasoning process during inference. The implementation is based on the approach used in [langchain-anthropic](https://github.com/langchain-ai/langchain/blob/master/libs/partners/anthropic/langchain_anthropic/chat_models.py) and should provide more consistent API relative to https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#streaming-extended-thinking with more complete handling across both streaming and non-streaming modes than PR https://github.com/langchain-ai/langchain-aws/pull/372.

## Features
- Added support for `reasoning_content` blocks in responses
- Implemented handling of thinking-related delta types in streaming responses
- Added utility function to detect thinking configuration in model parameters
- Complete support for both streaming and non-streaming modes

## Implementation Details
The thinking capability is implemented by handling three main patterns:
1. Full reasoning content with thinking text and signature
2. Redacted reasoning content (for audit logging)
3. Streaming thinking content with special delta types

The implementation follows the structure established in the official langchain-anthropic integration while adapting it to work with AWS Bedrock's API patterns.

## Required Changes
- Enhanced `_bedrock_to_lc` conversion function to handle `reasoning_content` blocks
- Added streaming support for `thinking_delta` and `signature_delta` types
- Added utility function `thinking_in_params` to detect thinking configuration
- Updated model compatibility logic to properly handle thinking content types
- Updated boto3 dependency requirement to >=1.37.0 (required to access underlying thinking calls)

## Usage Examples

### With ChatBedrock
```python
from langchain_aws import ChatBedrock
from langchain_core.messages import HumanMessage

chat_model = ChatBedrock(
    model="us.anthropic.claude-3-7-sonnet-20250219-v1:0",
    region="us-west-2",
    max_tokens=1500,
    model_kwargs={"thinking": {"type": "enabled", "budget_tokens": 1024}},
)

human_msg = HumanMessage(content="Why would you redact your thinking?")
# Invoke mode
print("====================Testing invoke mode====================")
response = chat_model.invoke([human_msg])

# Print thinking content if available
print("\n\033[1m=== THINKING ===\033[0m")
print(response.additional_kwargs["thinking"]["text"])

# Print the response
print("\n\033[1m=== RESPONSE ===\033[0m")
print(response.content)


# Streaming mode
print("\n====================Testing streaming mode====================")
in_thinking_mode = False
thinking_content = ""
text_content = ""
# Stream the response
for chunk in chat_model.stream([human_msg]):
    # Check if we have content
    if not chunk.content:
        continue

    if isinstance(chunk.content, str):
        # Plain text content
        print(chunk.content, end="", flush=True)
    elif isinstance(chunk.content, list):
        # Structured content with content blocks
        for block in chunk.content:
            if block.get("type") == "thinking":
                # If we weren't in thinking mode before, print header
                if not in_thinking_mode:
                    print(
                        "\n\033[33m=== THINKING ===\033[0m\n",
                        end="",
                        flush=True,
                    )
                    in_thinking_mode = True

                # Print thinking content if available
                if "thinking" in block and block["thinking"]:
                    thinking_content += block["thinking"]
                    print(block["thinking"], end="", flush=True)

                # If we received a signature, thinking block is complete
                if "signature" in block and block["signature"]:
                    print("\n\033[33m=== END THINKING ===\033[0m\n", flush=True)
                    in_thinking_mode = False

            elif block.get("type") == "text":
                # If we were in thinking mode, exit and print a separator
                if in_thinking_mode:
                    print("\n\033[33m=== END THINKING ===\033[0m\n", flush=True)
                    in_thinking_mode = False

                # Print text content
                if "text" in block and block["text"]:
                    text_content += block["text"]
                    print(block["text"], end="", flush=True)

```

### With ChatBedrockConverse (streaming)
```python
from langchain_aws import ChatBedrockConverse
from langchain_core.messages import HumanMessage

chat = ChatBedrockConverse(
    model="anthropic.claude-3-7-sonnet-20240229-v1:0",
    additional_model_request_fields={"thinking": {"type": "enabled"}}
)

for chunk in chat.stream([HumanMessage(content="Prove the Pythagorean theorem")]):
    for block in chunk.content:
        if isinstance(block, dict):
            if block.get("type") == "thinking":
                print("THINKING:", block.get("thinking", ""))
            elif block.get("type") == "text":
                print("ANSWER:", block.get("text", ""))
```

## Testing
Manually tested with all combinations:
- ChatBedrock (streaming and invoke)
- ChatBedrockConverse (streaming and invoke)
- With complex mathematical reasoning problems

## References
- Based on implementation in [langchain-anthropic](https://github.com/langchain-ai/langchain/blob/master/libs/partners/anthropic/langchain_anthropic/chat_models.py)
- [Anthropic Claude API Documentation](https://docs.anthropic.com/claude/docs/thinking)
- [AWS Bedrock Claude Documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-claude.html)

## Version Bump
Version updated from 0.2.13 to 0.2.14