### PR TITLE
Support DeepSeek-R1 streaming with ChatBedrock

### DIFF
--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -178,7 +178,7 @@ def _stream_response_to_generation_chunk(
     return GenerationChunk(
         text=(
             stream_response[output_key]
-            if provider != "mistral"
+            if provider not in ["mistral", "deepseek"]
             else stream_response[output_key][0]["text"]
         ),
         generation_info=generation_info,
@@ -265,6 +265,7 @@ class LLMInputOutputAdapter:
         "anthropic": "completion",
         "amazon": "outputText",
         "cohere": "text",
+        "deepseek": "choices",
         "meta": "generation",
         "mistral": "outputs",
     }
@@ -498,7 +499,11 @@ class LLMInputOutputAdapter:
             if generation_chunk:
                 yield generation_chunk
 
-            if (
+            if provider == "deepseek" and chunk_obj.get(output_key)[0].get("stop_reason", "") == "stop":
+                yield _get_invocation_metrics_chunk(chunk_obj)
+                return
+
+            elif (
                 provider == "mistral"
                 and chunk_obj.get(output_key, [{}])[0].get("stop_reason", "") == "stop"
             ):


### PR DESCRIPTION
Related: #395

This PR updates `LLMInputOutputAdapter` to correctly handle streaming responses from DeepSeek-R1 when using `ChatBedrock`.