### PR TITLE
Excludes tool calling spec from camelcase conversion.

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -592,7 +592,7 @@ class ChatBedrockConverse(BaseChatModel):
         logger.debug(f"input message to bedrock: {bedrock_messages}")
         logger.debug(f"System message to bedrock: {system}")
         params = self._converse_params(
-            stop=stop, **_snake_to_camel_keys(kwargs, excluded_keys={"inputSchema"})
+            stop=stop, **_snake_to_camel_keys(kwargs, excluded_keys={"inputSchema", "function"})
         )
         logger.debug(f"Input params: {params}")
         logger.info("Using Bedrock Converse API to generate response")
@@ -612,7 +612,7 @@ class ChatBedrockConverse(BaseChatModel):
     ) -> Iterator[ChatGenerationChunk]:
         bedrock_messages, system = _messages_to_bedrock(messages)
         params = self._converse_params(
-            stop=stop, **_snake_to_camel_keys(kwargs, excluded_keys={"inputSchema"})
+            stop=stop, **_snake_to_camel_keys(kwargs, excluded_keys={"inputSchema", "function"})
         )
         response = self.client.converse_stream(
             messages=bedrock_messages, system=system, **params


### PR DESCRIPTION
Fixes #409 