### PR TITLE
Enable `max_parallel_requests` in ChatBedrock and ChatBedrockConverse

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -1083,6 +1083,7 @@ class ChatBedrock(BaseChatModel, BedrockBase):
                 "additional_model_response_field_paths",
                 "performance_config",
                 "request_metadata",
+                "max_parallel_requests",
             )
         }
         if self.max_tokens:
@@ -1091,6 +1092,8 @@ class ChatBedrock(BaseChatModel, BedrockBase):
             kwargs["temperature"] = self.temperature
         if self.stop_sequences:
             kwargs["stop_sequences"] = self.stop_sequences
+        if self.max_parallel_requests:
+            kwargs["max_parallel_requests"] = self.max_parallel_requests
 
         return ChatBedrockConverse(
             client=self.client,

--- a/libs/aws/tests/unit_tests/chat_models/__snapshots__/test_bedrock_converse.ambr
+++ b/libs/aws/tests/unit_tests/chat_models/__snapshots__/test_bedrock_converse.ambr
@@ -7,6 +7,7 @@
       'ChatBedrockConverse',
     ]),
     'kwargs': dict({
+      'max_parallel_requests': 20,
       'max_tokens': 100,
       'model_id': 'anthropic.claude-3-sonnet-20240229-v1:0',
       'provider': 'anthropic',

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -41,6 +41,7 @@ class TestBedrockStandard(ChatModelUnitTests):
             "client": None,
             "model": "anthropic.claude-3-sonnet-20240229-v1:0",
             "region_name": "us-west-1",
+            "max_parallel_requests": 20,
         }
 
     @property

--- a/libs/aws/tests/unit_tests/test_standard.py
+++ b/libs/aws/tests/unit_tests/test_standard.py
@@ -19,6 +19,7 @@ class TestBedrockStandard(ChatModelUnitTests):
         return {
             "model_id": "anthropic.claude-3-sonnet-20240229-v1:0",
             "region_name": "us-east-1",
+            "max_parallel_requests": 20,
         }
 
     @property
@@ -41,6 +42,7 @@ class TestBedrockAsConverseStandard(ChatModelUnitTests):
             "model_id": "anthropic.claude-3-sonnet-20240229-v1:0",
             "region_name": "us-east-1",
             "beta_use_converse_api": True,
+            "max_parallel_requests": 20,
         }
 
     @property


### PR DESCRIPTION
For context, see [this comment](https://github.com/langchain-ai/langchain-aws/pull/391#pullrequestreview-2666312601) in PR #391.

This PR adds explicit `_astream` and `_agenerate` implementations to `ChatBedrock` and `ChatBedrockConverse`, overriding the default methods provided by `BaseChatModel`.

These overrides provide extra handling to account for the value of `max_parallel_requests` as configured by the user or our [default lower bound](https://github.com/langchain-ai/langchain-aws/blob/main/libs/aws/langchain_aws/llms/bedrock.py#L715), and set maximum worker threads accordingly for `ainvoke()` and `astream()` calls.

**Example usage:**
```python
# Invoke model
llm = ChatBedrock(
    model_id="us.anthropic.claude-3-7-sonnet-20250219-v1:0",
    max_parallel_requests=300
)

# Invoke model w/Converse API passthrough
llm = ChatBedrock(
    model_id="us.anthropic.claude-3-7-sonnet-20250219-v1:0",
    max_parallel_requests=300,
    beta_use_converse_api=True
)

# Converse model
llm = ChatBedrockConverse(
    model_id="us.anthropic.claude-3-7-sonnet-20250219-v1:0",
    max_parallel_requests=300
)

prompt = "What is the meaning of life?"

# Async invoke
ai_msg = (await llm.ainvoke(prompt))
print(ai_msg.content)

# Async stream
async def llm_astream(messages):
    generator = llm.astream(messages)
    
    chunks = []
    async for chunk in generator:
        chunks.append(chunk)
        print(chunk)
    
    return chunks

result = await invoke_astream(prompt)
print(result)
```