### PR TITLE
Update `langgraph-checkpoint-aws` to support LangGraph 0.5.x

### DIFF
--- a/libs/langgraph-checkpoint-aws/README.md
+++ b/libs/langgraph-checkpoint-aws/README.md
@@ -22,8 +22,8 @@ poetry add langgraph-checkpoint-aws
 ## Requirements
 ```text
 Python >=3.9
-langgraph-checkpoint >=2.0.0
-langgraph >=0.2.55
+langgraph-checkpoint >=2.1.0
+langgraph >=0.5.3
 boto3 >=1.37.3
 ```
 

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/utils.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/utils.py
@@ -150,7 +150,6 @@ def construct_checkpoint_tuple(
     checkpoint_ns: str,
     session_checkpoint: SessionCheckpoint,
     pending_writes: list[SessionPendingWrite],
-    sends: list,
     serde: SerializerProtocol,
 ) -> CheckpointTuple:
     """Construct checkpoint tuple from components.
@@ -160,7 +159,6 @@ def construct_checkpoint_tuple(
         checkpoint_ns: Checkpoint namespace
         session_checkpoint: Checkpoint payload data
         pending_writes: List of pending write operations
-        sends: List of task sends
         serde: Protocol for serialization and deserialization of objects
 
     Returns:
@@ -178,7 +176,6 @@ def construct_checkpoint_tuple(
             Checkpoint,
             {
                 **deserialize_from_base64(serde, *session_checkpoint.checkpoint),
-                "pending_sends": [serde.loads_typed(s[2]) for s in sends],
                 "channel_values": deserialize_from_base64(
                     serde, *session_checkpoint.channel_values
                 ),
@@ -260,9 +257,6 @@ def create_session_checkpoint(
     """
     # Create copy to avoid modifying original checkpoint
     checkpoint_copy = checkpoint.copy()
-
-    # Remove pending sends as they are handled separately
-    checkpoint_copy.pop("pending_sends")
 
     # Extract required config values
     thread_id = config["configurable"]["thread_id"]

--- a/libs/langgraph-checkpoint-aws/poetry.lock
+++ b/libs/langgraph-checkpoint-aws/poetry.lock
@@ -575,21 +575,21 @@ typing-extensions = ">=4.7"
 
 [[package]]
 name = "langgraph"
-version = "0.4.8"
+version = "0.5.4"
 description = "Building stateful, multi-actor applications with LLMs"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "langgraph-0.4.8-py3-none-any.whl", hash = "sha256:273b02782669a474ba55ef4296607ac3bac9e93639d37edc0d32d8cf1a41a45b"},
-    {file = "langgraph-0.4.8.tar.gz", hash = "sha256:48445ac8a351b7bdc6dee94e2e6a597f8582e0516ebd9dea0fd0164ae01b915e"},
+    {file = "langgraph-0.5.4-py3-none-any.whl", hash = "sha256:7122840225623e081be24ac30a691a24e5dac4c0361f593208f912838192d7f6"},
+    {file = "langgraph-0.5.4.tar.gz", hash = "sha256:ab8f6b7b9c50fd2ae35a2efb072fbbfe79500dfc18071ac4ba6f5de5fa181931"},
 ]
 
 [package.dependencies]
 langchain-core = ">=0.1"
-langgraph-checkpoint = ">=2.0.26"
-langgraph-prebuilt = ">=0.2.0"
-langgraph-sdk = ">=0.1.42"
+langgraph-checkpoint = ">=2.1.0,<3.0.0"
+langgraph-prebuilt = ">=0.5.0,<0.6.0"
+langgraph-sdk = ">=0.1.42,<0.2.0"
 pydantic = ">=2.7.4"
 xxhash = ">=3.5.0"
 
@@ -611,19 +611,19 @@ ormsgpack = ">=1.10.0"
 
 [[package]]
 name = "langgraph-prebuilt"
-version = "0.2.2"
+version = "0.5.1"
 description = "Library with high-level APIs for creating and executing LangGraph agents and tools."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "langgraph_prebuilt-0.2.2-py3-none-any.whl", hash = "sha256:72de5ef1d969a8f02ad7adc7cc1915bb9b4467912d57ba60da34b5a70fdad1f6"},
-    {file = "langgraph_prebuilt-0.2.2.tar.gz", hash = "sha256:0a5d1f651f97c848cd1c3dd0ef017614f47ee74effb7375b59ac639e41b253f9"},
+    {file = "langgraph_prebuilt-0.5.1-py3-none-any.whl", hash = "sha256:60a752c62a954fab816e9047e1dd05df8f2fabbdf59e1c745d9e2f700202662f"},
+    {file = "langgraph_prebuilt-0.5.1.tar.gz", hash = "sha256:43a361612b8fb9784338bfc481245e3422ca366ca8e43f68c4c6723d7eb8b9f4"},
 ]
 
 [package.dependencies]
 langchain-core = ">=0.3.22"
-langgraph-checkpoint = ">=2.0.10"
+langgraph-checkpoint = ">=2.1.0"
 
 [[package]]
 name = "langgraph-sdk"
@@ -1785,4 +1785,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "ec4602a5086ce90702d1b44800851a755d5ecd64973d1d4d0164c1d50f030967"
+content-hash = "c08cbfef87ee4b434348e470bd25cc3a48a232d4c2592fce2d3b134fade93c27"

--- a/libs/langgraph-checkpoint-aws/pyproject.toml
+++ b/libs/langgraph-checkpoint-aws/pyproject.toml
@@ -17,8 +17,8 @@ keywords = ["aws", "bedrock", "langchain", "langgraph", "checkpointer"]
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-langgraph-checkpoint = ">=2.0.0"
-langgraph = ">=0.2.55"
+langgraph-checkpoint = ">=2.1.0"
+langgraph = ">=0.5.3"
 boto3 = ">=1.37.3"
 
 [tool.poetry.group.dev]

--- a/libs/langgraph-checkpoint-aws/tests/integration_tests/saver/test_saver.py
+++ b/libs/langgraph-checkpoint-aws/tests/integration_tests/saver/test_saver.py
@@ -61,9 +61,8 @@ class TestBedrockMemorySaver:
             channel_values={"key": "value"},
             channel_versions={},
             versions_seen={},
-            pending_sends=[],
         )
-        checkpoint_metadata = {"source": "input", "step": 1, "writes": {"key": "value"}}
+        checkpoint_metadata = {"source": "input", "step": 1}
 
         try:
             saved_config = session_saver.put(

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/conftest.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/conftest.py
@@ -252,7 +252,6 @@ def sample_checkpoint(sample_timestamp):
             "node1": {"default": "v1", "tasks": "v2"},
             "node2": {"results": "v1"},
         },
-        pending_sends=[],
     )
 
 
@@ -261,7 +260,6 @@ def sample_checkpoint_metadata(sample_timestamp):
     return CheckpointMetadata(
         source="input",
         step=-1,
-        writes={"node1": ["write1", "write2"], "node2": {"key": "value"}},
         parents={
             "namespace1": "parent_checkpoint_1",
             "namespace2": "parent_checkpoint_2",

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/test_saver.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/test_saver.py
@@ -440,58 +440,6 @@ class TestBedrockSessionSaver:
         )
         mock_boto_client.get_invocation_step.assert_not_called()
 
-    def test__get_task_sends_without_parent_checkpoint_id(
-        self, session_saver, sample_session_checkpoint
-    ):
-        # Arrange
-        thread_id = "test_thread_id"
-        checkpoint_ns = "test_namespace"
-
-        # Act
-        result = session_saver._get_task_sends(thread_id, checkpoint_ns, None)
-
-        # Assert
-        assert result == []
-
-    def test__get_task_sends(
-        self, session_saver, sample_session_pending_write_with_sends
-    ):
-        # Arrange
-        thread_id = "test_thread_id"
-        checkpoint_ns = "test_namespace"
-        parent_checkpoint_id = "test_parent_checkpoint_id"
-
-        session_saver._get_checkpoint_pending_writes = Mock(
-            return_value=sample_session_pending_write_with_sends
-        )
-
-        # Act
-        result = session_saver._get_task_sends(
-            thread_id, checkpoint_ns, parent_checkpoint_id
-        )
-
-        # Assert
-        assert result == [
-            ["2", "__pregel_tasks", ["json", b"eyJrMiI6ICJ2MiJ9"], "/test2/path2", 1],
-            ["3", "__pregel_tasks", ["json", b"eyJrMyI6ICJ2MyJ9"], "/test3/path3", 1],
-        ]
-
-    def test__get_task_sends_empty(self, session_saver):
-        # Arrange
-        thread_id = "test_thread_id"
-        checkpoint_ns = "test_namespace"
-        parent_checkpoint_id = "test_parent_checkpoint_id"
-
-        session_saver._get_checkpoint_pending_writes = Mock(return_value=[])
-
-        # Act
-        result = session_saver._get_task_sends(
-            thread_id, checkpoint_ns, parent_checkpoint_id
-        )
-
-        # Assert
-        assert result == []
-
     @patch("langgraph_checkpoint_aws.saver.construct_checkpoint_tuple")
     def test_get_tuple_success(
         self,
@@ -517,7 +465,6 @@ class TestBedrockSessionSaver:
         session_saver._get_checkpoint_pending_writes = Mock(
             return_value=sample_session_pending_write_with_sends
         )
-        session_saver._get_task_sends = Mock(return_value=[])
         mock_construct_checkpoint.return_value = Mock(spec=CheckpointTuple)
 
         # Act
@@ -730,7 +677,6 @@ class TestBedrockSessionSaver:
             )
         )
         session_saver._get_checkpoint_pending_writes = Mock(return_value=[])
-        session_saver._get_task_sends = Mock(return_value=[])
         mock_construct_checkpoint.return_value = Mock(spec=CheckpointTuple)
 
         # Act
@@ -801,7 +747,6 @@ class TestBedrockSessionSaver:
             )
         )
         session_saver._get_checkpoint_pending_writes = Mock(return_value=[])
-        session_saver._get_task_sends = Mock(return_value=[])
         mock_construct_checkpoint.return_value = Mock(spec=CheckpointTuple)
 
         # Act
@@ -836,7 +781,6 @@ class TestBedrockSessionSaver:
             )
         )
         session_saver._get_checkpoint_pending_writes = Mock(return_value=[])
-        session_saver._get_task_sends = Mock(return_value=[])
         session_saver._construct_checkpoint_tuple = Mock(
             return_value=Mock(spec=CheckpointTuple)
         )

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/test_utils.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/test_utils.py
@@ -118,7 +118,6 @@ class TestUtils:
             checkpoint_ns,
             sample_session_checkpoint,
             [sample_session_pending_write],
-            [],
             serde,
         )
 


### PR DESCRIPTION
Fixes #546 

This PR addresses incompatibilities of `langgraph-checkpoint-aws` with LangGraph 0.5.x:
- Removed all usage of deprecated Checkpoint attributes:
  - `Checkpoint.pending_sends`: https://github.com/langchain-ai/langgraph/pull/4820
  - `CheckpointMetadata.writes`: https://github.com/langchain-ai/langgraph/pull/4822
- Bumped minimum requirement to `langgraph>=0.5.3`.
