### PR TITLE
aws[patch]: support extra keys on multi-modal content blocks

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -1056,14 +1056,16 @@ def _format_data_content_block(block: dict) -> dict:
                     },
                 }
             }
-            if (metadata := block.get("metadata")) and "name" in metadata:
+            if name := block.get("name"):
+                formatted_block["document"]["name"] = name
+            elif (metadata := block.get("metadata")) and "name" in metadata:
                 formatted_block["document"]["name"] = metadata["name"]
             else:
                 warnings.warn(
                     "Bedrock Converse may require a filename for file inputs. Specify "
-                    "a filename in the metadata: {'type': 'file', 'source_type': "
+                    "a filename in the content block: {'type': 'file', 'source_type': "
                     "'base64', 'mime_type': 'application/pdf', 'data': '...', "
-                    "'metadata': {'name': 'my-pdf'}}"
+                    "'name': 'my-pdf'}"
                 )
         else:
             error_message = "File data only supported through in-line base64 format."

--- a/libs/aws/poetry.lock
+++ b/libs/aws/poetry.lock
@@ -667,14 +667,14 @@ xai = ["langchain-xai"]
 
 [[package]]
 name = "langchain-core"
-version = "0.3.52"
+version = "0.3.53"
 description = "Building applications with LLMs through composability"
 optional = false
 python-versions = "<4.0,>=3.9"
 groups = ["main", "test"]
 files = [
-    {file = "langchain_core-0.3.52-py3-none-any.whl", hash = "sha256:cd137109c1e3d04f5a582c2cae9539b2cd5e4b795f486b58969dbc3d0387fe7c"},
-    {file = "langchain_core-0.3.52.tar.gz", hash = "sha256:f1981ec9efa4fceb11ff5ca57f5f9c8e22859cea3a94f8a044e6de8815afbd57"},
+    {file = "langchain_core-0.3.53-py3-none-any.whl", hash = "sha256:bf7e6027b841804fe0686d1dc07f26528528fd995dab1e38ffc53e1d76f1163d"},
+    {file = "langchain_core-0.3.53.tar.gz", hash = "sha256:94fa88d6d3a9695665c3d60e2a296148a8a2cea7a6f5f738cb75210581db15c1"},
 ]
 
 [package.dependencies]
@@ -1905,4 +1905,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "66600641a5cc77c7c6203f2e05ad5f197f6df49c52402eaf305402685ba53b4e"
+content-hash = "7ab522278cfc2927e4c47489371c5171f8abc9511f788378e04c98d275980413"

--- a/libs/aws/pyproject.toml
+++ b/libs/aws/pyproject.toml
@@ -12,7 +12,7 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-langchain-core = "^0.3.52"
+langchain-core = "^0.3.53"
 boto3 = ">=1.37.24"
 pydantic = ">=2.10.0,<3"
 numpy = [

--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
@@ -383,7 +383,7 @@ def test_bedrock_pdf_inputs() -> None:
                 "source_type": "base64",
                 "mime_type": "application/pdf",
                 "data": pdf_data,
-                "metadata": {"name": "my-pdf"},  # Converse requires a filename
+                "name": "my-pdf",  # Converse requires a filename
             },
         ]
     )


### PR DESCRIPTION
Following https://github.com/langchain-ai/langchain/pull/30887, these are no longer required to be stuffed in the `metadata` key.