### PR TITLE
Fix max_tokens for DeepSeek-R1 base

### DIFF
--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -367,7 +367,7 @@ class LLMInputOutputAdapter:
                 elif provider == "mistral":
                     input_body["max_tokens"] = max_tokens
                 elif provider == "deepseek":
-                    input_body["max_new_tokens"] = max_tokens
+                    input_body["max_tokens"] = max_tokens
                 else:
                     # TODO: Add AI21 support, param depends on specific model.
                     pass
@@ -500,7 +500,7 @@ class LLMInputOutputAdapter:
 
             if provider == "deepseek":
                 opt = chunk_obj.get(output_key, [{}])[0]
-                if opt.get("stop_reason") == "stop" or opt.get("finish_reason") == "eos_token":
+                if opt.get("stop_reason") in ["stop", "length"] or opt.get("finish_reason") == "eos_token":
                     yield _get_invocation_metrics_chunk(chunk_obj)
                     return
 

--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock.py
@@ -104,6 +104,28 @@ def test_chat_bedrock_token_counts() -> None:
 
 
 @pytest.mark.scheduled
+def test_chat_bedrock_token_counts_deepseek_r1() -> None:
+    chat = ChatBedrock(  # type: ignore[call-arg]
+        model_id="us.deepseek.r1-v1:0",
+        temperature=0,
+        max_tokens=6,
+    )
+
+    invoke_response = chat.invoke("hi")
+    assert isinstance(invoke_response, AIMessage)
+    assert invoke_response.usage_metadata is not None
+    assert invoke_response.usage_metadata["output_tokens"] <= 6
+
+    stream = chat.stream("hi")
+    stream_response = next(stream)
+    for chunk in stream:
+        stream_response += chunk
+    assert isinstance(stream_response, AIMessage)
+    assert stream_response.usage_metadata is not None
+    assert stream_response.usage_metadata["output_tokens"] <= 6
+
+
+@pytest.mark.scheduled
 def test_chat_bedrock_streaming_llama3() -> None:
     """Test that streaming correctly streams message chunks"""
     chat = ChatBedrock(  # type: ignore[call-arg]


### PR DESCRIPTION
Fixes #414.

Bedrock Invoke API accepts both `max_new_tokens` and `max_tokens` for DeepSeek-R1-Distill-Qwen and DeepSeek-R1-Distill-Llama models. However, the DeepSeek-R1 base model is less flexible, only accepting `max_tokens`.

For better compatibility, this PR updates BedrockBase to use `max_tokens` for all DeepSeek-R1 models.