### PR TITLE
Update AWS client creation for additional chains

### DIFF
--- a/libs/aws/langchain_aws/graphs/neptune_graph.py
+++ b/libs/aws/langchain_aws/graphs/neptune_graph.py
@@ -2,6 +2,10 @@ import json
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, Tuple, Union
 
+from pydantic import SecretStr
+
+from langchain_aws.utils import create_aws_client
+
 
 def _format_triples(triples: List[dict]) -> List[str]:
     triple_template = "(:`{a}`)-[:`{e}`]->(:`{b}`)"
@@ -213,47 +217,29 @@ class NeptuneAnalyticsGraph(BaseNeptuneGraph):
         client: Any = None,
         credentials_profile_name: Optional[str] = None,
         region_name: Optional[str] = None,
+        aws_access_key_id: Optional[SecretStr] = None,
+        aws_secret_access_key: Optional[SecretStr] = None,
+        aws_session_token: Optional[SecretStr] = None,
+        endpoint_url: Optional[str] = None,
+        config: Any = None,
     ) -> None:
         """Create a new Neptune Analytics graph wrapper instance."""
 
-        try:
-            if client is not None:
-                self.client = client
-            else:
-                import boto3
+        self.graph_identifier = graph_identifier
 
-                if credentials_profile_name is not None:
-                    session = boto3.Session(profile_name=credentials_profile_name)
-                else:
-                    # use default credentials
-                    session = boto3.Session()
-
-                self.graph_identifier = graph_identifier
-
-                if region_name:
-                    self.client = session.client(
-                        "neptune-graph", region_name=region_name
-                    )
-                else:
-                    self.client = session.client("neptune-graph")
-
-        except ImportError:
-            raise ModuleNotFoundError(
-                "Could not import boto3 python package. "
-                "Please install it with `pip install boto3`."
+        if client is not None:
+            self.client = client
+        else:
+            self.client = create_aws_client(
+                region_name=region_name,
+                credentials_profile_name=credentials_profile_name,
+                aws_access_key_id=aws_access_key_id,
+                aws_secret_access_key=aws_secret_access_key,
+                aws_session_token=aws_session_token,
+                endpoint_url=endpoint_url,
+                config=config,
+                service_name="neptune-graph",
             )
-        except Exception as e:
-            if type(e).__name__ == "UnknownServiceError":
-                raise ModuleNotFoundError(
-                    "NeptuneGraph requires a boto3 version 1.34.40 or greater."
-                    "Please install it with `pip install -U boto3`."
-                ) from e
-            else:
-                raise ValueError(
-                    "Could not load credentials to authenticate with AWS client. "
-                    "Please check that credentials in the specified "
-                    "profile name are valid."
-                ) from e
 
         try:
             self._refresh_schema()
@@ -376,6 +362,11 @@ class NeptuneGraph(BaseNeptuneGraph):
         credentials_profile_name: Optional[str] = None,
         region_name: Optional[str] = None,
         sign: bool = True,
+        aws_access_key_id: Optional[SecretStr] = None,
+        aws_secret_access_key: Optional[SecretStr] = None,
+        aws_session_token: Optional[SecretStr] = None,
+        endpoint_url: Optional[str] = None,
+        config: Any = None,
     ) -> None:
         """Create a new Neptune graph wrapper instance."""
 
@@ -385,31 +376,56 @@ class NeptuneGraph(BaseNeptuneGraph):
             else:
                 import boto3
 
-                if credentials_profile_name is not None:
-                    session = boto3.Session(profile_name=credentials_profile_name)
-                else:
-                    # use default credentials
+                any_creds = bool(
+                    credentials_profile_name or
+                    aws_access_key_id or
+                    aws_secret_access_key or
+                    aws_session_token
+                )
+
+                if not any_creds:
                     session = boto3.Session()
+                elif credentials_profile_name:
+                    session = boto3.Session(profile_name=credentials_profile_name)
+                elif aws_access_key_id and aws_secret_access_key:
+                    session_params = {
+                        "aws_access_key_id": aws_access_key_id.get_secret_value(),
+                        "aws_secret_access_key": aws_secret_access_key.get_secret_value(),
+                    }
+                    if aws_session_token:
+                        session_params["aws_session_token"] = aws_session_token.get_secret_value()
+                    session = boto3.Session(**session_params)
+                else:
+                    raise ValueError(
+                        "If providing credentials, both aws_access_key_id and "
+                        "aws_secret_access_key must be specified."
+                    )
 
                 client_params = {}
                 if region_name:
                     client_params["region_name"] = region_name
 
-                protocol = "https" if use_https else "http"
-
-                client_params["endpoint_url"] = f"{protocol}://{host}:{port}"
-
-                if sign:
-                    self.client = session.client("neptunedata", **client_params)
+                if endpoint_url is not None:
+                    client_params["endpoint_url"] = endpoint_url
                 else:
+                    protocol = "https" if use_https else "http"
+                    client_params["endpoint_url"] = f"{protocol}://{host}:{port}"
+
+                if config is not None:
+                    client_params["config"] = config
+
+                if not sign:
                     from botocore import UNSIGNED
                     from botocore.config import Config
 
-                    self.client = session.client(
-                        "neptunedata",
-                        **client_params,
-                        config=Config(signature_version=UNSIGNED),
-                    )
+                    if "config" in client_params:
+                        client_params["config"] = client_params["config"].merge(
+                            Config(signature_version=UNSIGNED)
+                        )
+                    else:
+                        client_params["config"] = Config(signature_version=UNSIGNED)
+
+                self.client = session.client("neptunedata", **client_params)
 
         except ImportError:
             raise ModuleNotFoundError(

--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import logging
-import os
 import warnings
 from abc import ABC
 from typing import (

--- a/libs/aws/tests/integration_tests/chat_models/test_standard.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_standard.py
@@ -2,9 +2,9 @@
 
 from typing import Type
 
+import pytest
 from langchain_core.language_models import BaseChatModel
 from langchain_tests.integration_tests import ChatModelIntegrationTests
-import pytest
 
 from langchain_aws.chat_models.bedrock import ChatBedrock
 


### PR DESCRIPTION
Follow-up to #360.

This PR updates the following classes to use the `create_aws_client` utility function, and/or accept additional Boto client parameters during initialization:
- `BedrockRerank`
- `ChatSagemakerEndpoint`
- `NeptuneGraph`
- `NeptuneAnalyticsGraph`