### PR TITLE
extras checks after boto3 bedrock-runtime client invoke

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -574,6 +574,8 @@ class ChatBedrockConverse(BaseChatModel):
             messages=bedrock_messages, system=system, **params
         )
         logger.debug(f"Response from Bedrock: {response}")
+        if 'output' not in response:
+            raise ValueError(f"AWS returns an invalid response, key 'output' is not in reponse.")
         response_message = _parse_response(response)
         return ChatResult(generations=[ChatGeneration(message=response_message)])
 

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -575,7 +575,15 @@ class ChatBedrockConverse(BaseChatModel):
         )
         logger.debug(f"Response from Bedrock: {response}")
         if 'output' not in response:
-            raise ValueError(f"AWS returns an invalid response, key 'output' is not in reponse.")
+            if self.endpoint_url:
+                raise ValueError(
+                    "The AWS response is invalid as it does not contain the expected 'output' key. "
+                    "Please verify that the correct bedrock-runtime endpoint is being used."
+                )
+            else:
+                raise ValueError(
+                    "The AWS response is invalid as it does not contain the expected 'output' key. "
+                )
         response_message = _parse_response(response)
         return ChatResult(generations=[ChatGeneration(message=response_message)])
 


### PR DESCRIPTION
In the ChatBedrockConverse class, additional checks have been added after invoking the bedrock-runtime boto3 client to ensure that errors are not delayed in cases where the response is successful but invalid. [langchain#29729](https://github.com/langchain-ai/langchain/issues/29729)