### PR TITLE
Support prompt caching on system messages

### DIFF
--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
@@ -296,7 +296,14 @@ def test__format_anthropic_messages_with_cache_control() -> None:
     )
     messages = [system, human]
     expected = (
-        "fuzzbar",
+        [
+            {
+                "type": "text",
+                "text": "fuzz",
+                "cache_control": {"type": "ephemeral"},
+            },
+            {"type": "text", "text": "bar"},
+        ],
         [
             {
                 "role": "user",
@@ -308,6 +315,30 @@ def test__format_anthropic_messages_with_cache_control() -> None:
                     }
                 ],
             },
+        ],
+    )
+
+    actual = _format_anthropic_messages(messages)
+    assert expected == actual
+
+
+def test__format_anthropic_messages_system_message_list_content() -> None:
+    """Test that system messages with list content return as list of content blocks"""
+    system = SystemMessage(
+        [
+            {"type": "text", "text": "You are a helpful assistant."},
+            {"type": "text", "text": "Additional instructions here."},
+        ],
+    )
+    human = HumanMessage("Hello!")
+    messages = [system, human]
+    expected = (
+        [
+            {"type": "text", "text": "You are a helpful assistant."},
+            {"type": "text", "text": "Additional instructions here."},
+        ],
+        [
+            {"role": "user", "content": "Hello!"},
         ],
     )
 


### PR DESCRIPTION
Prompt caching was initially added [here](https://github.com/langchain-ai/langchain-aws/commit/0067b861a47af295683e101c98f9f6719f514728#diff-78c2abdea066a69391d4a156ea3d401a6fec2cb8ea8f578e2d42e7888a615d7c) but seems like it wasn't supported on system messages at that time. It is now!

https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching#large-context-caching-example


This PR preserves `SystemMessage` content as a list of blocks rather than converting it into a single concatenated string.  This will make sure the caching param is retained.

