### PR TITLE
fix: text and character limits on Cohere embedding API

### DIFF
--- a/libs/aws/langchain_aws/embeddings/bedrock.py
+++ b/libs/aws/langchain_aws/embeddings/bedrock.py
@@ -276,6 +276,7 @@ def _batch_cohere_embedding_texts(texts: List[str]) -> Generator[List[str], None
     chunks of at most 96 items, or 2048 characters."""
 
     # Cohere embeddings want a maximum of 96 items and 2048 characters
+    # See: https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-embed.html
     max_items = 96
     max_chars = 2048
 


### PR DESCRIPTION
In a [previous PR](https://github.com/langchain-ai/langchain-aws/pull/350), I added support for retrieving more than one embedding at once from the Cohere embedding API.

@romenlee [pointed out](https://github.com/langchain-ai/langchain-aws/pull/350#issuecomment-2688770323) that this causes problems with a large number of texts. It looks like the [Cohere embedding API](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-embed.html) has a limit of either 96 texts, or 2048 characters.

This PR implements more intelligent batching that respects these limits -- it batches texts in chunks that are at most 96 texts or 2048 characters, submits them to the embedding API, and combines the results.

There is a complexity vs. efficiency tradeoff call to make here for the maintainers. This code is much more complex than the original naive code, pre #350 -- but it is much more efficient with network calls so will execute faster. An alternative if we don't want to take on this complexity would be to just revert #350, which would restore functionality for embedding large texts at the cost of giving up performance improvements.