### PR TITLE
rerank: preserve Document-fields

### DIFF
--- a/libs/aws/langchain_aws/document_compressors/rerank.py
+++ b/libs/aws/langchain_aws/document_compressors/rerank.py
@@ -179,7 +179,7 @@ class BedrockRerank(BaseDocumentCompressor):
         compressed = []
         for res in self.rerank(documents, query):
             doc = documents[res["index"]]
-            doc_copy = Document(doc.page_content, metadata=deepcopy(doc.metadata))
+            doc_copy = Document(**doc.model_dump())
             doc_copy.metadata["relevance_score"] = res["relevance_score"]
             compressed.append(doc_copy)
         return compressed

--- a/libs/aws/tests/unit_tests/document_compressors/test_rerank.py
+++ b/libs/aws/tests/unit_tests/document_compressors/test_rerank.py
@@ -51,9 +51,17 @@ def test_compress_documents(mock_rerank: MagicMock, reranker: BedrockRerank) -> 
         {"index": 1, "relevance_score": 0.85},
     ]
 
-    documents = [Document(page_content="Content 1"), Document(page_content="Content 2")]
+    documents = [
+        Document(page_content="Content 1", id="doc1"),
+        Document(page_content="Content 2", id="doc2"),
+    ]
     query = "Relevant query"
     compressed_docs = reranker.compress_documents(documents, query)
+
+    assert compressed_docs[0].id == "doc1"
+    assert compressed_docs[0].page_content == "Content 1"
+    assert compressed_docs[1].id == "doc2"
+    assert compressed_docs[1].page_content == "Content 2"
 
     assert len(compressed_docs) == 2
     assert compressed_docs[0].metadata["relevance_score"] == 0.95


### PR DESCRIPTION
Document(BaseMedia) has at least one more property that is currently dropped: "id". Could also be added explicitly.