### PR TITLE
Add DeepSeek-R1 'no_tools' streaming support for ChatBedrockConverse

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -492,7 +492,9 @@ class ChatBedrockConverse(BaseChatModel):
             # All Meta Llama models
             (provider == "meta") or
             # All Mistral models
-            (provider == "mistral")
+            (provider == "mistral") or
+            # DeepSeek-R1 models
+            (provider == "deepseek" and "r1" in model_id_lower)
         ):
             streaming_support = "no_tools"
         else:

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -481,6 +481,7 @@ def test_standard_tracing_params() -> None:
         ("us.meta.llama3-3-70b-instruct-v1:0", "tool_calling"),
         ("us.amazon.nova-lite-v1:0", False),
         ("us.amazon.nonstreaming-model-v1:0", True),
+        ("us.deepseek.r1-v1:0", "tool_calling"),
     ],
 )
 def test_set_disable_streaming(


### PR DESCRIPTION
Fixes https://github.com/langchain-ai/langchain-aws/issues/395

DeepSeeks supports ConverseStream but not Streaming Tool Use: https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-supported-models-features.html

Similar to https://github.com/langchain-ai/langchain-aws/pull/400 but for the ChatBedrockConverse. Added a test to ensure no_tools streaming is working. 

Tests pass, and manually testing appears to work as well.

