### PR TITLE
fix(bedrock): Interleave Image Content in ChatPromptAdapter

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -443,7 +443,7 @@ def _format_anthropic_messages(
                     if "type" not in item:
                         raise ValueError("Dict content item must have a type key")
                     elif is_data_content_block(item):
-                        tool_blocks.append(_format_data_content_block(item))
+                        native_blocks.append(_format_data_content_block(item))
                     elif item["type"] == "image_url":
                         # convert format
                         source = _format_image(item["image_url"]["url"])


### PR DESCRIPTION
Fixes Issue: https://github.com/langchain-ai/langchain-aws/issues/501: Inaccurate re-ordering of message content when using ChatPromptAdapter.format_messages

## Description
- Modified `__format_anthropic_messages` in bedrock.py
  - Renamed `text_blocks` to `native_blocks`
  - Insert the image content into `native_blocks` instead of `tool_blocks`

## Testing
- Added test `test__format_anthropic_messages_preserves_content_order`

Ignore that 1st force push, had to re-set my name and email on the commit.

Fixes: #501 