### PR TITLE
bug: Ensure anthropic AIMessages with tool_calls work if their content is not a str

### DIFF
--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
@@ -188,8 +188,8 @@ def test__format_anthropic_messages_with_str_content_and_tool_calls() -> None:
 def test__format_anthropic_messages_with_list_content_and_tool_calls() -> None:
     system = SystemMessage("fuzz")  # type: ignore[misc]
     human = HumanMessage("foo")  # type: ignore[misc]
-    # If content and tool_calls are specified and content is a list, then content is
-    # preferred.
+    # If content and tool_calls are specified and content is a list, both are
+    # included
     ai = AIMessage(  # type: ignore[misc]
         [{"type": "text", "text": "thought"}],
         tool_calls=[{"name": "bar", "id": "1", "args": {"baz": "buzz"}}],
@@ -205,7 +205,15 @@ def test__format_anthropic_messages_with_list_content_and_tool_calls() -> None:
             {"role": "user", "content": "foo"},
             {
                 "role": "assistant",
-                "content": [{"type": "text", "text": "thought"}],
+                "content": [
+                    {"type": "text", "text": "thought"},
+                    {
+                        "type": "tool_use",
+                        "name": "bar",
+                        "id": "1",
+                        "input": {"baz": "buzz"},
+                    },
+                ],
             },
             {
                 "role": "user",


### PR DESCRIPTION
Similar to https://github.com/langchain-ai/langchain-aws/issues/141, ChatBedrock was failing when an AIMessage had a tool_calls defined but whose content was not a str. Have not yet run integration tests but unit tests are passing.

Sample that would previously fail:

```python
import logging

from langchain_aws import ChatBedrock
from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
from langchain_core.tools import tool

@tool
def search_google(query: str) -> str:
    """Search Google for the given query"""
    return "Paris"

llm = ChatBedrock(
    model_id="anthropic.claude-3-5-sonnet-20240620-v1:0",
    temperature=0.1,
    max_tokens=2048,
)

llm_with_tools = llm.bind_tools([search_google])

messages = [
    SystemMessage(content="You are a helpful assistant."),
    HumanMessage(content=[{"type": "text", "text": "What is the capital of France?"}]),
    AIMessage(
        content=[{"type": "text", "text": "Let me look that up for you."}],
        tool_calls=[
            {
                "id": "123",
                "name": "search_google",
                "args": {"query": "What is the capital of France?"},
            }
        ],
    ),
    ToolMessage(tool_call_id="123", content="Paris"),
]

for chunk in llm_with_tools.stream(messages):
    print(chunk.content)
```

Prior to this PR, Bedrock would raise 

```
ValidationException('An error occurred (ValidationException) when calling the InvokeModel operation: messages.2: `tool_result` block(s) provided when previous message does not contain any `tool_use` blocks')
```

Afterwards things work.