### PR TITLE
Fix issue with tool_response block ordering after message merge

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -272,14 +272,37 @@ def _merge_messages(
                 )
         last = merged[-1] if merged else None
         if isinstance(last, HumanMessage) and isinstance(curr, HumanMessage):
+            # Extract content from both messages
             if isinstance(last.content, str):
-                new_content: List = [{"type": "text", "text": last.content}]
+                last_content = [{"type": "text", "text": last.content}]
             else:
-                new_content = last.content
+                last_content = last.content
+
             if isinstance(curr.content, str):
-                new_content.append({"type": "text", "text": curr.content})
+                curr_content = [{"type": "text", "text": curr.content}]
             else:
-                new_content.extend(curr.content)
+                curr_content = curr.content
+            
+            # Separate tool_result blocks from other content
+            tool_result_blocks = []
+            other_blocks = []
+            
+            # Process blocks from last message
+            for block in last_content:
+                if isinstance(block, dict) and block.get("type") == "tool_result":
+                    tool_result_blocks.append(block)
+                else:
+                    other_blocks.append(block)
+            
+            # Process blocks from current message
+            for block in curr_content:
+                if isinstance(block, dict) and block.get("type") == "tool_result":
+                    tool_result_blocks.append(block)
+                else:
+                    other_blocks.append(block)
+            
+            # Create new content with tool_result blocks at the beginning
+            new_content = tool_result_blocks + other_blocks
             last.content = new_content
         else:
             merged.append(curr)


### PR DESCRIPTION
as discussed in the following thread, the newly added _merge_messages function does not respect the proper ordering for tool_result blocks following tool_use and results in the following exception:
"Did not find 1 tool_result block(s) at the beginning of this message"

This change fixes the ordering to be in the form that claude expects.
link to discussion: https://github.com/langchain-ai/langgraph/discussions/2161