### PR TITLE
Update base.py on redis-py index definition path

### DIFF
--- a/libs/aws/langchain_aws/vectorstores/inmemorydb/base.py
+++ b/libs/aws/langchain_aws/vectorstores/inmemorydb/base.py
@@ -1192,7 +1192,7 @@ class InMemoryVectorStore(VectorStore):
 
     def _create_index_if_not_exist(self, dim: int = 1536) -> None:
         try:
-            from redis.commands.search.indexDefinition import (  # type: ignore
+            from redis.commands.search.index_definition import (  # type: ignore
                 IndexDefinition,
                 IndexType,
             )


### PR DESCRIPTION
In latest version of redis-py 6.2, it is using this path `index_definition` instead of `indexDefinition` from https://github.com/redis/redis-py/blob/513c8d0f61460ef690d3218805e9a4a2ee675af9/redis/commands/search/index_definition.py#L11

This has been tested with Python 3.12.10 with Redis 6.2.0