### PR TITLE
Add support of Prompt Caching for tools

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -479,13 +479,19 @@ class ChatBedrockConverse(BaseChatModel):
         # (e.g., "amazon", "anthropic", "ai21", "meta", "mistral")
         if "provider" not in values:
             if model_id.startswith("arn"):
-                raise ValueError("Model provider should be supplied when passing a model ARN as model_id.")
+                raise ValueError(
+                    "Model provider should be supplied when passing a model ARN as model_id."
+                )
             model_parts = model_id.split(".")
-            values["provider"] = model_parts[-2] if len(model_parts) > 1 else model_parts[0]
+            values["provider"] = (
+                model_parts[-2] if len(model_parts) > 1 else model_parts[0]
+            )
 
         provider = values["provider"]
 
-        model_id_lower = values.get("base_model_id", values.get("base_model", model_id)).lower()
+        model_id_lower = values.get(
+            "base_model_id", values.get("base_model", model_id)
+        ).lower()
 
         # Determine if the model supports plain-text streaming (ConverseStream)
         # Here we check based on the updated AWS documentation.
@@ -532,7 +538,8 @@ class ChatBedrockConverse(BaseChatModel):
             (provider == "meta")
             or
             # All Mistral models
-            (provider == "mistral") or
+            (provider == "mistral")
+            or
             # DeepSeek-R1 models
             (provider == "deepseek" and "r1" in model_id_lower)
         ):
@@ -613,7 +620,10 @@ class ChatBedrockConverse(BaseChatModel):
         logger.debug(f"input message to bedrock: {bedrock_messages}")
         logger.debug(f"System message to bedrock: {system}")
         params = self._converse_params(
-            stop=stop, **_snake_to_camel_keys(kwargs, excluded_keys={"inputSchema", "properties", "thinking"})
+            stop=stop,
+            **_snake_to_camel_keys(
+                kwargs, excluded_keys={"inputSchema", "properties", "thinking"}
+            ),
         )
         logger.debug(f"Input params: {params}")
         logger.info("Using Bedrock Converse API to generate response")
@@ -634,7 +644,10 @@ class ChatBedrockConverse(BaseChatModel):
     ) -> Iterator[ChatGenerationChunk]:
         bedrock_messages, system = _messages_to_bedrock(messages)
         params = self._converse_params(
-            stop=stop, **_snake_to_camel_keys(kwargs, excluded_keys={"inputSchema", "properties", "thinking"})
+            stop=stop,
+            **_snake_to_camel_keys(
+                kwargs, excluded_keys={"inputSchema", "properties", "thinking"}
+            ),
         )
         response = self.client.converse_stream(
             messages=bedrock_messages, system=system, **params
@@ -720,9 +733,7 @@ class ChatBedrockConverse(BaseChatModel):
                         f"are supported: {self.supports_tool_choice_values}."
                     )
                 else:
-                    supported = (
-                        f"Model {self._get_base_model()} does not currently support tool_choice."
-                    )
+                    supported = f"Model {self._get_base_model()} does not currently support tool_choice."
 
                 raise ValueError(
                     f"{supported} Please see "
@@ -936,6 +947,7 @@ def _extract_response_metadata(response: Dict[str, Any]) -> Dict[str, Any]:
 
     return response_metadata
 
+
 def _extract_usage_metadata(response: Dict[str, Any]) -> UsageMetadata:
     usage_dict = response.pop("usage")
 
@@ -955,6 +967,7 @@ def _extract_usage_metadata(response: Dict[str, Any]) -> UsageMetadata:
         total_tokens=total_tokens,
     )
     return usage
+
 
 def _parse_response(response: Dict[str, Any]) -> AIMessage:
     if "output" not in response:
@@ -1047,9 +1060,7 @@ def _format_data_content_block(block: dict) -> dict:
             formatted_block = {
                 "image": {
                     "format": block["mimeType"].split("/")[1],
-                    "source": {
-                        "bytes": _b64str_to_bytes(block["data"])
-                    },
+                    "source": {"bytes": _b64str_to_bytes(block["data"])},
                 }
             }
         else:
@@ -1064,9 +1075,7 @@ def _format_data_content_block(block: dict) -> dict:
             formatted_block = {
                 "document": {
                     "format": block["mimeType"].split("/")[1],
-                    "source": {
-                        "bytes": _b64str_to_bytes(block["data"])
-                    },
+                    "source": {"bytes": _b64str_to_bytes(block["data"])},
                 }
             }
             if name := block.get("name"):
@@ -1099,9 +1108,8 @@ def _lc_content_to_bedrock(
         # Assume block is already in bedrock format.
         elif "type" not in block:
             bedrock_content.append(block)
-        elif (
-            isinstance(block, dict)
-            and is_data_content_block(_camel_to_snake_keys(block))
+        elif isinstance(block, dict) and is_data_content_block(
+            _camel_to_snake_keys(block)
         ):
             bedrock_content.append(_format_data_content_block(block))
         elif block["type"] == "text":
@@ -1506,6 +1514,7 @@ def _format_openai_video_url(video_url: str) -> Dict:
         "format": match.group("media_type"),
         "source": {"bytes": _b64str_to_bytes(match.group("data"))},
     }
+
 
 def _is_cache_point(cache_point: Any) -> bool:
     return (

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -54,7 +54,7 @@ from langchain_core.utils.pydantic import TypeBaseModel, is_basemodel_subclass
 from pydantic import BaseModel, ConfigDict, Field, SecretStr, model_validator
 from typing_extensions import Self
 
-from langchain_aws.function_calling import ToolsOutputParser, is_cache_point
+from langchain_aws.function_calling import ToolsOutputParser
 from langchain_aws.utils import create_aws_client
 
 logger = logging.getLogger(__name__)
@@ -702,7 +702,7 @@ class ChatBedrockConverse(BaseChatModel):
     ) -> Runnable[LanguageModelInput, BaseMessage]:
         formatted_tools = []
         for tool in tools:
-            if is_cache_point(tool):
+            if _is_cache_point(tool):
                 formatted_tools.append(tool)
             else:
                 try:
@@ -1335,7 +1335,7 @@ def _format_tools(
 ) -> List[Dict[Literal["toolSpec"], Dict[str, Union[Dict[str, Any], str]]]]:
     formatted_tools: List = []
     for tool in tools:
-        if is_cache_point(tool):
+        if _is_cache_point(tool):
             formatted_tools.append(tool)
         else:
             if isinstance(tool, dict) and "toolSpec" in tool:
@@ -1506,3 +1506,10 @@ def _format_openai_video_url(video_url: str) -> Dict:
         "format": match.group("media_type"),
         "source": {"bytes": _b64str_to_bytes(match.group("data"))},
     }
+
+def _is_cache_point(cache_point: Any) -> bool:
+    return (
+        isinstance(cache_point, dict)
+        and "cachePoint" in cache_point
+        and cache_point.get("cachePoint").get("type") is not None
+    )

--- a/libs/aws/langchain_aws/function_calling.py
+++ b/libs/aws/langchain_aws/function_calling.py
@@ -203,23 +203,11 @@ class ToolsOutputParser(BaseGenerationOutputParser):
         ]
         return cls_(**tool_call["args"])
 
-def is_cache_point(cache_point: Any) -> bool:
-    return (
-        isinstance(cache_point, dict)
-        and len(cache_point) == 1
-        and "cachePoint" in cache_point
-        and isinstance(cache_point["cachePoint"], dict)
-        and len(cache_point["cachePoint"]) == 1
-        and "type" in cache_point["cachePoint"]
-    )
-
 def convert_to_anthropic_tool(
     tool: Union[Dict[str, Any], TypeBaseModel, Callable, BaseTool],
 ) -> Union[AnthropicTool, Dict]:
     # already in Anthropic tool format
-    if is_cache_point(tool):
-        return tool
-    elif isinstance(tool, dict) and all(
+    if isinstance(tool, dict) and all(
         k in tool for k in ("name", "description", "input_schema")
     ):
         tool["description"] = tool["description"] or tool["name"]

--- a/libs/aws/langchain_aws/function_calling.py
+++ b/libs/aws/langchain_aws/function_calling.py
@@ -63,17 +63,6 @@ TOOL_PARAMETER_FORMAT = """<parameter>
 <description>{parameter_description}</description>
 </parameter>"""
 
-class CachePointType(TypedDict):
-    """Configuration for prompt caching in Bedrock toolConfig."""
-    
-    type: Literal["default"]
-
-
-class CachePoint(TypedDict):
-    """Configuration for prompt caching in Bedrock."""
-    
-    cachePoint: CachePointType
-
 
 class AnthropicTool(TypedDict):
     name: str
@@ -216,9 +205,9 @@ class ToolsOutputParser(BaseGenerationOutputParser):
 
 def is_cache_point(cache_point: Any) -> bool:
     return (
-        isinstance(cache_point, dict) 
+        isinstance(cache_point, dict)
         and len(cache_point) == 1
-        and "cachePoint" in cache_point 
+        and "cachePoint" in cache_point
         and isinstance(cache_point["cachePoint"], dict)
         and len(cache_point["cachePoint"]) == 1
         and "type" in cache_point["cachePoint"]
@@ -226,7 +215,7 @@ def is_cache_point(cache_point: Any) -> bool:
 
 def convert_to_anthropic_tool(
     tool: Union[Dict[str, Any], TypeBaseModel, Callable, BaseTool],
-) -> Union[AnthropicTool, CachePoint]:
+) -> Union[AnthropicTool, Dict]:
     # already in Anthropic tool format
     if is_cache_point(tool):
         return tool

--- a/libs/aws/langchain_aws/function_calling.py
+++ b/libs/aws/langchain_aws/function_calling.py
@@ -203,6 +203,7 @@ class ToolsOutputParser(BaseGenerationOutputParser):
         ]
         return cls_(**tool_call["args"])
 
+
 def convert_to_anthropic_tool(
     tool: Union[Dict[str, Any], TypeBaseModel, Callable, BaseTool],
 ) -> Union[AnthropicTool, Dict]:

--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
@@ -247,9 +247,9 @@ def test_structured_output_streaming() -> None:
 
 def test_tool_use_with_cache_point() -> None:
     """Test toolUse with cachepoint to verify cache metrics are being reported.
-    
-    This test creates tools with a length exceeding 1024 tokens to ensure 
-    caching is triggered, and verifies the response metrics indicate cache 
+
+    This test creates tools with a length exceeding 1024 tokens to ensure
+    caching is triggered, and verifies the response metrics indicate cache
     activity.
     """
     # Define a large number of tools to exceed 1024 tokens
@@ -259,9 +259,9 @@ def test_tool_use_with_cache_point() -> None:
     for i in range(1, 20):
         # Creating a unique class for each tool
         tool_class_name = f"CalculateTool{i}"
-        
+
         # Define the class using a closure to properly scope the fields
-        def create_tool_class(i):
+        def create_tool_class(i: int) -> Type[BaseModel]:
             class ToolClass(BaseModel):
                 number1: float = Field(description=f"First number for calculation {i}")
                 number2: float = Field(description=f"Second number for calculation {i}")
@@ -275,24 +275,23 @@ def test_tool_use_with_cache_point() -> None:
         tool_class = create_tool_class(i)
         tool_class.__name__ = tool_class_name
         tool_classes.append(tool_class)
-    
+
     # Create the model instance
     model = ChatBedrockConverse(
-        model="us.anthropic.claude-3-7-sonnet-20250219-v1:0",
-        temperature=0
+        model="us.anthropic.claude-3-7-sonnet-20250219-v1:0", temperature=0
     )
-    
+
     # Create cache point configuration
     cache_point = ChatBedrockConverse.create_cache_point()
-    
+
     # Bind tools with cache point
     chat = model.bind_tools(tool_classes + [cache_point], tool_choice="any")
-    
+
     # Invocation
     response = chat.invoke("What's 5 + 3?")
     assert isinstance(response, AIMessage)
     assert len(response.tool_calls) == 1
-    
+
     # Verify the response has cache metrics
     assert response.usage_metadata is not None
     input_token_details = response.usage_metadata["input_token_details"]

--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
@@ -243,6 +243,62 @@ def test_structured_output_streaming() -> None:
     assert chunk_count > 1
 
 
+def test_tool_use_with_cache_point() -> None:
+    """Test toolUse with cachepoint to verify cache metrics are being reported.
+    
+    This test creates tools with a length exceeding 1024 tokens to ensure 
+    caching is triggered, and verifies the response metrics indicate cache 
+    activity.
+    """
+    # Define a large number of tools to exceed 1024 tokens
+    tool_classes = []
+
+    # Each tool is simple but we'll define many of them
+    for i in range(1, 20):
+        # Creating a unique class for each tool
+        tool_class_name = f"CalculateTool{i}"
+        
+        # Define the class using a closure to properly scope the fields
+        def create_tool_class(i):
+            class ToolClass(BaseModel):
+                number1: float = Field(description=f"First number for calculation {i}")
+                number2: float = Field(description=f"Second number for calculation {i}")
+                operation: Literal["add", "subtract", "multiply", "divide"] = Field(
+                    description=f"Operation {i} to perform on the numbers"
+                )
+
+            ToolClass.__doc__ = f"A tool to calculate the {i}th mathematical operation"
+            return ToolClass
+
+        tool_class = create_tool_class(i)
+        tool_class.__name__ = tool_class_name
+        tool_classes.append(tool_class)
+    
+    # Create the model instance
+    model = ChatBedrockConverse(
+        model="us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+        temperature=0
+    )
+    
+    # Create cache point configuration
+    cache_point = ChatBedrockConverse.create_cache_point()
+    
+    # Bind tools with cache point
+    chat = model.bind_tools(tool_classes + [cache_point], tool_choice="any")
+    
+    # Invocation
+    response = chat.invoke("What's 5 + 3?")
+    assert isinstance(response, AIMessage)
+    assert len(response.tool_calls) == 1
+    
+    # Verify the response has cache metrics
+    assert response.usage_metadata is not None
+    input_token_details = response.usage_metadata["input_token_details"]
+    cache_read_input_tokens = input_token_details["cache_read"]
+    cache_write_input_tokens = input_token_details["cache_creation"]
+    assert cache_read_input_tokens + cache_write_input_tokens != 0
+
+
 @pytest.mark.skip(reason="Needs guardrails setup to run.")
 def test_guardrails() -> None:
     params = {

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -29,9 +29,7 @@ from langchain_aws.chat_models.bedrock_converse import (
     _snake_to_camel,
     _snake_to_camel_keys,
 )
-from langchain_aws.function_calling import (
-    convert_to_anthropic_tool
-)
+from langchain_aws.function_calling import convert_to_anthropic_tool
 
 
 class TestBedrockStandard(ChatModelUnitTests):
@@ -1075,8 +1073,7 @@ def test__lc_content_to_bedrock_reasoning_content_signature() -> None:
 
 def test__get_provider() -> None:
     llm = ChatBedrockConverse(
-        model="anthropic.claude-3-sonnet-20240229-v1:0",
-        region_name="us-west-2"
+        model="anthropic.claude-3-sonnet-20240229-v1:0", region_name="us-west-2"
     )
 
     assert llm.provider == "anthropic"
@@ -1084,23 +1081,24 @@ def test__get_provider() -> None:
     llm = ChatBedrockConverse(
         model="arn:aws:bedrock:us-west-2::foundation-model/anthropic.claude-3-sonnet-20240229-v1:0",
         provider="anthropic",
-        region_name="us-west-2"
+        region_name="us-west-2",
     )
 
     assert llm.provider == "anthropic"
 
-    with pytest.raises(ValueError,
-                       match="Model provider should be supplied when passing a model ARN as model_id."):
+    with pytest.raises(
+        ValueError,
+        match="Model provider should be supplied when passing a model ARN as model_id.",
+    ):
         ChatBedrockConverse(
             model="arn:aws:bedrock:us-west-2::foundation-model/anthropic.claude-3-sonnet-20240229-v1:0",
-            region_name="us-west-2"
+            region_name="us-west-2",
         )
 
 
 def test__get_base_model() -> None:
     llm_model_only = ChatBedrockConverse(
-        model="anthropic.claude-3-sonnet-20240229-v1:0",
-        region_name="us-west-2"
+        model="anthropic.claude-3-sonnet-20240229-v1:0", region_name="us-west-2"
     )
 
     assert llm_model_only._get_base_model() == "anthropic.claude-3-sonnet-20240229-v1:0"
@@ -1109,10 +1107,13 @@ def test__get_base_model() -> None:
         model="arn:aws:bedrock:us-west-2::foundation-model/anthropic.claude-3-sonnet-20240229-v1:0",
         base_model="anthropic.claude-3-sonnet-20240229-v1:0",
         provider="anthropic",
-        region_name="us-west-2"
+        region_name="us-west-2",
     )
 
-    assert llm_with_base_model._get_base_model() == "anthropic.claude-3-sonnet-20240229-v1:0"
+    assert (
+        llm_with_base_model._get_base_model()
+        == "anthropic.claude-3-sonnet-20240229-v1:0"
+    )
 
 
 @pytest.mark.parametrize(
@@ -1122,70 +1123,70 @@ def test__get_base_model() -> None:
             "arn:aws:bedrock:us-west-2::foundation-model/anthropic.claude-3-sonnet-20240229-v1:0",
             "anthropic.claude-3-sonnet-20240229-v1:0",
             "anthropic",
-            False
+            False,
         ),
         (
             "arn:aws:bedrock:us-west-2::custom-model/anthropic.claude-v2:1/MyModel",
             "anthropic.claude-v2:1",
             "anthropic",
-            "tool_calling"
+            "tool_calling",
         ),
         (
             "arn:aws:bedrock:us-west-2::custom-model/meta.llama3-8b-instruct-v1:0/MyModel",
             "meta.llama3-8b-instruct-v1:0",
             "meta",
-            "tool_calling"
+            "tool_calling",
         ),
         (
             "arn:aws:bedrock:us-west-2::custom-model/meta.llama2-70b-chat-v1/MyModel",
             "meta.llama2-70b-chat-v1",
             "meta",
-            "tool_calling"
+            "tool_calling",
         ),
         (
             "arn:aws:bedrock:us-west-2::custom-model/mistral.mistral-large-2402-v1:0/MyModel",
             "mistral.mistral-large-2402-v1:0",
             "mistral",
-            "tool_calling"
+            "tool_calling",
         ),
         (
             "arn:aws:bedrock:us-west-2::custom-model/cohere.command-r-v1:0/MyModel",
             "cohere.command-r-v1:0",
             "cohere",
-            False
+            False,
         ),
         (
             "arn:aws:bedrock:us-west-2::custom-model/amazon.nova-8b/MyModel",
             "amazon.nova-8b",
             "amazon",
-            True
+            True,
         ),
         (
             "arn:aws:bedrock:us-west-2::custom-model/amazon.titan-text-express-v1/MyModel",
             "amazon.titan-text-express-v1",
             "amazon",
-            "tool_calling"
+            "tool_calling",
         ),
         (
             "arn:aws:sagemaker:us-west-2::endpoint/endpoint-quick-start-xxxxx",
             "deepseek.r1-v1:0",
             "deepseek",
-            "tool_calling"
+            "tool_calling",
         ),
-    ]
+    ],
 )
 def test_disable_streaming_with_arn(
     arn_model_id: str,
     base_model_id: str,
-    provider: str, 
-    expected_disable_streaming: Union[bool, str]
+    provider: str,
+    expected_disable_streaming: Union[bool, str],
 ) -> None:
     """Test that disable_streaming is properly set when base_model is provided."""
     llm = ChatBedrockConverse(
         model=arn_model_id,
         base_model=base_model_id,
         provider=provider,
-        region_name="us-west-2"
+        region_name="us-west-2",
     )
     assert llm.disable_streaming == expected_disable_streaming
 
@@ -1193,7 +1194,7 @@ def test_disable_streaming_with_arn(
 def test_create_cache_point() -> None:
     """Test creating a cache point configuration"""
     cache_point = ChatBedrockConverse.create_cache_point()
-    assert cache_point["cachePoint"]["type"] == "default"    
+    assert cache_point["cachePoint"]["type"] == "default"
 
 
 def test_anthropic_tool_with_cache_point() -> None:
@@ -1205,7 +1206,7 @@ def test_anthropic_tool_with_cache_point() -> None:
     tool_dict = {
         "name": "calculator",
         "description": "A tool that performs calculations",
-        "input_schema": {"properties": {}}
+        "input_schema": {"properties": {}},
     }
     result = convert_to_anthropic_tool(tool_dict)
     assert result["name"] == "calculator"
@@ -1214,18 +1215,16 @@ def test_anthropic_tool_with_cache_point() -> None:
     # Test bind_tools with cache point
     chat_model = ChatBedrockConverse(
         model="us.anthropic.claude-3-7-sonnet-20250219-v1:0", region_name="us-east-1"
-    )  
-    chat_model_with_tools = chat_model.bind_tools(
-        [tool_dict, cache_point]
     )
-    
+    chat_model_with_tools = chat_model.bind_tools([tool_dict, cache_point])
+
     # Verify that both the tool_dict and cache_point are in the tools list
     runnable_binding = cast(RunnableBinding, chat_model_with_tools)
     tools = runnable_binding.kwargs.get("tools", [])
-    
+
     # Assert that we have two tools
     assert len(tools) == 2
-    
+
     # Check that the cache_point was passed through unchanged
     cache_points = [t for t in tools if "cachePoint" in t]
     assert len(cache_points) == 1

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -29,6 +29,10 @@ from langchain_aws.chat_models.bedrock_converse import (
     _snake_to_camel,
     _snake_to_camel_keys,
 )
+from langchain_aws.function_calling import (
+    convert_to_anthropic_tool,
+    is_cache_point,
+)
 
 
 class TestBedrockStandard(ChatModelUnitTests):
@@ -1185,3 +1189,63 @@ def test_disable_streaming_with_arn(
         region_name="us-west-2"
     )
     assert llm.disable_streaming == expected_disable_streaming
+
+
+def test_create_cache_point() -> None:
+    """Test creating a cache point configuration"""
+    cache_point = ChatBedrockConverse.create_cache_point()
+    assert cache_point["cachePoint"]["type"] == "default"    
+
+def test_is_cache_point() -> None:
+    """Test the is_cache_point function for identifying cache point configurations"""
+    # Valid cache points
+    assert is_cache_point({"cachePoint": {"type": "default"}})
+    
+    # Invalid cases
+    assert not is_cache_point({"cachePoint": {}})  # Missing type
+    assert not is_cache_point(
+        {
+            "cachePoint": {"type": "default", "extra": "field"}
+        }
+    )  # Extra field
+    assert not is_cache_point({})  # Empty dict
+    assert not is_cache_point({"other": "value"})  # Wrong key
+    assert not is_cache_point("string")  # Not a dict
+    assert not is_cache_point(None)  # None
+
+
+def test_anthropic_tool_with_cache_point() -> None:
+    """Test convert_to_anthropic_tool with cache point"""
+    # Test with cache point
+    cache_point = {"cachePoint": {"type": "default"}}
+    result = convert_to_anthropic_tool(cache_point)
+    assert result == cache_point
+    
+    # Test with other tool types
+    tool_dict = {
+        "name": "calculator",
+        "description": "A tool that performs calculations",
+        "input_schema": {"properties": {}}
+    }
+    result = convert_to_anthropic_tool(tool_dict)
+    assert result["name"] == "calculator"
+    assert result["description"] == "A tool that performs calculations"
+
+    # Test bind_tools with cache point
+    chat_model = ChatBedrockConverse(
+        model="us.anthropic.claude-3-7-sonnet-20250219-v1:0", region_name="us-east-1"
+    )  
+    chat_model_with_tools = chat_model.bind_tools(
+        [tool_dict, cache_point]
+    )
+    
+    # Verify that both the tool_dict and cache_point are in the tools list
+    runnable_binding = cast(RunnableBinding, chat_model_with_tools)
+    tools = runnable_binding.kwargs.get("tools", [])
+    
+    # Assert that we have two tools
+    assert len(tools) == 2
+    
+    # Check that the cache_point was passed through unchanged
+    cache_points = [t for t in tools if "cachePoint" in t]
+    assert len(cache_points) == 1

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -30,8 +30,7 @@ from langchain_aws.chat_models.bedrock_converse import (
     _snake_to_camel_keys,
 )
 from langchain_aws.function_calling import (
-    convert_to_anthropic_tool,
-    is_cache_point,
+    convert_to_anthropic_tool
 )
 
 
@@ -1196,31 +1195,12 @@ def test_create_cache_point() -> None:
     cache_point = ChatBedrockConverse.create_cache_point()
     assert cache_point["cachePoint"]["type"] == "default"    
 
-def test_is_cache_point() -> None:
-    """Test the is_cache_point function for identifying cache point configurations"""
-    # Valid cache points
-    assert is_cache_point({"cachePoint": {"type": "default"}})
-    
-    # Invalid cases
-    assert not is_cache_point({"cachePoint": {}})  # Missing type
-    assert not is_cache_point(
-        {
-            "cachePoint": {"type": "default", "extra": "field"}
-        }
-    )  # Extra field
-    assert not is_cache_point({})  # Empty dict
-    assert not is_cache_point({"other": "value"})  # Wrong key
-    assert not is_cache_point("string")  # Not a dict
-    assert not is_cache_point(None)  # None
-
 
 def test_anthropic_tool_with_cache_point() -> None:
     """Test convert_to_anthropic_tool with cache point"""
     # Test with cache point
     cache_point = {"cachePoint": {"type": "default"}}
-    result = convert_to_anthropic_tool(cache_point)
-    assert result == cache_point
-    
+
     # Test with other tool types
     tool_dict = {
         "name": "calculator",


### PR DESCRIPTION
1. add prompt caching for tools to bedrock converse api
2. unit tests and integration tests have been added 
3. local run on unit tests and integration tests:

poetry run pytest tests/integration_tests/chat_models/test_bedrock_converse.py::test_tool_use_with_cache_point     
...
tests/integration_tests/chat_models/test_bedrock_converse.py .                                                             [100%]

