### PR TITLE
Correctly handle empty input in ChatBedrock's Anthropic prompt adapter

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -158,9 +158,8 @@ def convert_messages_to_prompt_anthropic(
         return ""
     
     messages = messages.copy()  # don't mutate the original list
-    if messages:
-        if not isinstance(messages[-1], AIMessage):
-            messages.append(AIMessage(content=""))
+    if len(messages) > 0 and not isinstance(messages[-1], AIMessage):
+        messages.append(AIMessage(content=""))
 
     text = "".join(
         _convert_one_message_to_text_anthropic(message, human_prompt, ai_prompt)

--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -154,10 +154,13 @@ def convert_messages_to_prompt_anthropic(
     Returns:
         str: Combined string with necessary human_prompt and ai_prompt tags.
     """
-
+    if messages is None:
+        return ""
+    
     messages = messages.copy()  # don't mutate the original list
-    if not isinstance(messages[-1], AIMessage):
-        messages.append(AIMessage(content=""))
+    if messages:
+        if not isinstance(messages[-1], AIMessage):
+            messages.append(AIMessage(content=""))
 
     text = "".join(
         _convert_one_message_to_text_anthropic(message, human_prompt, ai_prompt)

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
@@ -18,6 +18,7 @@ from langchain_aws.chat_models.bedrock import (
     ChatPromptAdapter,
     _format_anthropic_messages,
     _merge_messages,
+    convert_messages_to_prompt_anthropic
 )
 from langchain_aws.function_calling import convert_to_anthropic_tool
 
@@ -633,6 +634,16 @@ def test__format_anthropic_messages_with_thinking_blocks() -> None:
     actual_system, actual_messages = _format_anthropic_messages(messages)
     assert expected_system == actual_system
     assert expected_messages == actual_messages
+
+
+def test__convert_messages_to_prompt_anthropic_message_is_none() -> None:
+    messages = None
+    assert convert_messages_to_prompt_anthropic(messages) == ""
+
+
+def test__convert_messages_to_prompt_anthropic_message_is_empty() -> None:
+    messages = []
+    assert convert_messages_to_prompt_anthropic(messages) == ""
 
 
 def test__format_anthropic_messages_with_thinking_in_content_blocks() -> None:


### PR DESCRIPTION
Making convert_messages_to_prompt_anthropic work with messages or empty message list