### PR TITLE
Add citation support #537

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -1378,13 +1378,25 @@ def _bedrock_to_lc(content: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
                             },
                         }
                     )
+        elif "citations_content" in block:
+            citations_dict = block.get("citations_content", {})
+            content_items = citations_dict.get("content", [])
+            citations = citations_dict.get("citations", [])
+
+            for content_item in content_items:
+                if "text" in content_item:
+                    text_block = {"type": "text", "text": content_item["text"]}
+                    if citations:
+                        # Preserve original Bedrock citations format
+                        text_block["citations"] = citations
+                    lc_content.append(text_block)
 
         else:
             raise ValueError(
                 "Unexpected content block type in content. Expected to have one of "
                 "'text', 'tool_use', 'image', 'video, 'document', 'tool_result',"
                 "'json', 'guard_content', or "
-                "'reasoning_content' keys. Received:\n\n{block}"
+                f"'reasoning_content' keys. Received:\n\n{block}"
             )
     return lc_content
 


### PR DESCRIPTION
Add citation support. [Here](https://python.langchain.com/docs/integrations/chat/anthropic/#simple-example) is an example using langchain_anthropic.

```py
from langchain_core.messages import HumanMessage, SystemMessage
from langchain_aws import ChatBedrockConverse

llm = ChatBedrockConverse(
    model="eu.anthropic.claude-3-7-sonnet-20250219-v1:0",
    max_tokens=1000,
    temperature=0.1,
)

response = llm.invoke(
    input=[
        HumanMessage(
            content=[
                {
                    "type": "document",
                    "document": {
                        "format": "txt",
                        "source": {
                            "text": "The grass is green. The sky is blue."
                        },
                        "name": "My Document",
                        'context': 'This is a trustworthy document.',
                        "citations": {"enabled": True},
                    },
                },
                {"type": "text", "text": "What color is the grass and sky?"},
            ]
        ),
    ],
)

response.content
```

This results in a Validation

```
ValueError: Unexpected content block type in content. Expected to have one of 'text', 'tool_use', 'image', 'video, 'document', 'tool_result','json', 'guard_content', 'reasoning_content', or 'citations_content' keys. Received:
{'citations_content': {'content': [{'text': 'The grass is green.'}], 'citations': [{'title': 'My Document', 'source_content': [{'text': 'The grass is green. '}], 'location': {'document_char': {'document_index': 0, 'start': 0, 'end': 20}}}]}}
```

with the incoming changes the `citations` list is preserved as I believe langchain_anthropic [does](https://github.com/langchain-ai/langchain/blob/ad44f0688b1cc0809e526b9bf1ff68127aee8d48/libs/partners/anthropic/langchain_anthropic/chat_models.py#L2150)
