### PR TITLE
aws[patch]: support model_kwargs

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -597,7 +597,16 @@ class ChatBedrock(BaseChatModel, BedrockBase):
     def build_extra(cls, values: dict[str, Any]) -> Any:
         """Build extra kwargs from additional params that were passed in."""
         all_required_field_names = get_pydantic_field_names(cls)
+
+        # For backwards compatibility, we don't transfer known parameters out of
+        # model_kwargs
+        model_kwargs = values.pop("model_kwargs", {})
         values = _build_model_kwargs(values, all_required_field_names)
+        if model_kwargs or values.get("model_kwargs", {}):
+            values["model_kwargs"] = {
+                **values.get("model_kwargs", {}),
+                **model_kwargs,
+            }
         return values
 
     @property

--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -38,8 +38,10 @@ from langchain_core.messages.tool import ToolCall, ToolMessage
 from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
 from langchain_core.runnables import Runnable, RunnableMap, RunnablePassthrough
 from langchain_core.tools import BaseTool
+from langchain_core.utils import get_pydantic_field_names
 from langchain_core.utils.function_calling import convert_to_openai_tool
 from langchain_core.utils.pydantic import TypeBaseModel, is_basemodel_subclass
+from langchain_core.utils.utils import _build_model_kwargs
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from langchain_aws.chat_models.bedrock_converse import ChatBedrockConverse
@@ -588,6 +590,14 @@ class ChatBedrock(BaseChatModel, BedrockBase):
 
         if model_id and "beta_use_converse_api" not in values:
             values["beta_use_converse_api"] = "nova" in model_id
+        return values
+
+    @model_validator(mode="before")
+    @classmethod
+    def build_extra(cls, values: dict[str, Any]) -> Any:
+        """Build extra kwargs from additional params that were passed in."""
+        all_required_field_names = get_pydantic_field_names(cls)
+        values = _build_model_kwargs(values, all_required_field_names)
         return values
 
     @property

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -456,9 +456,6 @@ class ChatBedrockConverse(BaseChatModel):
     request_metadata: Optional[Dict[str, str]] = None
     """Key-Value pairs that you can use to filter invocation logs."""
 
-    model_kwargs: dict[str, Any] = Field(default_factory=dict)
-    """Holds any unexpected initialization parameters."""
-
     model_config = ConfigDict(
         extra="forbid",
         populate_by_name=True,
@@ -480,6 +477,17 @@ class ChatBedrockConverse(BaseChatModel):
         """Build extra kwargs from additional params that were passed in."""
         all_required_field_names = get_pydantic_field_names(cls)
         values = _build_model_kwargs(values, all_required_field_names)
+
+        # Merge model_kwargs (name assumed in langchain-core) and
+        # additional_model_request_fields (name used in ChatBedrockConverse)
+        model_kwargs = values.pop("model_kwargs", {})
+        additional_model_request_fields = values.pop(
+            "additional_model_request_fields", {}
+        )
+        if additional_model_request_fields or model_kwargs:
+            values["additional_model_request_fields"] = {
+                **model_kwargs, **additional_model_request_fields
+            }
         return values
 
     @model_validator(mode="before")

--- a/libs/aws/tests/unit_tests/__snapshots__/test_standard.ambr
+++ b/libs/aws/tests/unit_tests/__snapshots__/test_standard.ambr
@@ -17,6 +17,8 @@
       'max_tokens': 100,
       'model_id': 'anthropic.claude-3-sonnet-20240229-v1:0',
       'model_kwargs': dict({
+        'stop': list([
+        ]),
       }),
       'provider_stop_reason_key_map': dict({
         'ai21': 'finishReason',
@@ -33,9 +35,7 @@
         'mistral': 'stop_sequences',
       }),
       'region_name': 'us-east-1',
-      'stop_sequences': list([
-      ]),
-      'temperature': 0.0,
+      'temperature': 0,
     }),
     'lc': 1,
     'name': 'ChatBedrock',

--- a/libs/aws/tests/unit_tests/__snapshots__/test_standard.ambr
+++ b/libs/aws/tests/unit_tests/__snapshots__/test_standard.ambr
@@ -17,8 +17,6 @@
       'max_tokens': 100,
       'model_id': 'anthropic.claude-3-sonnet-20240229-v1:0',
       'model_kwargs': dict({
-        'stop': list([
-        ]),
       }),
       'provider_stop_reason_key_map': dict({
         'ai21': 'finishReason',
@@ -35,7 +33,9 @@
         'mistral': 'stop_sequences',
       }),
       'region_name': 'us-east-1',
-      'temperature': 0,
+      'stop_sequences': list([
+      ]),
+      'temperature': 0.0,
     }),
     'lc': 1,
     'name': 'ChatBedrock',
@@ -57,6 +57,8 @@
         'trace': None,
       }),
       'model_id': 'anthropic.claude-3-sonnet-20240229-v1:0',
+      'model_kwargs': dict({
+      }),
       'provider_stop_reason_key_map': dict({
         'ai21': 'finishReason',
         'amazon': 'completionReason',

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
@@ -801,3 +801,25 @@ def test_chat_prompt_adapter_with_model_detection(model_id, base_model_id, provi
     )
 
     assert expected_format_marker in prompt
+
+
+def test_model_kwargs() -> None:
+    """Test we can transfer unknown params to model_kwargs."""
+    llm = ChatBedrock(
+        model_id="my-model",
+        region_name="us-west-2",
+        model_kwargs={"foo": "bar"},
+    )
+    assert llm.model_id == "my-model"
+    assert llm.region_name == "us-west-2"
+    assert llm.model_kwargs == {"foo": "bar"}
+
+    with pytest.warns(match="transferred to model_kwargs"):
+        llm = ChatBedrock(
+            model_id="my-model",
+            region_name="us-west-2",
+            foo="bar",
+        )
+    assert llm.model_id == "my-model"
+    assert llm.region_name == "us-west-2"
+    assert llm.model_kwargs == {"foo": "bar"}

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
@@ -823,3 +823,14 @@ def test_model_kwargs() -> None:
     assert llm.model_id == "my-model"
     assert llm.region_name == "us-west-2"
     assert llm.model_kwargs == {"foo": "bar"}
+
+    with pytest.warns(match="transferred to model_kwargs"):
+        llm = ChatBedrock(
+            model_id="my-model",
+            region_name="us-west-2",
+            foo="bar",
+            model_kwargs={"baz": "qux"},
+        )
+    assert llm.model_id == "my-model"
+    assert llm.region_name == "us-west-2"
+    assert llm.model_kwargs == {"foo": "bar", "baz": "qux"}

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
@@ -834,3 +834,9 @@ def test_model_kwargs() -> None:
     assert llm.model_id == "my-model"
     assert llm.region_name == "us-west-2"
     assert llm.model_kwargs == {"foo": "bar", "baz": "qux"}
+
+    # For backward compatibility, test that we don't transfer known parameters out
+    # of model_kwargs
+    llm = ChatBedrock(model_id="my-model", model_kwargs={"stop_sequences": ["test"]})
+    assert llm.model_kwargs == {"stop_sequences": ["test"]}
+    assert llm.stop_sequences is None

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
@@ -837,6 +837,10 @@ def test_model_kwargs() -> None:
 
     # For backward compatibility, test that we don't transfer known parameters out
     # of model_kwargs
-    llm = ChatBedrock(model_id="my-model", model_kwargs={"stop_sequences": ["test"]})
+    llm = ChatBedrock(
+        model_id="my-model",
+        region_name="us-west-2",
+        model_kwargs={"stop_sequences": ["test"]},
+    )
     assert llm.model_kwargs == {"stop_sequences": ["test"]}
     assert llm.stop_sequences is None

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -1242,7 +1242,7 @@ def test_model_kwargs() -> None:
     assert llm.model_kwargs == {"foo": "bar"}
 
     with pytest.warns(match="transferred to model_kwargs"):
-        llm = ChatBedrockConverse(
+        llm = ChatBedrockConverse(  # type: ignore[call-arg]
             model="my-model",
             region_name="us-west-2",
             foo="bar",

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -1228,3 +1228,25 @@ def test_anthropic_tool_with_cache_point() -> None:
     # Check that the cache_point was passed through unchanged
     cache_points = [t for t in tools if "cachePoint" in t]
     assert len(cache_points) == 1
+
+
+def test_model_kwargs() -> None:
+    """Test we can transfer unknown params to model_kwargs."""
+    llm = ChatBedrockConverse(
+        model="my-model",
+        region_name="us-west-2",
+        model_kwargs={"foo": "bar"},
+    )
+    assert llm.model_id == "my-model"
+    assert llm.region_name == "us-west-2"
+    assert llm.model_kwargs == {"foo": "bar"}
+
+    with pytest.warns(match="transferred to model_kwargs"):
+        llm = ChatBedrockConverse(
+            model="my-model",
+            region_name="us-west-2",
+            foo="bar",
+        )
+    assert llm.model_id == "my-model"
+    assert llm.region_name == "us-west-2"
+    assert llm.model_kwargs == {"foo": "bar"}

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -1235,11 +1235,11 @@ def test_model_kwargs() -> None:
     llm = ChatBedrockConverse(
         model="my-model",
         region_name="us-west-2",
-        model_kwargs={"foo": "bar"},
+        additional_model_request_fields={"foo": "bar"},
     )
     assert llm.model_id == "my-model"
     assert llm.region_name == "us-west-2"
-    assert llm.model_kwargs == {"foo": "bar"}
+    assert llm.additional_model_request_fields == {"foo": "bar"}
 
     with pytest.warns(match="transferred to model_kwargs"):
         llm = ChatBedrockConverse(  # type: ignore[call-arg]
@@ -1249,4 +1249,15 @@ def test_model_kwargs() -> None:
         )
     assert llm.model_id == "my-model"
     assert llm.region_name == "us-west-2"
-    assert llm.model_kwargs == {"foo": "bar"}
+    assert llm.additional_model_request_fields == {"foo": "bar"}
+
+    with pytest.warns(match="transferred to model_kwargs"):
+        llm = ChatBedrockConverse(  # type: ignore[call-arg]
+            model="my-model",
+            region_name="us-west-2",
+            foo="bar",
+            additional_model_request_fields={"baz": "qux"},
+        )
+    assert llm.model_id == "my-model"
+    assert llm.region_name == "us-west-2"
+    assert llm.additional_model_request_fields == {"foo": "bar", "baz": "qux"}

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -1261,3 +1261,11 @@ def test_model_kwargs() -> None:
     assert llm.model_id == "my-model"
     assert llm.region_name == "us-west-2"
     assert llm.additional_model_request_fields == {"foo": "bar", "baz": "qux"}
+
+    # For backward compatibility, test that we don't transfer known parameters out
+    # of model_kwargs
+    llm = ChatBedrockConverse(
+        model="my-model", additional_model_request_fields={"temperature": 0.2}
+    )
+    assert llm.additional_model_request_fields == {"temperature": 0.2}
+    assert llm.temperature is None

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -1265,7 +1265,9 @@ def test_model_kwargs() -> None:
     # For backward compatibility, test that we don't transfer known parameters out
     # of model_kwargs
     llm = ChatBedrockConverse(
-        model="my-model", additional_model_request_fields={"temperature": 0.2}
+        model="my-model",
+        region_name="us-west-2",
+        additional_model_request_fields={"temperature": 0.2},
     )
     assert llm.additional_model_request_fields == {"temperature": 0.2}
     assert llm.temperature is None


### PR DESCRIPTION
Implement a convenience for initialization that is common to most other LangChat chat models.

Here we catch params on init that are invalid according to Pydantic and store in the `model_kwargs` parameter (or `additional_model_request_fields` in the case of ChatBedrockConverse).

Consider initializing with a param that is not explicitly typed as an attribute:

```python
from langchain_aws import ChatBedrock, ChatBedrockConverse

thinking = {"type": "enabled", "budget_tokens": 2000}  # invalid param

llm_1 = ChatBedrock(
    model="anthropic.claude-3-5-sonnet-20240620-v1:0",
    thinking=thinking,
)
llm_2 = ChatBedrockConverse(
    model="anthropic.claude-3-5-sonnet-20240620-v1:0",
    thinking=thinking,
)
```
Currently, both of the above raise ValidationError.

After this change, ChatBedrock will transfer `thinking` to `model_kwargs`, and ChatBedrockConverse will transfer it to `additional_model_request_fields` (while emitting a warning). Both will include it in request payloads.