### PR TITLE
aws[patch]: allow structured output when thinking is enabled for Claude 3.7

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -679,10 +679,13 @@ class ChatBedrockConverse(BaseChatModel):
             tool_choice = "any"
         else:
             tool_choice = None
-        if tool_choice:
-            llm = self.bind_tools([schema], tool_choice=tool_choice)
-        else:
+        if tool_choice is None and "claude-3-7-sonnet" in self.model_id:
+            # TODO: remove restriction to Claude 3.7. If a model does not support
+            # forced tool calling, we we should raise an exception instead of
+            # returning None when no tool calls are generated.
             llm = self._get_llm_for_structured_output_no_tool_choice(schema)
+        else:
+            llm = self.bind_tools([schema], tool_choice=tool_choice)
         if isinstance(schema, type) and is_basemodel_subclass(schema):
             if self.disable_streaming:
                 output_parser: OutputParserLike = ToolsOutputParser(

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -485,9 +485,9 @@ class ChatBedrockConverse(BaseChatModel):
         if self.supports_tool_choice_values is None:
             if "claude-3" in self.model_id:
                 # Tool choice not supported when thinking is enabled
-                thinking_params = (
-                    self.additional_model_request_fields or {}
-                ).get("thinking", {})
+                thinking_params = (self.additional_model_request_fields or {}).get(
+                    "thinking", {}
+                )
                 if (
                     "claude-3-7-sonnet" in self.model_id
                     and thinking_params.get("type") == "enabled"

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import re
+import warnings
 from operator import itemgetter
 from typing import (
     Any,
@@ -20,7 +21,6 @@ from typing import (
     Union,
     cast,
 )
-import warnings
 
 import boto3
 from langchain_core.callbacks import CallbackManagerForLLMRun

--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
@@ -142,17 +142,18 @@ class TestBedrockMetaStandard(ChatModelIntegrationTests):
         super().test_tool_message_histories_list_content(model)
 
 
+class ClassifyQuery(BaseModel):
+    """Classify a query."""
+
+    query_type: Literal["cat", "dog"] = Field(
+        description="Classify a query as related to cats or dogs."
+    )
+
+
 def test_structured_output_snake_case() -> None:
     model = ChatBedrockConverse(
         model="anthropic.claude-3-sonnet-20240229-v1:0", temperature=0
     )
-
-    class ClassifyQuery(BaseModel):
-        """Classify a query."""
-
-        query_type: Literal["cat", "dog"] = Field(
-            description="Classify a query as related to cats or dogs."
-        )
 
     chat = model.with_structured_output(ClassifyQuery)
     for chunk in chat.stream("How big are cats?"):
@@ -246,13 +247,6 @@ def test_guardrails() -> None:
 
 
 def test_structured_output_tool_choice_not_supported() -> None:
-    class ClassifyQuery(BaseModel):
-        """Classify a query."""
-
-        query_type: Literal["cat", "dog"] = Field(
-            description="Classify a query as related to cats or dogs."
-        )
-
     llm = ChatBedrockConverse(model="us.anthropic.claude-3-7-sonnet-20250219-v1:0")
     with pytest.warns(None) as record:  # type: ignore[call-overload]
         structured_llm = llm.with_structured_output(ClassifyQuery)
@@ -275,3 +269,52 @@ def test_structured_output_tool_choice_not_supported() -> None:
 
     with pytest.raises(OutputParserException):
         structured_llm.invoke("Hello!")
+
+
+def test_structured_output_thinking_force_tool_use() -> None:
+    # Structured output currently relies on forced tool use, which is not supported
+    # when `thinking` is enabled for Claude 3.7. When this test fails, it means that
+    # the feature is supported and the workarounds in `with_structured_output` should
+    # be removed.
+
+    # Instantiate as convenience for getting client
+    llm = ChatBedrockConverse(model="us.anthropic.claude-3-7-sonnet-20250219-v1:0")
+    messages = [
+        {
+            "role": "user",
+            "content": [{"text": "Generate a username for Sally with green hair"}],
+        }
+    ]
+    params = {
+        "modelId": "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+        "inferenceConfig": {"maxTokens": 5000},
+        "toolConfig": {
+            "tools": [
+                {
+                    "toolSpec": {
+                        "name": "ClassifyQuery",
+                        "description": "Classify a query.",
+                        "inputSchema": {
+                            "json": {
+                                "properties": {
+                                    "queryType": {
+                                        "description": "Classify a query as related to cats or dogs.",
+                                        "enum": ["cat", "dog"],
+                                        "type": "string",
+                                    }
+                                },
+                                "required": ["query_type"],
+                                "type": "object",
+                            }
+                        },
+                    }
+                }
+            ],
+            "toolChoice": {"tool": {"name": "ClassifyQuery"}},
+        },
+        "additionalModelRequestFields": {
+            "thinking": {"type": "enabled", "budget_tokens": 2000}
+        },
+    }
+    with pytest.raises(llm.client.exceptions.ValidationException):
+        response = llm.client.converse(messages=messages, **params)

--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
@@ -266,13 +266,6 @@ def test_structured_output_tool_choice_not_supported() -> None:
             "thinking": {"type": "enabled", "budget_tokens": 2000}
         },
     )
-    with pytest.warns(match="Claude"):
-        structured_llm = llm.with_structured_output(ClassifyQuery)
-    response = structured_llm.invoke("How big are cats?")
-    assert isinstance(response, ClassifyQuery)
-
-    # Unsupported model
-    llm = ChatBedrockConverse(model="us.amazon.nova-lite-v1:0")
     with pytest.warns(match="structured output"):
         structured_llm = llm.with_structured_output(ClassifyQuery)
     response = structured_llm.invoke("How big are cats?")

--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
@@ -298,7 +298,10 @@ def test_structured_output_thinking_force_tool_use() -> None:
                             "json": {
                                 "properties": {
                                     "queryType": {
-                                        "description": "Classify a query as related to cats or dogs.",
+                                        "description": (
+                                            "Classify a query as related to cats or "
+                                            "dogs."
+                                        ),
                                         "enum": ["cat", "dog"],
                                         "type": "string",
                                     }

--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
@@ -254,8 +254,10 @@ def test_structured_output_tool_choice_not_supported() -> None:
         )
 
     llm = ChatBedrockConverse(model="us.anthropic.claude-3-7-sonnet-20250219-v1:0")
-    structured_llm = llm.with_structured_output(ClassifyQuery)
-    response = structured_llm.invoke("How big are cats?")
+    with pytest.warns(None) as record:  # type: ignore[call-overload]
+        structured_llm = llm.with_structured_output(ClassifyQuery)
+        response = structured_llm.invoke("How big are cats?")
+    assert len(record) == 0
     assert isinstance(response, ClassifyQuery)
 
     # Unsupported params


### PR DESCRIPTION
Structured output will currently always raise a ValidationException when Claude 3.7 Sonnet's `thinking` is enabled, because we rely on forced tool use for structured output and this feature is not supported when `thinking` is enabled.

Here we:
- Emit a warning if `with_structured_output` is called when `thinking` is enabled.
- Raise `OutputParserException` if no tool calls are generated.

This is arguably preferable to raising an error in all cases.

```python
from langchain_aws import ChatBedrockConverse
from pydantic import BaseModel


class Person(BaseModel):
    name: str
    age: int


llm = ChatBedrockConverse(
    model="us.anthropic.claude-3-7-sonnet-20250219-v1:0",
    max_tokens=5000,
    additional_model_request_fields={
        "thinking": {"type": "enabled", "budget_tokens": 2000}
    },
)
structured_llm = llm.with_structured_output(Person)  # <-- this generates a warning
```

```python
structured_llm.invoke("Alice is 30.")  # <-- works
```

```python
structured_llm.invoke("Hello!")  # <-- raises OutputParserException
```