### PR TITLE
fix(bedrock): hoist cachePoint blocks out of ToolMessage content to comply with Bedrock API

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -486,7 +486,8 @@ class ChatBedrockConverse(BaseChatModel):
         )
         if additional_model_request_fields or model_kwargs:
             values["additional_model_request_fields"] = {
-                **model_kwargs, **additional_model_request_fields
+                **model_kwargs,
+                **additional_model_request_fields,
             }
         return values
 
@@ -531,7 +532,8 @@ class ChatBedrockConverse(BaseChatModel):
             (
                 provider == "anthropic"
                 and any(
-                    x in model_id_lower for x in ["claude-3", "claude-sonnet-4", "claude-opus-4"]
+                    x in model_id_lower
+                    for x in ["claude-3", "claude-sonnet-4", "claude-opus-4"]
                 )
             )
             or

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -954,14 +954,26 @@ def _messages_to_bedrock(
             else:
                 curr = {"role": "user", "content": []}
 
-            curr["content"].append(
-                {
-                    "toolResult": {
-                        "content": content,
-                        "toolUseId": msg.tool_call_id,
-                        "status": msg.status,
-                    }
-                }
+            tool_result_content = []
+            special_blocks = []
+
+            for block in content:
+                if _is_cache_point(block):
+                    special_blocks.append(block)
+                else:
+                    tool_result_content.append(block)
+
+            curr["content"].extend(
+                [
+                    {
+                        "toolResult": {
+                            "content": tool_result_content,
+                            "toolUseId": msg.tool_call_id,
+                            "status": msg.status,
+                        }
+                    },
+                    *special_blocks,
+                ]
             )
             bedrock_messages.append(curr)
         else:

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -346,6 +346,44 @@ def test__messages_to_bedrock() -> None:
     assert expected_system == actual_system
 
 
+def test_messages_to_bedrock_with_cache_point():
+    messages = [
+        HumanMessage(content=[
+            "Hello!",
+            {"cachePoint": {"type": "default"}}
+        ]),
+        ToolMessage(
+            content=[
+                {"type": "text", "text": "Tool response"},
+                {"cachePoint": {"type": "default"}},
+            ],
+            tool_call_id="tool-123",
+            status="success",
+        ),
+    ]
+
+    actual_messages, actual_system = _messages_to_bedrock(messages)
+    expected_messages = [
+        {
+            "role": "user",
+            "content": [
+                {"text": "Hello!"},
+                {"cachePoint": {"type": "default"}},
+                {
+                    "toolResult": {
+                        "content": [{"text": "Tool response"}],
+                        "status": "success",
+                        "toolUseId": "tool-123",
+                    }
+                },
+                {"cachePoint": {"type": "default"}},
+            ],
+        }
+    ]
+    assert expected_messages == actual_messages
+    assert [] == actual_system
+
+
 def test__bedrock_to_lc() -> None:
     bedrock: List[Dict] = [
         {"text": "text1"},

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -346,12 +346,9 @@ def test__messages_to_bedrock() -> None:
     assert expected_system == actual_system
 
 
-def test_messages_to_bedrock_with_cache_point():
+def test_messages_to_bedrock_with_cache_point() -> None:
     messages = [
-        HumanMessage(content=[
-            "Hello!",
-            {"cachePoint": {"type": "default"}}
-        ]),
+        HumanMessage(content=["Hello!", {"cachePoint": {"type": "default"}}]),
         ToolMessage(
             content=[
                 {"type": "text", "text": "Tool response"},


### PR DESCRIPTION
## What this PR does

Fixes Issue #500: Incorrect nesting of `cachePoint` blocks inside `ToolMessage` causes Bedrock API request validation errors.

### Before (Invalid Bedrock format)

The `cachePoint` block is nested under `toolResult.content`, which is not allowed by Bedrock API:

```json
{
  "role": "user",
  "content": [
    {
      "toolResult": {
        "content": [
          {"text": "Tool response"},
          {"cachePoint": {"type": "default"}}  // ❌ Invalid here!
        ],
        "toolUseId": "xyz",
        "status": "success"
      }
    }
  ]
}
```

### After (Valid Bedrock format)

This PR hoists the `cachePoint` block to be a top-level sibling entry within the message's content array:

```json
{
  "role": "user",
  "content": [
    {
      "toolResult": {
        "content": [
          {"text": "Tool response"}
        ],
        "toolUseId": "xyz",
        "status": "success"
      }
    },
    {
      "cachePoint": {"type": "default"}  // ✅ Valid placement
    }
  ]
}
```

---

## Implementation details

- In `_messages_to_bedrock`, `ToolMessage.content` is split into:
  - `tool_result_content`: Blocks safe to nest under `toolResult` (e.g., text)
  - `special_blocks`: Blocks like `cachePoint` that must be top-level
- Both are placed accordingly in the final Bedrock message structure.

---

## Test coverage

Added `test_messages_to_bedrock_with_cache_point()` in `test_bedrock_converse.py` to validate:
- Proper splitting of blocks
- Correct nesting according to API expectations

---

## Reference

- AWS Bedrock prompt caching spec: https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html#prompt-caching-converse

---

Fixes #500