### PR TITLE
Change to be able to pass stream param during ainvoke

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -652,7 +652,7 @@ class ChatBedrockConverse(BaseChatModel):
         params = self._converse_params(
             stop=stop,
             **_snake_to_camel_keys(
-                kwargs, excluded_keys={"inputSchema", "properties", "thinking"}
+                kwargs, excluded_keys={"inputSchema", "properties", "thinking", "stream"}
             ),
         )
         logger.debug(f"Input params: {params}")
@@ -676,7 +676,7 @@ class ChatBedrockConverse(BaseChatModel):
         params = self._converse_params(
             stop=stop,
             **_snake_to_camel_keys(
-                kwargs, excluded_keys={"inputSchema", "properties", "thinking"}
+                kwargs, excluded_keys={"inputSchema", "properties", "thinking", "stream"}
             ),
         )
         response = self.client.converse_stream(


### PR DESCRIPTION
I want to be able to control whether to stream or not using ainvoke method. 
However, current code gives following error - 

ChatBedrockConverse._converse_params() got an unexpected keyword argument 'stream'

Hence, adding a check to ignore stream param.