### PR TITLE
Prevent sending thinking blocks with no signature with ChatBedrockConverse

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -460,9 +460,12 @@ class ChatBedrockConverse(BaseChatModel):
     def set_disable_streaming(cls, values: Dict) -> Any:
         model_id = values.get("model_id", values.get("model"))
         model_parts = model_id.split(".")
-        
-        # Extract provider from the model_id (e.g., "amazon", "anthropic", "ai21", "meta", "mistral")
-        provider = values.get("provider") or (model_parts[-2] if len(model_parts) > 1 else model_parts[0])
+
+        # Extract provider from the model_id
+        # (e.g., "amazon", "anthropic", "ai21", "meta", "mistral")
+        provider = values.get("provider") or (
+            model_parts[-2] if len(model_parts) > 1 else model_parts[0]
+        )
         values["provider"] = provider
 
         model_id_lower = model_id.lower()
@@ -471,26 +474,46 @@ class ChatBedrockConverse(BaseChatModel):
         # Here we check based on the updated AWS documentation.
         if (
             # AI21 Jamba 1.5 models
-            (provider == "ai21" and "jamba-1-5" in model_id_lower) or
+            (provider == "ai21" and "jamba-1-5" in model_id_lower)
+            or
             # Some Amazon Nova models
-            (provider == "amazon" and any(x in model_id_lower for x in ["nova-lite", "nova-micro", "nova-pro"])) or
+            (
+                provider == "amazon"
+                and any(
+                    x in model_id_lower for x in ["nova-lite", "nova-micro", "nova-pro"]
+                )
+            )
+            or
             # Anthropic Claude 3 and newer models
-            (provider == "anthropic" and "claude-3" in model_id_lower) or
+            (provider == "anthropic" and "claude-3" in model_id_lower)
+            or
             # Cohere Command R models
             (provider == "cohere" and "command-r" in model_id_lower)
         ):
             streaming_support = True
         elif (
             # AI21 Jamba-Instruct model
-            (provider == "ai21" and "jamba-instruct" in model_id_lower) or
+            (provider == "ai21" and "jamba-instruct" in model_id_lower)
+            or
             # Amazon Titan Text models
-            (provider == "amazon" and "titan-text" in model_id_lower) or
+            (provider == "amazon" and "titan-text" in model_id_lower)
+            or
             # Anthropic older Claude models (Claude 2, Claude 2.1, Claude Instant)
-            (provider == "anthropic" and any(x in model_id_lower for x in ["claude-v2", "claude-instant"])) or
+            (
+                provider == "anthropic"
+                and any(x in model_id_lower for x in ["claude-v2", "claude-instant"])
+            )
+            or
             # Cohere Command (non-R) models
-            (provider == "cohere" and "command" in model_id_lower and "command-r" not in model_id_lower) or
+            (
+                provider == "cohere"
+                and "command" in model_id_lower
+                and "command-r" not in model_id_lower
+            )
+            or
             # All Meta Llama models
-            (provider == "meta") or
+            (provider == "meta")
+            or
             # All Mistral models
             (provider == "mistral")
         ):
@@ -499,8 +522,10 @@ class ChatBedrockConverse(BaseChatModel):
             streaming_support = False
 
         # Set the disable_streaming flag accordingly:
-        # - If streaming is supported (plain streaming), we want streaming enabled (i.e. disable_streaming == False).
-        # - If the model supports streaming only in non-tool mode ("no_tools"), then we must force disable streaming when tools are used.
+        # - If streaming is supported (plain streaming),
+        #       we want streaming enabled (i.e. disable_streaming == False).
+        # - If the model supports streaming only in non-tool mode ("no_tools"),
+        #       then we must force disable streaming when tools are used.
         # - Otherwise, if streaming is not supported, we set disable_streaming to True.
         if "disable_streaming" not in values:
             if not streaming_support:
@@ -511,7 +536,6 @@ class ChatBedrockConverse(BaseChatModel):
                 values["disable_streaming"] = False
 
         return values
-
 
     @model_validator(mode="after")
     def validate_environment(self) -> Self:
@@ -809,10 +833,13 @@ class ChatBedrockConverse(BaseChatModel):
                 "modelId": modelId or self.model_id,
                 "inferenceConfig": inferenceConfig,
                 "toolConfig": toolConfig,
-                "additionalModelRequestFields": additionalModelRequestFields
-                or self.additional_model_request_fields,
-                "additionalModelResponseFieldPaths": additionalModelResponseFieldPaths
-                or self.additional_model_response_field_paths,
+                "additionalModelRequestFields": (
+                    additionalModelRequestFields or self.additional_model_request_fields
+                ),
+                "additionalModelResponseFieldPaths": (
+                    additionalModelResponseFieldPaths
+                    or self.additional_model_response_field_paths
+                ),
                 "guardrailConfig": guardrailConfig or self.guardrail_config,
                 "performanceConfig": performanceConfig or self.performance_config,
                 "requestMetadata": requestMetadata or self.request_metadata,
@@ -1203,7 +1230,7 @@ def _bedrock_to_lc(content: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
                             "type": "reasoning_content",
                             "reasoning_content": {
                                 "type": "text",
-                                "text": reasoning_dict.get("text")
+                                "text": reasoning_dict.get("text"),
                             },
                         }
                     )
@@ -1213,7 +1240,7 @@ def _bedrock_to_lc(content: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
                             "type": "reasoning_content",
                             "reasoning_content": {
                                 "type": "signature",
-                                "signature": reasoning_dict.get("signature")
+                                "signature": reasoning_dict.get("signature"),
                             },
                         }
                     )

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -1080,28 +1080,30 @@ def _lc_content_to_bedrock(
         elif block["type"] == "guard_content":
             bedrock_content.append({"guardContent": {"text": {"text": block["text"]}}})
         elif block["type"] == "thinking":
-            bedrock_content.append(
-                {
-                    "reasoningContent": {
-                        "reasoningText": {
-                            "text": block.get("thinking", ""),
-                            "signature": block.get("signature", "")
+            if block.get("signature", ""):
+                bedrock_content.append(
+                    {
+                        "reasoningContent": {
+                            "reasoningText": {
+                                "text": block.get("thinking", ""),
+                                "signature": block.get("signature", ""),
+                            }
                         }
                     }
-                }
-            )
+                )
         elif block["type"] == "reasoning_content":
             reasoning_content = block.get("reasoningContent", {})
-            bedrock_content.append(
-                {
-                    "reasoningContent": {
-                        "reasoningText": {
-                            "text": reasoning_content.get("text", ""),
-                            "signature": reasoning_content.get("signature", "")
+            if reasoning_content.get("signature", ""):
+                bedrock_content.append(
+                    {
+                        "reasoningContent": {
+                            "reasoningText": {
+                                "text": reasoning_content.get("text", ""),
+                                "signature": reasoning_content.get("signature", ""),
+                            }
                         }
                     }
-                }
-            )
+                )
         else:
             raise ValueError(f"Unsupported content block type:\n{block}")
     # drop empty text blocks

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -27,6 +27,7 @@ from langchain_aws.chat_models.bedrock_converse import (
     _messages_to_bedrock,
     _snake_to_camel,
     _snake_to_camel_keys,
+    _lc_content_to_bedrock
 )
 
 
@@ -707,6 +708,371 @@ def test__lc_content_to_bedrock_anthropic_reasoning() -> None:
                 },
                 {
                     "text": "I've double-checked and confirm that 27 * 14 = 378."
+                }
+            ]
+        },
+    ]
+
+    expected_system = [{"text": "You are a helpful assistant."}]
+
+    actual_messages, actual_system = _messages_to_bedrock(messages)
+
+    assert expected_messages == actual_messages
+    assert expected_system == actual_system
+
+def test__lc_content_to_bedrock_empty_signature() -> None:
+    """Test that thinking and reasoning blocks without signatures are omitted."""
+    messages = [
+        SystemMessage(content="You are a helpful assistant."),
+        # Human message with a question
+        HumanMessage(content="Tell me about machine learning."),
+        # AI message with thinking block that has NO signature (should be omitted)
+        AIMessage(content=[
+            {
+                "type": "thinking",
+                "thinking": "I'll explain machine learning concepts...",
+                "signature": ""  # Empty signature
+            },
+            {
+                "type": "text",
+                "text": "Machine learning is a field of AI that enables systems to learn from data."
+            }
+        ]),
+        # Human follow-up
+        HumanMessage(content="What about deep learning?"),
+        # AI message with reasoning_content block that has NO signature (should be omitted)
+        AIMessage(content=[
+            {
+                "type": "reasoning_content",
+                "reasoningContent": {
+                    "text": "Deep learning is a subset of machine learning using neural networks.",
+                    "signature": ""  # Empty signature
+                }
+            },
+            {
+                "type": "text",
+                "text": "Deep learning is a subfield of machine learning that uses neural networks with many layers."
+            }
+        ]),
+    ]
+
+    expected_messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "text": "Tell me about machine learning."
+                }
+            ]
+        },
+        {
+            "role": "assistant",
+            "content": [
+                # No reasoning block because signature is empty
+                {
+                    "text": "Machine learning is a field of AI that enables systems to learn from data."
+                }
+            ]
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "text": "What about deep learning?"
+                }
+            ]
+        },
+        {
+            "role": "assistant",
+            "content": [
+                # No reasoning block because signature is empty
+                {
+                    "text": "Deep learning is a subfield of machine learning that uses neural networks with many layers."
+                }
+            ]
+        },
+    ]
+
+    expected_system = [{"text": "You are a helpful assistant."}]
+
+    actual_messages, actual_system = _messages_to_bedrock(messages)
+
+    assert expected_messages == actual_messages
+    assert expected_system == actual_system
+
+def test__lc_content_to_bedrock_mixed_signatures() -> None:
+    """Test a mix of thinking/reasoning blocks with and without signatures."""
+    messages = [
+        SystemMessage(content="You are a helpful assistant."),
+        # Human message
+        HumanMessage(content="Explain AI and machine learning."),
+        # AI message with mixed thinking/reasoning blocks (with/without signatures)
+        AIMessage(content=[
+            {
+                "type": "thinking",
+                "thinking": "I should start with AI definitions...",
+                "signature": ""  # Empty signature - should be omitted
+            },
+            {
+                "type": "text",
+                "text": "AI is a broad field of computer science."
+            },
+            {
+                "type": "thinking",
+                "thinking": "Now I'll explain machine learning...",
+                "signature": "signature-xyz"  # Has signature - should be included
+            },
+            {
+                "type": "text",
+                "text": "Machine learning is a subset of AI."
+            }
+        ]),
+        # Human follow-up
+        HumanMessage(content="What about neural networks?"),
+        # AI response with mixed reasoning_content blocks
+        AIMessage(content=[
+            {
+                "type": "reasoning_content",
+                "reasoningContent": {
+                    "text": "Neural networks are inspired by biological neurons.",
+                    "signature": "nn-signature"  # Has signature - should be included
+                }
+            },
+            {
+                "type": "reasoning_content",
+                "reasoningContent": {
+                    "text": "They consist of interconnected layers of nodes.",
+                    "signature": ""  # Empty signature - should be omitted
+                }
+            },
+            {
+                "type": "text",
+                "text": "Neural networks are computing systems inspired by biological neural networks."
+            }
+        ]),
+    ]
+
+    expected_messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "text": "Explain AI and machine learning."
+                }
+            ]
+        },
+        {
+            "role": "assistant",
+            "content": [
+                # First thinking block omitted (empty signature)
+                {
+                    "text": "AI is a broad field of computer science."
+                },
+                {
+                    "reasoningContent": {
+                        "reasoningText": {
+                            "text": "Now I'll explain machine learning...",
+                            "signature": "signature-xyz"
+                        }
+                    }
+                },
+                {
+                    "text": "Machine learning is a subset of AI."
+                }
+            ]
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "text": "What about neural networks?"
+                }
+            ]
+        },
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "reasoningContent": {
+                        "reasoningText": {
+                            "text": "Neural networks are inspired by biological neurons.",
+                            "signature": "nn-signature"
+                        }
+                    }
+                },
+                # Second reasoning block omitted (empty signature)
+                {
+                    "text": "Neural networks are computing systems inspired by biological neural networks."
+                }
+            ]
+        },
+    ]
+
+    expected_system = [{"text": "You are a helpful assistant."}]
+
+    actual_messages, actual_system = _messages_to_bedrock(messages)
+
+    assert expected_messages == actual_messages
+    assert expected_system == actual_system
+    """Test that reasoning_content blocks without signatures are omitted."""
+    # Test with empty signature
+    content = [
+        {"type": "text", "text": "Some text"},
+        {"type": "reasoning_content", "reasoningContent": {"text": "This is reasoning", "signature": ""}}
+    ]
+    
+    bedrock_content = _lc_content_to_bedrock(content)
+    
+    # Verify that the reasoning_content block was omitted because it has an empty signature
+    assert len(bedrock_content) == 1
+    assert bedrock_content[0] == {"text": "Some text"}
+    
+    # Test with signature present
+    content = [
+        {"type": "text", "text": "Some text"},
+        {"type": "reasoning_content", "reasoningContent": {"text": "This is reasoning", "signature": "some-signature"}}
+    ]
+    
+    bedrock_content = _lc_content_to_bedrock(content)
+    
+    # Verify that the reasoning_content block is included when it has a signature
+    assert len(bedrock_content) == 2
+    assert bedrock_content[0] == {"text": "Some text"}
+    assert bedrock_content[1] == {
+        "reasoningContent": {
+            "reasoningText": {
+                "text": "This is reasoning",
+                "signature": "some-signature",
+            }
+        }
+    }
+
+
+def test__lc_content_to_bedrock_reasoning_content_signature() -> None:
+    """Test that reasoning_content blocks with and without signatures are handled correctly."""
+    messages = [
+        SystemMessage(content="You are a helpful assistant."),
+        # Human message with a question
+        HumanMessage(content="Explain quantum computing."),
+        # AI message with reasoning_content blocks with and without signatures
+        AIMessage(content=[
+            {
+                "type": "reasoning_content",
+                "reasoningContent": {
+                    "text": "Quantum computing uses quantum bits or qubits...",
+                    "signature": "qc-signature"  # Has signature - should be included
+                }
+            },
+            {
+                "type": "text",
+                "text": "Quantum computing is a type of computation that harnesses quantum mechanics."
+            },
+        ]),
+        # Human follow-up
+        HumanMessage(content="How does it differ from classical computing?"),
+        # AI response with reasoning_content block without signature
+        AIMessage(content=[
+            {
+                "type": "reasoning_content",
+                "reasoningContent": {
+                    "text": "Unlike classical bits that are either 0 or 1, qubits can be in superposition.",
+                    "signature": ""  # Empty signature - should be omitted
+                }
+            },
+            {
+                "type": "text",
+                "text": "Classical computers use bits as the smallest unit of data, while quantum computers use qubits which can exist in multiple states simultaneously."
+            }
+        ]),
+        # Another follow-up
+        HumanMessage(content="What are the practical applications?"),
+        # AI response with multiple reasoning_content blocks with mixed signatures
+        AIMessage(content=[
+            {
+                "type": "reasoning_content",
+                "reasoningContent": {
+                    "text": "Quantum computing excels at certain types of problems...",
+                    "signature": "apps-signature"  # Has signature - should be included
+                }
+            },
+            {
+                "type": "reasoning_content",
+                "reasoningContent": {
+                    "text": "Examples include cryptography, optimization, and simulation.",
+                    "signature": ""  # Empty signature - should be omitted
+                }
+            },
+            {
+                "type": "text",
+                "text": "Practical applications include cryptography, drug discovery, materials science, and complex optimization problems."
+            }
+        ]),
+    ]
+
+    expected_messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "text": "Explain quantum computing."
+                }
+            ]
+        },
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "reasoningContent": {
+                        "reasoningText": {
+                            "text": "Quantum computing uses quantum bits or qubits...",
+                            "signature": "qc-signature"
+                        }
+                    }
+                },
+                {
+                    "text": "Quantum computing is a type of computation that harnesses quantum mechanics."
+                }
+            ]
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "text": "How does it differ from classical computing?"
+                }
+            ]
+        },
+        {
+            "role": "assistant",
+            "content": [
+                # No reasoning block because signature is empty
+                {
+                    "text": "Classical computers use bits as the smallest unit of data, while quantum computers use qubits which can exist in multiple states simultaneously."
+                }
+            ]
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "text": "What are the practical applications?"
+                }
+            ]
+        },
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "reasoningContent": {
+                        "reasoningText": {
+                            "text": "Quantum computing excels at certain types of problems...",
+                            "signature": "apps-signature"
+                        }
+                    }
+                },
+                # Second reasoning block omitted (empty signature)
+                {
+                    "text": "Practical applications include cryptography, drug discovery, materials science, and complex optimization problems."
                 }
             ]
         },

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -875,7 +875,7 @@ def test__lc_content_to_bedrock_mixed_signatures() -> None:
     assert expected_system == actual_system
     """Test that reasoning_content blocks without signatures are omitted."""
     # Test with empty signature
-    content: List[str | Dict[str, Any]] = [
+    content: List[Union[str, Dict[str, Any]]] = [
         {"type": "text", "text": "Some text"},
         {
             "type": "reasoning_content",

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -24,10 +24,10 @@ from langchain_aws.chat_models.bedrock_converse import (
     _camel_to_snake,
     _camel_to_snake_keys,
     _extract_response_metadata,
+    _lc_content_to_bedrock,
     _messages_to_bedrock,
     _snake_to_camel,
     _snake_to_camel_keys,
-    _lc_content_to_bedrock
 )
 
 
@@ -530,89 +530,53 @@ def test_chat_bedrock_converse_environment_variable() -> None:
 def test__bedrock_to_lc_anthropic_reasoning() -> None:
     bedrock_content: List[Dict[str, Any]] = [
         # Expected LC format for non-reasoning block
-        {
-            "text": "Thought text"
-        },
+        {"text": "Thought text"},
         # Invoke format with reasoning_text
         {
             "reasoning_content": {
-                "reasoning_text": {
-                    "text": "Thought text",
-                    "signature": "sig"
-                }
+                "reasoning_text": {"text": "Thought text", "signature": "sig"}
             }
         },
         # Streaming format with text only
-        {
-            "reasoning_content": {
-                "text": "Thought text"
-            }
-        },
+        {"reasoning_content": {"text": "Thought text"}},
         # Streaming format with signature only
-        {
-            "reasoning_content": {
-                "signature": "sig"
-            }
-        },
+        {"reasoning_content": {"signature": "sig"}},
         # Expected LC format for reasoning with no text
-        {
-            "reasoning_content": {
-                "reasoning_text": {
-                    "text": "",
-                    "signature": "sig"
-                }
-            }
-        },
+        {"reasoning_content": {"reasoning_text": {"text": "", "signature": "sig"}}},
         # Expected LC format for reasoning with no signature
         {
             "reasoning_content": {
-                "reasoning_text": {
-                    "text": "Another reasoning block",
-                    "signature": ""
-                }
+                "reasoning_text": {"text": "Another reasoning block", "signature": ""}
             }
-        }
+        },
     ]
 
     expected_lc = [
         # Expected LC format for non-reasoning block
-        {
-            "type": "text",
-            "text": "Thought text"
-        },
+        {"type": "text", "text": "Thought text"},
         # Expected LC format for invoke reasoning_text
         {
             "type": "reasoning_content",
             "reasoning_content": {
                 "type": "text",
                 "text": "Thought text",
-                "signature": "sig"
-            }
+                "signature": "sig",
+            },
         },
         # Expected LC format for streaming text
         {
             "type": "reasoning_content",
-            "reasoning_content": {
-                "type": "text",
-                "text": "Thought text"
-            }
+            "reasoning_content": {"type": "text", "text": "Thought text"},
         },
         # Expected LC format for streaming signature
         {
             "type": "reasoning_content",
-            "reasoning_content": {
-                "type": "signature",
-                "signature": "sig"
-            }
+            "reasoning_content": {"type": "signature", "signature": "sig"},
         },
         # Expected LC format for reasoning with no text
         {
             "type": "reasoning_content",
-            "reasoning_content": {
-                "type": "text",
-                "text": "",
-                "signature": "sig"
-            }
+            "reasoning_content": {"type": "text", "text": "", "signature": "sig"},
         },
         # Expected LC format for reasoning with no signature
         {
@@ -620,9 +584,9 @@ def test__bedrock_to_lc_anthropic_reasoning() -> None:
             "reasoning_content": {
                 "type": "text",
                 "text": "Another reasoning block",
-                "signature": ""
-            }
-        }
+                "signature": "",
+            },
+        },
     ]
 
     actual = _bedrock_to_lc(bedrock_content)
@@ -634,42 +598,43 @@ def test__lc_content_to_bedrock_anthropic_reasoning() -> None:
         SystemMessage(content="You are a helpful assistant."),
         # Anthropic "thinking" type
         HumanMessage(content="Solve this problem step by step: what is 27 * 14?"),
-        AIMessage(content=[
-            {
-                "type": "thinking",
-                "thinking": "To solve 27 * 14, I'll break it down into steps...",
-                "signature": "sig-123"
-            },
-            {
-                "type": "text",
-                "text": "The answer is 378."
-            }
-        ]),
+        AIMessage(
+            content=[
+                {
+                    "type": "thinking",
+                    "thinking": "To solve 27 * 14, I'll break it down into steps...",
+                    "signature": "sig-123",
+                },
+                {"type": "text", "text": "The answer is 378."},
+            ]
+        ),
         # Bedrock "reasoning_content" type
         HumanMessage(content="Can you re-check your last answer?"),
-        AIMessage(content=[
-            {
-                "type": "reasoning_content",
-                "reasoning_content": {
-                    "text": "To solve 27 * 14, I'll break it down:\n1. First multiply 7 × 14 = 98\n2. Then multiply 20 × 14 = 280\n3. Add the results: 98 + 280 = 378",
-                    "signature": "math-sig-456"
-                }
-            },
-            {
-                "type": "text",
-                "text": "I've double-checked and confirm that 27 * 14 = 378."
-            }
-        ]),
+        AIMessage(
+            content=[
+                {
+                    "type": "reasoning_content",
+                    "reasoning_content": {
+                        "text": (
+                            "To solve 27 * 14, I'll break it down:\n1. "
+                            "First multiply 7 × 14 = 98\n2. Then multiply "
+                            "20 × 14 = 280\n3. Add the results: 98 + 280 = 378"
+                        ),
+                        "signature": "math-sig-456",
+                    },
+                },
+                {
+                    "type": "text",
+                    "text": "I've double-checked and confirm that 27 * 14 = 378.",
+                },
+            ]
+        ),
     ]
 
     expected_messages = [
         {
             "role": "user",
-            "content": [
-                {
-                    "text": "Solve this problem step by step: what is 27 * 14?"
-                }
-            ]
+            "content": [{"text": "Solve this problem step by step: what is 27 * 14?"}],
         },
         {
             "role": "assistant",
@@ -677,39 +642,34 @@ def test__lc_content_to_bedrock_anthropic_reasoning() -> None:
                 {
                     "reasoningContent": {
                         "reasoningText": {
-                            "text": "To solve 27 * 14, I'll break it down into steps...",
-                            "signature": "sig-123"
+                            "text": (
+                                "To solve 27 * 14, I'll break it down into steps..."
+                            ),
+                            "signature": "sig-123",
                         }
                     }
                 },
-                {
-                    "text": "The answer is 378."
-                }
-            ]
+                {"text": "The answer is 378."},
+            ],
         },
-        {
-            "role": "user",
-            "content": [
-                {
-                    "text": "Can you re-check your last answer?"
-                }
-            ]
-        },
+        {"role": "user", "content": [{"text": "Can you re-check your last answer?"}]},
         {
             "role": "assistant",
             "content": [
                 {
                     "reasoningContent": {
                         "reasoningText": {
-                            "text": "To solve 27 * 14, I'll break it down:\n1. First multiply 7 × 14 = 98\n2. Then multiply 20 × 14 = 280\n3. Add the results: 98 + 280 = 378",
-                            "signature": "math-sig-456"
+                            "text": (
+                                "To solve 27 * 14, I'll break it down:\n1. First "
+                                "multiply 7 × 14 = 98\n2. Then multiply 20 × 14 = 280"
+                                "\n3. Add the results: 98 + 280 = 378"
+                            ),
+                            "signature": "math-sig-456",
                         }
                     }
                 },
-                {
-                    "text": "I've double-checked and confirm that 27 * 14 = 378."
-                }
-            ]
+                {"text": "I've double-checked and confirm that 27 * 14 = 378."},
+            ],
         },
     ]
 
@@ -719,6 +679,7 @@ def test__lc_content_to_bedrock_anthropic_reasoning() -> None:
 
     assert expected_messages == actual_messages
     assert expected_system == actual_system
+
 
 def test__lc_content_to_bedrock_empty_signature() -> None:
     """Test that thinking and reasoning blocks without signatures are omitted."""
@@ -727,69 +688,75 @@ def test__lc_content_to_bedrock_empty_signature() -> None:
         # Human message with a question
         HumanMessage(content="Tell me about machine learning."),
         # AI message with thinking block that has NO signature (should be omitted)
-        AIMessage(content=[
-            {
-                "type": "thinking",
-                "thinking": "I'll explain machine learning concepts...",
-                "signature": ""  # Empty signature
-            },
-            {
-                "type": "text",
-                "text": "Machine learning is a field of AI that enables systems to learn from data."
-            }
-        ]),
+        AIMessage(
+            content=[
+                {
+                    "type": "thinking",
+                    "thinking": "I'll explain machine learning concepts...",
+                    "signature": "",  # Empty signature
+                },
+                {
+                    "type": "text",
+                    "text": (
+                        "Machine learning is a field of AI that enables systems to "
+                        "learn from data."
+                    ),
+                },
+            ]
+        ),
         # Human follow-up
         HumanMessage(content="What about deep learning?"),
-        # AI message with reasoning_content block that has NO signature (should be omitted)
-        AIMessage(content=[
-            {
-                "type": "reasoning_content",
-                "reasoningContent": {
-                    "text": "Deep learning is a subset of machine learning using neural networks.",
-                    "signature": ""  # Empty signature
-                }
-            },
-            {
-                "type": "text",
-                "text": "Deep learning is a subfield of machine learning that uses neural networks with many layers."
-            }
-        ]),
+        # AI message with reasoning_content block
+        # that has NO signature (should be omitted)
+        AIMessage(
+            content=[
+                {
+                    "type": "reasoning_content",
+                    "reasoningContent": {
+                        "text": (
+                            "Deep learning is a subset of machine learning using "
+                            "neural networks."
+                        ),
+                        "signature": "",  # Empty signature
+                    },
+                },
+                {
+                    "type": "text",
+                    "text": (
+                        "Deep learning is a subfield of machine learning that uses "
+                        "neural networks with many layers."
+                    ),
+                },
+            ]
+        ),
     ]
 
     expected_messages = [
-        {
-            "role": "user",
-            "content": [
-                {
-                    "text": "Tell me about machine learning."
-                }
-            ]
-        },
+        {"role": "user", "content": [{"text": "Tell me about machine learning."}]},
         {
             "role": "assistant",
             "content": [
                 # No reasoning block because signature is empty
                 {
-                    "text": "Machine learning is a field of AI that enables systems to learn from data."
+                    "text": (
+                        "Machine learning is a field of AI that enables systems to "
+                        "learn from data."
+                    )
                 }
-            ]
+            ],
         },
-        {
-            "role": "user",
-            "content": [
-                {
-                    "text": "What about deep learning?"
-                }
-            ]
-        },
+        {"role": "user", "content": [{"text": "What about deep learning?"}]},
         {
             "role": "assistant",
             "content": [
                 # No reasoning block because signature is empty
                 {
-                    "text": "Deep learning is a subfield of machine learning that uses neural networks with many layers."
+                    "text": (
+                        "Deep learning is a subfield of machine learning that uses "
+                        "neural networks with many layers."
+                    )
                 }
-            ]
+            ],
         },
     ]
 
@@ -800,6 +767,7 @@ def test__lc_content_to_bedrock_empty_signature() -> None:
     assert expected_messages == actual_messages
     assert expected_system == actual_system
 
+
 def test__lc_content_to_bedrock_mixed_signatures() -> None:
     """Test a mix of thinking/reasoning blocks with and without signatures."""
     messages = [
@@ -807,104 +775,94 @@ def test__lc_content_to_bedrock_mixed_signatures() -> None:
         # Human message
         HumanMessage(content="Explain AI and machine learning."),
         # AI message with mixed thinking/reasoning blocks (with/without signatures)
-        AIMessage(content=[
-            {
-                "type": "thinking",
-                "thinking": "I should start with AI definitions...",
-                "signature": ""  # Empty signature - should be omitted
-            },
-            {
-                "type": "text",
-                "text": "AI is a broad field of computer science."
-            },
-            {
-                "type": "thinking",
-                "thinking": "Now I'll explain machine learning...",
-                "signature": "signature-xyz"  # Has signature - should be included
-            },
-            {
-                "type": "text",
-                "text": "Machine learning is a subset of AI."
-            }
-        ]),
+        AIMessage(
+            content=[
+                {
+                    "type": "thinking",
+                    "thinking": "I should start with AI definitions...",
+                    "signature": "",  # Empty signature - should be omitted
+                },
+                {"type": "text", "text": "AI is a broad field of computer science."},
+                {
+                    "type": "thinking",
+                    "thinking": "Now I'll explain machine learning...",
+                    "signature": "signature-xyz",  # Has signature - should be included
+                },
+                {"type": "text", "text": "Machine learning is a subset of AI."},
+            ]
+        ),
         # Human follow-up
         HumanMessage(content="What about neural networks?"),
         # AI response with mixed reasoning_content blocks
-        AIMessage(content=[
-            {
-                "type": "reasoning_content",
-                "reasoningContent": {
-                    "text": "Neural networks are inspired by biological neurons.",
-                    "signature": "nn-signature"  # Has signature - should be included
-                }
-            },
-            {
-                "type": "reasoning_content",
-                "reasoningContent": {
-                    "text": "They consist of interconnected layers of nodes.",
-                    "signature": ""  # Empty signature - should be omitted
-                }
-            },
-            {
-                "type": "text",
-                "text": "Neural networks are computing systems inspired by biological neural networks."
-            }
-        ]),
+        AIMessage(
+            content=[
+                {
+                    "type": "reasoning_content",
+                    "reasoningContent": {
+                        "text": "Neural networks are inspired by biological neurons.",
+                        "signature": (
+                            "nn-signature"
+                        ),  # Has signature - should be included
+                    },
+                },
+                {
+                    "type": "reasoning_content",
+                    "reasoningContent": {
+                        "text": "They consist of interconnected layers of nodes.",
+                        "signature": "",  # Empty signature - should be omitted
+                    },
+                },
+                {
+                    "type": "text",
+                    "text": (
+                        "Neural networks are computing systems inspired by biological "
+                        "neural networks."
+                    ),
+                },
+            ]
+        ),
     ]
 
     expected_messages = [
-        {
-            "role": "user",
-            "content": [
-                {
-                    "text": "Explain AI and machine learning."
-                }
-            ]
-        },
+        {"role": "user", "content": [{"text": "Explain AI and machine learning."}]},
         {
             "role": "assistant",
             "content": [
                 # First thinking block omitted (empty signature)
-                {
-                    "text": "AI is a broad field of computer science."
-                },
+                {"text": "AI is a broad field of computer science."},
                 {
                     "reasoningContent": {
                         "reasoningText": {
                             "text": "Now I'll explain machine learning...",
-                            "signature": "signature-xyz"
+                            "signature": "signature-xyz",
                         }
                     }
                 },
-                {
-                    "text": "Machine learning is a subset of AI."
-                }
-            ]
+                {"text": "Machine learning is a subset of AI."},
+            ],
         },
-        {
-            "role": "user",
-            "content": [
-                {
-                    "text": "What about neural networks?"
-                }
-            ]
-        },
+        {"role": "user", "content": [{"text": "What about neural networks?"}]},
         {
             "role": "assistant",
             "content": [
                 {
                     "reasoningContent": {
                         "reasoningText": {
-                            "text": "Neural networks are inspired by biological neurons.",
-                            "signature": "nn-signature"
+                            "text": (
+                                "Neural networks are inspired by biological neurons."
+                            ),
+                            "signature": "nn-signature",
                         }
                     }
                 },
                 # Second reasoning block omitted (empty signature)
                 {
-                    "text": "Neural networks are computing systems inspired by biological neural networks."
-                }
-            ]
+                    "text": (
+                        "Neural networks are computing systems inspired by biological "
+                        "neural networks."
+                    )
+                },
+            ],
         },
     ]
 
@@ -916,25 +874,34 @@ def test__lc_content_to_bedrock_mixed_signatures() -> None:
     assert expected_system == actual_system
     """Test that reasoning_content blocks without signatures are omitted."""
     # Test with empty signature
-    content = [
+    content: List[str | Dict[str, Any]] = [
         {"type": "text", "text": "Some text"},
-        {"type": "reasoning_content", "reasoningContent": {"text": "This is reasoning", "signature": ""}}
+        {
+            "type": "reasoning_content",
+            "reasoningContent": {"text": "This is reasoning", "signature": ""},
+        },
     ]
-    
+
     bedrock_content = _lc_content_to_bedrock(content)
-    
-    # Verify that the reasoning_content block was omitted because it has an empty signature
+
+    # Verify reasoning_content block was omitted because it has an empty signature
     assert len(bedrock_content) == 1
     assert bedrock_content[0] == {"text": "Some text"}
-    
+
     # Test with signature present
     content = [
         {"type": "text", "text": "Some text"},
-        {"type": "reasoning_content", "reasoningContent": {"text": "This is reasoning", "signature": "some-signature"}}
+        {
+            "type": "reasoning_content",
+            "reasoningContent": {
+                "text": "This is reasoning",
+                "signature": "some-signature",
+            },
+        },
     ]
-    
+
     bedrock_content = _lc_content_to_bedrock(content)
-    
+
     # Verify that the reasoning_content block is included when it has a signature
     assert len(bedrock_content) == 2
     assert bedrock_content[0] == {"text": "Some text"}
@@ -949,75 +916,99 @@ def test__lc_content_to_bedrock_mixed_signatures() -> None:
 
 
 def test__lc_content_to_bedrock_reasoning_content_signature() -> None:
-    """Test that reasoning_content blocks with and without signatures are handled correctly."""
+    """
+    Test that reasoning_content blocks with and without signatures
+    are handled correctly.
+    """
     messages = [
         SystemMessage(content="You are a helpful assistant."),
         # Human message with a question
         HumanMessage(content="Explain quantum computing."),
         # AI message with reasoning_content blocks with and without signatures
-        AIMessage(content=[
-            {
-                "type": "reasoning_content",
-                "reasoningContent": {
-                    "text": "Quantum computing uses quantum bits or qubits...",
-                    "signature": "qc-signature"  # Has signature - should be included
-                }
-            },
-            {
-                "type": "text",
-                "text": "Quantum computing is a type of computation that harnesses quantum mechanics."
-            },
-        ]),
+        AIMessage(
+            content=[
+                {
+                    "type": "reasoning_content",
+                    "reasoningContent": {
+                        "text": "Quantum computing uses quantum bits or qubits...",
+                        "signature": (
+                            "qc-signature"
+                        ),  # Has signature - should be included
+                    },
+                },
+                {
+                    "type": "text",
+                    "text": (
+                        "Quantum computing is a type of computation that harnesses "
+                        "quantum mechanics."
+                    ),
+                },
+            ]
+        ),
         # Human follow-up
         HumanMessage(content="How does it differ from classical computing?"),
         # AI response with reasoning_content block without signature
-        AIMessage(content=[
-            {
-                "type": "reasoning_content",
-                "reasoningContent": {
-                    "text": "Unlike classical bits that are either 0 or 1, qubits can be in superposition.",
-                    "signature": ""  # Empty signature - should be omitted
-                }
-            },
-            {
-                "type": "text",
-                "text": "Classical computers use bits as the smallest unit of data, while quantum computers use qubits which can exist in multiple states simultaneously."
-            }
-        ]),
+        AIMessage(
+            content=[
+                {
+                    "type": "reasoning_content",
+                    "reasoningContent": {
+                        "text": (
+                            "Unlike classical bits that are either 0 or 1, qubits can "
+                            "be in superposition."
+                        ),
+                        "signature": "",  # Empty signature - should be omitted
+                    },
+                },
+                {
+                    "type": "text",
+                    "text": (
+                        "Classical computers use bits as the smallest unit of data, "
+                        "while quantum computers use qubits which can exist in "
+                        "multiple states simultaneously."
+                    ),
+                },
+            ]
+        ),
         # Another follow-up
         HumanMessage(content="What are the practical applications?"),
         # AI response with multiple reasoning_content blocks with mixed signatures
-        AIMessage(content=[
-            {
-                "type": "reasoning_content",
-                "reasoningContent": {
-                    "text": "Quantum computing excels at certain types of problems...",
-                    "signature": "apps-signature"  # Has signature - should be included
-                }
-            },
-            {
-                "type": "reasoning_content",
-                "reasoningContent": {
-                    "text": "Examples include cryptography, optimization, and simulation.",
-                    "signature": ""  # Empty signature - should be omitted
-                }
-            },
-            {
-                "type": "text",
-                "text": "Practical applications include cryptography, drug discovery, materials science, and complex optimization problems."
-            }
-        ]),
+        AIMessage(
+            content=[
+                {
+                    "type": "reasoning_content",
+                    "reasoningContent": {
+                        "text": (
+                            "Quantum computing excels at certain types of problems..."
+                        ),
+                        "signature": (
+                            "apps-signature"
+                        ),  # Has signature - should be included
+                    },
+                },
+                {
+                    "type": "reasoning_content",
+                    "reasoningContent": {
+                        "text": (
+                            "Examples include cryptography, optimization, and "
+                            "simulation."
+                        ),
+                        "signature": "",  # Empty signature - should be omitted
+                    },
+                },
+                {
+                    "type": "text",
+                    "text": (
+                        "Practical applications include cryptography, drug discovery, "
+                        "materials science, and complex optimization problems."
+                    ),
+                },
+            ]
+        ),
     ]
 
     expected_messages = [
-        {
-            "role": "user",
-            "content": [
-                {
-                    "text": "Explain quantum computing."
-                }
-            ]
-        },
+        {"role": "user", "content": [{"text": "Explain quantum computing."}]},
         {
             "role": "assistant",
             "content": [
@@ -1025,56 +1016,58 @@ def test__lc_content_to_bedrock_reasoning_content_signature() -> None:
                     "reasoningContent": {
                         "reasoningText": {
                             "text": "Quantum computing uses quantum bits or qubits...",
-                            "signature": "qc-signature"
+                            "signature": "qc-signature",
                         }
                     }
                 },
                 {
-                    "text": "Quantum computing is a type of computation that harnesses quantum mechanics."
-                }
-            ]
+                    "text": (
+                        "Quantum computing is a type of computation that harnesses "
+                        "quantum mechanics."
+                    )
+                },
+            ],
         },
         {
             "role": "user",
-            "content": [
-                {
-                    "text": "How does it differ from classical computing?"
-                }
-            ]
+            "content": [{"text": "How does it differ from classical computing?"}],
         },
         {
             "role": "assistant",
             "content": [
                 # No reasoning block because signature is empty
                 {
-                    "text": "Classical computers use bits as the smallest unit of data, while quantum computers use qubits which can exist in multiple states simultaneously."
+                    "text": (
+                        "Classical computers use bits as the smallest unit of data, "
+                        "while quantum computers use qubits which can exist in "
+                        "multiple states simultaneously."
+                    )
                 }
-            ]
+            ],
         },
-        {
-            "role": "user",
-            "content": [
-                {
-                    "text": "What are the practical applications?"
-                }
-            ]
-        },
+        {"role": "user", "content": [{"text": "What are the practical applications?"}]},
         {
             "role": "assistant",
             "content": [
                 {
                     "reasoningContent": {
                         "reasoningText": {
-                            "text": "Quantum computing excels at certain types of problems...",
-                            "signature": "apps-signature"
+                            "text": (
+                                "Quantum computing excels at certain types of "
+                                "problems..."
+                            ),
+                            "signature": "apps-signature",
                         }
                     }
                 },
                 # Second reasoning block omitted (empty signature)
                 {
-                    "text": "Practical applications include cryptography, drug discovery, materials science, and complex optimization problems."
-                }
-            ]
+                    "text": (
+                        "Practical applications include cryptography, drug discovery, "
+                        "materials science, and complex optimization problems."
+                    )
+                },
+            ],
         },
     ]
 


### PR DESCRIPTION
Fixes https://github.com/langchain-ai/langchain-aws/issues/401

Claude 3.7 still works because signatures are always returned with those thinking blocks. DeepSeek thinking blocks do not contain signatures and the ValidationError indicates a signature must be included with thinking blocks.

According to Converse API docs:
> "Within the reasoningText field, the text fields describes the reasoning. The signature field is a hash of all the messages in the conversation and is a safeguard against tampering of the reasoning used by the model. You must include the signature and all previous messages in subsequent Converse requests. If any of the messages are changed, the response throws an error."

https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-call.html

@3coins I posted a separate PR https://github.com/langchain-ai/langchain-aws/pull/407 to make reviewing easier. Happy to combine if preferred.