### PR TITLE
aws[patch]: support standard format for multi-modal content blocks

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -34,6 +34,7 @@ from langchain_core.messages import (
     SystemMessage,
     ToolCall,
     ToolMessage,
+    is_data_content_block,
     merge_message_runs,
 )
 from langchain_core.messages.ai import AIMessageChunk, UsageMetadata
@@ -1023,6 +1024,47 @@ def _parse_stream_event(event: Dict[str, Any]) -> Optional[BaseMessageChunk]:
         raise ValueError(f"Received unsupported stream event:\n\n{event}")
 
 
+def _format_data_content_block(block: dict) -> dict:
+    """Format standard data content block to format expected by Converse API."""
+    if block["type"] == "image":
+        if block["sourceType"] == "base64":
+            if "mimeType" not in block:
+                error_message = "mime_type key is required for base64 data."
+                raise ValueError(error_message)
+            formatted_block = {
+                "image": {
+                    "format": block["mimeType"].split("/")[1],
+                    "source": {
+                        "bytes": _b64str_to_bytes(block["data"])
+                    },
+                }
+            }
+        else:
+            error_message = "Image data only supported through in-line base64 format."
+            raise ValueError(error_message)
+
+    elif block["type"] == "file":
+        if block["sourceType"] == "base64":
+            if "mimeType" not in block:
+                error_message = "mime_type key is required for base64 data."
+                raise ValueError(error_message)
+            formatted_block = {
+                "document": {
+                    "format": block["mimeType"].split("/")[1],
+                    "source": {
+                        "bytes": _b64str_to_bytes(block["data"])
+                    },
+                }
+            }
+            if (metadata := block.get("metadata")) and "name" in metadata:
+                formatted_block["document"]["name"] = metadata["name"]
+        else:
+            error_message = "File data only supported through in-line base64 format."
+            raise ValueError(error_message)
+
+    return formatted_block
+
+
 def _lc_content_to_bedrock(
     content: Union[str, List[Union[str, Dict[str, Any]]]],
 ) -> List[Dict[str, Any]]:
@@ -1035,6 +1077,11 @@ def _lc_content_to_bedrock(
         # Assume block is already in bedrock format.
         elif "type" not in block:
             bedrock_content.append(block)
+        elif (
+            isinstance(block, dict)
+            and is_data_content_block(_camel_to_snake_keys(block))
+        ):
+            bedrock_content.append(_format_data_content_block(block))
         elif block["type"] == "text":
             bedrock_content.append({"text": block["text"]})
         elif block["type"] == "image":

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -1058,6 +1058,13 @@ def _format_data_content_block(block: dict) -> dict:
             }
             if (metadata := block.get("metadata")) and "name" in metadata:
                 formatted_block["document"]["name"] = metadata["name"]
+            else:
+                warnings.warn(
+                    "Bedrock Converse may require a filename for file inputs. Specify "
+                    "a filename in the metadata: {'type': 'file', 'source_type': "
+                    "'base64', 'mime_type': 'application/pdf', 'data': '...', "
+                    "'metadata': {'name': 'my-pdf'}}"
+                )
         else:
             error_message = "File data only supported through in-line base64 format."
             raise ValueError(error_message)

--- a/libs/aws/poetry.lock
+++ b/libs/aws/poetry.lock
@@ -1905,4 +1905,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "de3e5a6a946deacfef9c771f7a383826ea6677761d8d88ff4960db1b747fd1fe"
+content-hash = "66600641a5cc77c7c6203f2e05ad5f197f6df49c52402eaf305402685ba53b4e"

--- a/libs/aws/poetry.lock
+++ b/libs/aws/poetry.lock
@@ -667,14 +667,14 @@ xai = ["langchain-xai"]
 
 [[package]]
 name = "langchain-core"
-version = "0.3.50"
+version = "0.3.52"
 description = "Building applications with LLMs through composability"
 optional = false
 python-versions = "<4.0,>=3.9"
 groups = ["main", "test"]
 files = [
-    {file = "langchain_core-0.3.50-py3-none-any.whl", hash = "sha256:76b7ff99125d160427801ea47c4b5202363856603e8382208a889fdd914d7d4d"},
-    {file = "langchain_core-0.3.50.tar.gz", hash = "sha256:8e141b89f2be6020e94c32d7d5141fc6eb5acf1e04e4d80ebd2c74bf30de9f77"},
+    {file = "langchain_core-0.3.52-py3-none-any.whl", hash = "sha256:cd137109c1e3d04f5a582c2cae9539b2cd5e4b795f486b58969dbc3d0387fe7c"},
+    {file = "langchain_core-0.3.52.tar.gz", hash = "sha256:f1981ec9efa4fceb11ff5ca57f5f9c8e22859cea3a94f8a044e6de8815afbd57"},
 ]
 
 [package.dependencies]
@@ -691,20 +691,23 @@ typing-extensions = ">=4.7"
 
 [[package]]
 name = "langchain-tests"
-version = "0.3.17"
+version = "0.3.18"
 description = "Standard tests for LangChain implementations"
 optional = false
 python-versions = "<4.0,>=3.9"
 groups = ["test"]
 files = [
-    {file = "langchain_tests-0.3.17-py3-none-any.whl", hash = "sha256:7b156322d6579f3fd0028930f6a0172d6e0a3270bf0efbfa8118c5fcc3d50d14"},
-    {file = "langchain_tests-0.3.17.tar.gz", hash = "sha256:d4e27c8a6cdc680988f2261f892b927f835711a41facc74b2e31ffd4d56c86c2"},
+    {file = "langchain_tests-0.3.18-py3-none-any.whl", hash = "sha256:d8f3542050f13f0c3e452a10027cd31bd02f5e1d16f7710c35fff2ba3cbfe67d"},
+    {file = "langchain_tests-0.3.18.tar.gz", hash = "sha256:2c6c1fd94b6773b2f97f93c99dd3d6cb62481887b95efadf464232b0fd288b1c"},
 ]
 
 [package.dependencies]
 httpx = ">=0.25.0,<1"
-langchain-core = ">=0.3.49,<1.0.0"
-numpy = ">=1.26.2,<3"
+langchain-core = ">=0.3.52,<1.0.0"
+numpy = [
+    {version = ">=1.26.2", markers = "python_version < \"3.13\""},
+    {version = ">=2.1.0", markers = "python_version >= \"3.13\""},
+]
 pytest = ">=7,<9"
 pytest-asyncio = ">=0.20,<1"
 pytest-socket = ">=0.6.0,<1"
@@ -1902,4 +1905,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "7da22694f2bd2f9983a55228ebd8a417eda9dcae28c2efe287fe906ece0e2c5e"
+content-hash = "de3e5a6a946deacfef9c771f7a383826ea6677761d8d88ff4960db1b747fd1fe"

--- a/libs/aws/pyproject.toml
+++ b/libs/aws/pyproject.toml
@@ -12,7 +12,7 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-langchain-core = "^0.3.49"
+langchain-core = "^0.3.52"
 boto3 = ">=1.37.24"
 pydantic = ">=2.10.0,<3"
 numpy = [

--- a/libs/aws/pyproject.toml
+++ b/libs/aws/pyproject.toml
@@ -29,7 +29,7 @@ pytest-cov = "^4.1.0"
 syrupy = "^4.0.2"
 pytest-asyncio = "^0.23.2"
 pytest-watcher = "^0.3.4"
-langchain-tests = "0.3.17"
+langchain-tests = "0.3.18"
 langchain = "^0.3.7"
 
 [tool.poetry.group.codespell]

--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
@@ -1,7 +1,9 @@
 """Standard LangChain interface tests"""
 
-from typing import Literal, Optional, Type
+import base64
+from typing import Literal, Type
 
+import httpx
 import pytest
 from langchain_core.exceptions import OutputParserException
 from langchain_core.language_models import BaseChatModel
@@ -366,3 +368,23 @@ def test_structured_output_thinking_force_tool_use() -> None:
     }
     with pytest.raises(llm.client.exceptions.ValidationException):
         response = llm.client.converse(messages=messages, **params)
+
+
+def test_bedrock_pdf_inputs() -> None:
+    model = ChatBedrockConverse(model="anthropic.claude-3-sonnet-20240229-v1:0")
+    url = "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf"
+    pdf_data = base64.b64encode(httpx.get(url).content).decode("utf-8")
+
+    message = HumanMessage(
+        [
+            {"type": "text", "text": "Summarize this document:"},
+            {
+                "type": "file",
+                "source_type": "base64",
+                "mime_type": "application/pdf",
+                "data": pdf_data,
+                "metadata": {"name": "my-pdf"},  # Converse requires a filename
+            },
+        ]
+    )
+    _ = model.invoke([message])

--- a/libs/aws/tests/integration_tests/chat_models/test_standard.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_standard.py
@@ -22,6 +22,10 @@ class TestBedrockStandard(ChatModelIntegrationTests):
     def standard_chat_model_params(self) -> dict:
         return {"temperature": 0, "max_tokens": 100}
 
+    @property
+    def supports_image_inputs(self) -> bool:
+        return True
+
     @pytest.mark.xfail(reason="Not implemented.")
     def test_double_messages_conversation(self, model: BaseChatModel) -> None:
         super().test_double_messages_conversation(model)


### PR DESCRIPTION
We're rolling out a standard format for content blocks for multi modal data (see https://github.com/langchain-ai/langchain/pull/30746).

Here we add support in ChatBedrock and ChatBedrockConverse.