### PR TITLE
Increase default worker thread count and make it configurable

### DIFF
--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -712,7 +712,7 @@ class BedrockBase(BaseLanguageModel, ABC):
     temperature: Optional[float] = None
     max_tokens: Optional[int] = None
 
-    max_parallel_requests: int = os.cpu_count() * 5 if os.cpu_count() else 10
+    max_parallel_requests: int = (os.cpu_count() or 10) * 5
     """
     The maximum number of network requests that can be resolved in parallel by
     an instance of this class. This sets the number of worker threads available

--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -4,6 +4,7 @@ import logging
 import os
 import warnings
 from abc import ABC
+from concurrent.futures import ThreadPoolExecutor
 from typing import (
     Any,
     AsyncGenerator,
@@ -30,7 +31,6 @@ from langchain_core.outputs import Generation, GenerationChunk, LLMResult
 from langchain_core.utils import secret_from_env
 from pydantic import ConfigDict, Field, SecretStr, model_validator
 from typing_extensions import Self
-from concurrent.futures import ThreadPoolExecutor
 
 from langchain_aws.function_calling import _tools_in_params
 from langchain_aws.utils import (

--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -732,6 +732,8 @@ class BedrockBase(BaseLanguageModel, ABC):
     applications should optimize this value through performance testing.
     """
 
+    __executor: Optional[ThreadPoolExecutor] = None
+
     @property
     def lc_secrets(self) -> Dict[str, str]:
         return {

--- a/libs/aws/tests/unit_tests/__snapshots__/test_standard.ambr
+++ b/libs/aws/tests/unit_tests/__snapshots__/test_standard.ambr
@@ -14,6 +14,7 @@
         'guardrailVersion': None,
         'trace': None,
       }),
+      'max_parallel_requests': 20,
       'max_tokens': 100,
       'model_id': 'anthropic.claude-3-sonnet-20240229-v1:0',
       'model_kwargs': dict({
@@ -56,6 +57,7 @@
         'guardrailVersion': None,
         'trace': None,
       }),
+      'max_parallel_requests': 20,
       'model_id': 'anthropic.claude-3-sonnet-20240229-v1:0',
       'provider_stop_reason_key_map': dict({
         'ai21': 'finishReason',


### PR DESCRIPTION
## Description

- Increases the default worker thread count from `os.cpu_count() + 4` to `os.cpu_count() * 5` in `BedrockBase`.
  - This worker thread count determines the number of Bedrock requests that can be awaited in parallel. Increasing this value makes all Bedrock model classes more capable in handling a large number of concurrent requests.
- Adds a new `max_parallel_requests` argument to allow users to tune the worker thread count to optimize request throughput.

## Motivation & context

I received a private report from a user trying to process multiple LLM requests in parallel via `ChatBedrock`. The user is using a M3 Macbook, and is using the `loop.create_task()` method on the event loop to send and handle requests concurrently.

However, the user noticed that after exceeding ~20 tasks, the time it took for all tasks to complete began increasing dramatically. **It took 300 seconds (!) for 200 Bedrock requests to complete in parallel.** 200 Bedrock requests should resolve on the order of 10 seconds if they are being processed in parallel.

I narrowed the cause of this issue down to the executor used to run `boto3` calls concurrently (i.e. asynchronously). Because `boto3` lacks async support, we call `loop.run_in_executor(None, ...)` to run each `boto3` call in a separate thread. This allows `boto3` calls to be processed concurrently, which is how we are able to provide an async API even though `boto3` lacks async support. The first argument accepts an instance of `ThreadPoolExecutor`, and if this is `None`, then the default executor for this process is used.

In most versions of Python on most platforms, [the default executor has a maximum worker thread count set to `os.cpu_count() + 4`](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor). The user's M3 Macbook had 16 logical CPUs, which explains why the user was encountering a bottleneck immediately after exceeding 20 tasks (16 + 4). This is far too low for I/O-bound tasks like handling network requests; a M3 Macbook can definitely handle more than 20 network requests concurrently.

The optimal thread count is determined by a number of factors, including the task itself, batch size, CPU clock speed, and network latency. A single default value cannot cover every hardware platform and usage scenario. However, we can choose a better default by leveraging the facts that a) our tasks are network requests that free the CPU, and b) modern hardware is much faster.

The new default I am proposing is `os.cpu_count() * 5`. This is a safe lower bound under the assumption that each thread will spend >80% of its lifecycle waiting for a network response, which should be true for virtually all modern hardware. [`os.cpu_count() * 5` was the previous default from Python 3.5-3.8](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor), and was only amended to improve default performance for CPU-bound tasks on computers with many cores.

Finally, this PR also adds the `max_parallel_requests` option to allow users to configure the thread count if the default does not work for them. Users can optimize the thread count by testing different values and choosing the one which processes their batch of requests the most quickly.

I hope I didn't bore you to death with an essay about multithreading. Just sharing what reviewers ought to know.

## Testing

The user tested the new default thread count locally, and reported that the time it took for 200 Bedrock requests to process concurrently **decreased from 300s to 30s (10x diff).**