### PR TITLE
Fix the last commit as it was not removing the stream parameter.

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -652,7 +652,7 @@ class ChatBedrockConverse(BaseChatModel):
         params = self._converse_params(
             stop=stop,
             **_snake_to_camel_keys(
-                kwargs, excluded_keys={"inputSchema", "properties", "thinking", "stream"}
+                kwargs, excluded_keys={"inputSchema", "properties", "thinking"}
             ),
         )
         logger.debug(f"Input params: {params}")
@@ -676,7 +676,7 @@ class ChatBedrockConverse(BaseChatModel):
         params = self._converse_params(
             stop=stop,
             **_snake_to_camel_keys(
-                kwargs, excluded_keys={"inputSchema", "properties", "thinking", "stream"}
+                kwargs, excluded_keys={"inputSchema", "properties", "thinking"}
             ),
         )
         response = self.client.converse_stream(
@@ -856,6 +856,7 @@ class ChatBedrockConverse(BaseChatModel):
         guardrailConfig: Optional[dict] = None,
         performanceConfig: Optional[Mapping[str, Any]] = None,
         requestMetadata: Optional[dict] = None,
+        stream: Optional[bool] = True,
     ) -> Dict[str, Any]:
         if not inferenceConfig:
             inferenceConfig = {


### PR DESCRIPTION
Misunderstood the exclude_keys part as its not removing the stream key from kwargs. Hence adding stream as parameter to _converse_params function to pass the pydantic check.
Now, tested it and works as expected.