### PR TITLE
Update tag and artifacts generation in release workflow

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -279,9 +279,9 @@ jobs:
       - name: Create Release
         uses: ncipollo/release-action@v1
         with:
-          artifacts: "dist/*"
+          artifacts: "${{ inputs.working-directory }}/dist/*"
           token: ${{ secrets.GITHUB_TOKEN }}
           draft: false
           generateReleaseNotes: true
-          tag: v${{ needs.build.outputs.version }}
+          tag: ${{needs.build.outputs.pkg-name}}==${{ needs.build.outputs.version }}
           commit: ${{ github.sha }}

--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -283,5 +283,5 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           draft: false
           generateReleaseNotes: true
-          tag: ${{needs.build.outputs.pkg-name}}==${{ needs.build.outputs.version }}
+          tag: ${{ needs.build.outputs.pkg-name }}==${{ needs.build.outputs.version }}
           commit: ${{ github.sha }}


### PR DESCRIPTION
Updates the `mark_release` step in `_release.yml` to:
1. Add the package release binary and archive to the release assets.
2. Accommodate separate package releases for `langchain-aws` and `langgraph-checkpoint-aws`. Moving forward, release tags for both packages will follow the `{package-name}=={version}` convention.