### PR TITLE
Revert BedrockBase worker thread configuration

### DIFF
--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -4,7 +4,6 @@ import logging
 import os
 import warnings
 from abc import ABC
-from concurrent.futures import ThreadPoolExecutor
 from typing import (
     Any,
     AsyncGenerator,
@@ -712,28 +711,6 @@ class BedrockBase(BaseLanguageModel, ABC):
     temperature: Optional[float] = None
     max_tokens: Optional[int] = None
 
-    max_parallel_requests: int = (os.cpu_count() or 10) * 5
-    """
-    The maximum number of network requests that can be resolved in parallel by
-    an instance of this class. This sets the number of worker threads available
-    in the `ThreadPoolExecutor` used to run boto3 calls asynchronously.
-
-    The default chosen is the number of logical CPUs multiplied by 5. This is a
-    safe choice when the network request consumes >80% of the task time, which
-    will be true in most modern usage scenarios.
-
-    We recommend that users leave this value unchanged unless they know what
-    they are doing. If the value is set too low, then issuing requests
-    concurrently via `loop.create_task()` will be needlessly slow. If the value
-    is too high, then the CPU may stall other processes on the device.
-
-    The ideal number is determined by several factors, including CPU clock speed
-    and network latency. Users who need to maximize request throughput in their
-    applications should optimize this value through performance testing.
-    """
-
-    __executor: Optional[ThreadPoolExecutor] = None
-
     @property
     def lc_secrets(self) -> Dict[str, str]:
         return {
@@ -1131,13 +1108,6 @@ class BedrockBase(BaseLanguageModel, ABC):
             if not isinstance(chunk, AIMessageChunk):
                 self._get_bedrock_services_signal(chunk.generation_info)  # type: ignore[arg-type]
 
-    @property
-    def _executor(self) -> ThreadPoolExecutor:
-        """Returns the thread pool executor used."""
-        if not self.__executor:
-            self.__executor = ThreadPoolExecutor(max_workers=self.max_parallel_requests)
-        return self.__executor
-
     async def _aprepare_input_and_invoke_stream(
         self,
         prompt: str,
@@ -1186,7 +1156,7 @@ class BedrockBase(BaseLanguageModel, ABC):
         body = json.dumps(input_body)
 
         response = await asyncio.get_running_loop().run_in_executor(
-            self._executor,
+            None,
             lambda: self.client.invoke_model_with_response_stream(
                 body=body,
                 modelId=self.model_id,

--- a/libs/aws/tests/unit_tests/__snapshots__/test_standard.ambr
+++ b/libs/aws/tests/unit_tests/__snapshots__/test_standard.ambr
@@ -14,7 +14,6 @@
         'guardrailVersion': None,
         'trace': None,
       }),
-      'max_parallel_requests': 20,
       'max_tokens': 100,
       'model_id': 'anthropic.claude-3-sonnet-20240229-v1:0',
       'model_kwargs': dict({
@@ -57,7 +56,6 @@
         'guardrailVersion': None,
         'trace': None,
       }),
-      'max_parallel_requests': 20,
       'model_id': 'anthropic.claude-3-sonnet-20240229-v1:0',
       'provider_stop_reason_key_map': dict({
         'ai21': 'finishReason',


### PR DESCRIPTION
Reverts the unreleased `max_parallel_requests` attribute added in #391, as it is redundant with the [`max_concurrency`](https://python.langchain.com/api_reference/core/runnables/langchain_core.runnables.config.RunnableConfig.html#langchain_core.runnables.config.RunnableConfig.max_concurrency) option already available in RunnableConfig for batching calls.

In general, the Runnable async invoke and stream methods are not intended to be able to make multiple requests in parallel, and do not use `max_concurrency`. We should not attempt to skirt this restriction via a custom parameter, and instead recommend users to utilize the purpose-built [`abatch`](https://python.langchain.com/api_reference/core/runnables/langchain_core.runnables.base.Runnable.html#langchain_core.runnables.base.Runnable.abatch) method.