### PR TITLE
aws[patch]: propagate model names to response metadata

### DIFF
--- a/libs/aws/poetry.lock
+++ b/libs/aws/poetry.lock
@@ -639,13 +639,13 @@ xai = ["langchain-xai"]
 
 [[package]]
 name = "langchain-core"
-version = "0.3.47"
+version = "0.3.49"
 description = "Building applications with LLMs through composability"
 optional = false
 python-versions = "<4.0,>=3.9"
 files = [
-    {file = "langchain_core-0.3.47-py3-none-any.whl", hash = "sha256:ef7c78202e6fd9df79fe8128c828d08a95d3878cf4aec282580baf358a3f2ec5"},
-    {file = "langchain_core-0.3.47.tar.gz", hash = "sha256:975a3daabf8e8d583749b3c553cc412d0527d935dfe820317431b475fa0c585a"},
+    {file = "langchain_core-0.3.49-py3-none-any.whl", hash = "sha256:893ee42c9af13bf2a2d8c2ec15ba00a5c73cccde21a2bd005234ee0e78a2bdf8"},
+    {file = "langchain_core-0.3.49.tar.gz", hash = "sha256:d9dbff9bac0021463a986355c13864d6a68c41f8559dbbd399a68e1ebd9b04b9"},
 ]
 
 [package.dependencies]
@@ -662,18 +662,18 @@ typing-extensions = ">=4.7"
 
 [[package]]
 name = "langchain-tests"
-version = "0.3.15"
+version = "0.3.17"
 description = "Standard tests for LangChain implementations"
 optional = false
 python-versions = "<4.0,>=3.9"
 files = [
-    {file = "langchain_tests-0.3.15-py3-none-any.whl", hash = "sha256:a667907dca7d4af0f1dfc474f0efcf6548e484cf08f9d5e585efa51856a1ead3"},
-    {file = "langchain_tests-0.3.15.tar.gz", hash = "sha256:e623b1bb9481fa15394b681289ec1b826781b846815c4626b53e538b769cbce3"},
+    {file = "langchain_tests-0.3.17-py3-none-any.whl", hash = "sha256:7b156322d6579f3fd0028930f6a0172d6e0a3270bf0efbfa8118c5fcc3d50d14"},
+    {file = "langchain_tests-0.3.17.tar.gz", hash = "sha256:d4e27c8a6cdc680988f2261f892b927f835711a41facc74b2e31ffd4d56c86c2"},
 ]
 
 [package.dependencies]
 httpx = ">=0.25.0,<1"
-langchain-core = ">=0.3.47,<1.0.0"
+langchain-core = ">=0.3.49,<1.0.0"
 numpy = ">=1.26.2,<3"
 pytest = ">=7,<9"
 pytest-asyncio = ">=0.20,<1"
@@ -1819,4 +1819,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "bd628e525884d8ca551d0ed63a9a62983de46fa9fb2f242616d4efa1123c227e"
+content-hash = "2b81b67ac66d18c943596b43e4813a4e5be25e224e3ed463e866bfc8390634d8"

--- a/libs/aws/pyproject.toml
+++ b/libs/aws/pyproject.toml
@@ -29,7 +29,7 @@ pytest-cov = "^4.1.0"
 syrupy = "^4.0.2"
 pytest-asyncio = "^0.23.2"
 pytest-watcher = "^0.3.4"
-langchain-tests = "0.3.15"
+langchain-tests = "0.3.17"
 langchain = "^0.3.7"
 
 [tool.poetry.group.codespell]

--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock.py
@@ -101,6 +101,8 @@ def test_chat_bedrock_token_counts() -> None:
     assert isinstance(stream_response, AIMessage)
     assert stream_response.usage_metadata is not None
     assert stream_response.usage_metadata["output_tokens"] <= 6
+    model_name = stream_response.response_metadata["model_name"]
+    assert model_name == "anthropic.claude-3-sonnet-20240229-v1:0"
 
 
 @pytest.mark.scheduled


### PR DESCRIPTION
Largely to support tracking token usage across models via a new [usage metadata callback handler](https://python.langchain.com/docs/how_to/chat_token_usage_tracking/#using-callbacks).

Standard tests were updated to enforce compatibility in https://github.com/langchain-ai/langchain/pull/30497.

Here we update `langchain-tests` to pick up the new test and update ChatBedrock and ChatBedrockConverse to pass.