### PR TITLE
Fix acronym casing for PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 This monorepo provides LangChain and LangGraph components for various AWS services. It aims to replace and expand upon the existing LangChain AWS components found in the `langchain-community` package in the LangChain repository.
 
 The following packages are hosted in this repository:
-- `langchain-aws` ([PyPi](https://pypi.org/project/langchain-aws/))
-- `langgraph-checkpoint-aws` ([PyPi](https://pypi.org/project/langgraph-checkpoint-aws/))
+- `langchain-aws` ([PyPI](https://pypi.org/project/langchain-aws/))
+- `langgraph-checkpoint-aws` ([PyPI](https://pypi.org/project/langgraph-checkpoint-aws/))
 
 ## Features
 


### PR DESCRIPTION
This PR fixes incorrect casing for PyPI (Python Package Index) and makes it consistent with the other uses within the README.