### PR TITLE
Fix ChatBedrock streaming with DeepSeek-R1 distilled models

### DIFF
--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock.py
@@ -137,7 +137,7 @@ def test_chat_bedrock_streaming_deepseek_r1() -> None:
     assert response.usage_metadata
 
 
-@pytest.mark.xfail(reason="Provisioned instance unavailable.")
+@pytest.mark.skip("Needs provisioned instance setup.")
 def test_chat_bedrock_streaming_deepseek_r1_distill_llama() -> None:
     chat = ChatBedrock(  # type: ignore[call-arg]
         provider="deepseek",
@@ -155,7 +155,7 @@ def test_chat_bedrock_streaming_deepseek_r1_distill_llama() -> None:
     assert response.usage_metadata
 
 
-@pytest.mark.xfail(reason="Provisioned instance unavailable.")
+@pytest.mark.skip("Needs provisioned instance setup.")
 def test_chat_bedrock_streaming_deepseek_r1_distill_qwen() -> None:
     chat = ChatBedrock(  # type: ignore[call-arg]
         provider="deepseek",

--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock.py
@@ -121,6 +121,59 @@ def test_chat_bedrock_streaming_llama3() -> None:
 
 
 @pytest.mark.scheduled
+def test_chat_bedrock_streaming_deepseek_r1() -> None:
+    chat = ChatBedrock(  # type: ignore[call-arg]
+        model="us.deepseek.r1-v1:0",
+        region_name="us-west-2"
+    )
+    message = HumanMessage(content="Hello")
+
+    response = AIMessageChunk(content="")
+    for chunk in chat.stream([message]):
+        response += chunk  # type: ignore[assignment]
+
+    assert response.content
+    assert response.response_metadata
+    assert response.usage_metadata
+
+
+@pytest.mark.xfail(reason="Provisioned instance unavailable.")
+def test_chat_bedrock_streaming_deepseek_r1_distill_llama() -> None:
+    chat = ChatBedrock(  # type: ignore[call-arg]
+        provider="deepseek",
+        model_id="arn:aws:sagemaker:us-east-2:xxxxxxxxxxxx:endpoint/endpoint-quick-start-xxxxx",
+        region_name="us-east-2"
+    )
+    message = HumanMessage(content="Hello. Please limit your response to 10 words or less.")
+
+    response = AIMessageChunk(content="")
+    for chunk in chat.stream([message]):
+        response += chunk # type: ignore[assignment]
+
+    assert response.content
+    assert response.response_metadata
+    assert response.usage_metadata
+
+
+@pytest.mark.xfail(reason="Provisioned instance unavailable.")
+def test_chat_bedrock_streaming_deepseek_r1_distill_qwen() -> None:
+    chat = ChatBedrock(  # type: ignore[call-arg]
+        provider="deepseek",
+        model_id="arn:aws:sagemaker:us-east-2:xxxxxxxxxxxx:endpoint/endpoint-quick-start-xxxxx",
+        region_name="us-east-2"
+    )
+    message = HumanMessage(content="Hello")
+
+    response = AIMessageChunk(content="")
+    for chunk in chat.stream([message]):
+        response += chunk  # type: ignore[assignment]
+
+    assert response.content
+    assert response.response_metadata
+    assert response.usage_metadata
+
+
+@pytest.mark.scheduled
 def test_chat_bedrock_streaming_generation_info() -> None:
     """Test that generation info is preserved when streaming."""
 


### PR DESCRIPTION
This PR updates ChatBedrock's DeepSeek-R1 stream response handling, compensating for differences between the base model and distilled model formats.

For example, a base model stream chunk looks like:
```
{
  "choices": [
    {
      "text": "hello",
      "stop_reason": null
    }
  ]
}
```

The Llama and Qwen distills both follow the format:
```
{
  "choices": [
    {
      "index": 0,
      "text": "hello",
      "logprobs": null,
      "finish_reason": ""
    }
  ],
  "model": "/opt/ml/model",
  "system_fingerprint": "3.0.1-native",
  "object": "text_completion",
  "id": "",
  "created": 1742011074
}
```



