### PR TITLE
aws[patch]: fix ordering of tool result content blocks

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -364,7 +364,7 @@ def _format_anthropic_messages(
                     )
 
             # For assistant messages, when thinking blocks exist, ensure they come first
-            if role == "asistant":
+            if role == "assistant":
                 content = text_blocks + tool_blocks
                 if thinking_blocks:
                     content = thinking_blocks + content

--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -364,15 +364,18 @@ def _format_anthropic_messages(
                     )
 
             # For assistant messages, when thinking blocks exist, ensure they come first
-            if role == "assistant" and thinking_blocks:
-                content = thinking_blocks + text_blocks + tool_blocks
+            if role == "asistant":
+                content = text_blocks + tool_blocks
+                if thinking_blocks:
+                    content = thinking_blocks + content
             elif role == "user" and tool_blocks and text_blocks:
                 content = tool_blocks + text_blocks  # tool result must precede text
+                if thinking_blocks:
+                    content = thinking_blocks + content
             else:
-                # For user messages or assistant messages without thinking,
-                # just combine all blocks in standard order
+                # combine all blocks in standard order
                 content = text_blocks + tool_blocks
-                # Only include thinking blocks if they exist (for assistant messages that might have them)
+                # Only include thinking blocks if they exist
                 if thinking_blocks:
                     content = thinking_blocks + content
 

--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -366,6 +366,8 @@ def _format_anthropic_messages(
             # For assistant messages, when thinking blocks exist, ensure they come first
             if role == "assistant" and thinking_blocks:
                 content = thinking_blocks + text_blocks + tool_blocks
+            elif role == "user" and tool_blocks and text_blocks:
+                content = tool_blocks + text_blocks  # tool result must precede text
             else:
                 # For user messages or assistant messages without thinking,
                 # just combine all blocks in standard order

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
@@ -134,8 +134,8 @@ def test__format_anthropic_messages_with_tool_calls() -> None:
             {
                 "role": "user",
                 "content": [
-                    {"type": "text", "text": "try again."},
                     {"type": "tool_result", "content": "blurb", "tool_use_id": "1"},
+                    {"type": "text", "text": "try again."},
                 ],
             },
         ],

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
@@ -114,7 +114,8 @@ def test__format_anthropic_messages_with_tool_calls() -> None:
         "blurb",
         tool_call_id="1",
     )
-    messages = [system, human, ai, tool]
+    human_2 = HumanMessage("try again.")
+    messages = [system, human, ai, tool, human_2]
     expected = (
         "fuzz",
         [
@@ -133,7 +134,8 @@ def test__format_anthropic_messages_with_tool_calls() -> None:
             {
                 "role": "user",
                 "content": [
-                    {"type": "tool_result", "content": "blurb", "tool_use_id": "1"}
+                    {"type": "text", "text": "try again."},
+                    {"type": "tool_result", "content": "blurb", "tool_use_id": "1"},
                 ],
             },
         ],


### PR DESCRIPTION
https://github.com/langchain-ai/langgraph/discussions/2161

Anthropic requires that tool result content blocks precede text in user messages. The functionality to merge messages does not account for this.
```python
from langchain_aws import ChatBedrock
from langchain_core.messages import (
    AIMessage,
    HumanMessage,
    SystemMessage,
    ToolMessage,
)
from langchain_core.tools import tool


@tool
def get_weather(location: str) -> str:
    """Get weather at a location."""
    return "It's sunny."

system = SystemMessage("You are a helpful assistant.")
human = HumanMessage("What is the weather in Boston?")
ai = AIMessage(
    "",
    tool_calls=[
        {"name": "get_weather", "id": "1", "args": {"location": "Boston, MA"}},
    ],
)
tool = ToolMessage(
    "It's sunny.",
    tool_call_id="1",
)
human_2 = HumanMessage("That doesn't look right.")
messages = [system, human, ai, tool, human_2]


llm = ChatBedrock(
    model="anthropic.claude-3-5-sonnet-20240620-v1:0",
).bind_tools([get_weather])

response = llm.invoke(messages)
```
^ Before this PR, this will raise:
> ValidationException: An error occurred (ValidationException) when calling the InvokeModel operation: messages.2: Did not find 1 `tool_result` block(s) at the beginning of this message. Messages following `tool_use` blocks must begin with a matching number of `tool_result` blocks.

cc @laithalsaadoon @andresriancho