### PR TITLE
Add Support for GuardRailConverseContentBlock

### DIFF
--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -1319,7 +1319,7 @@ def _create_mock_llm_guard_last_turn_only() -> (
         model="anthropic.claude-3-sonnet-20240229-v1:0",
         region_name="us-west-2",
         guard_last_turn_only=True,
-        guardrail_config={"guardrailId": "dummy-guardrail", "guardrailVersion": "1"},
+        guardrails={"guardrailId": "dummy-guardrail", "guardrailVersion": "1"},
     )
     return llm, mocked_client
 


### PR DESCRIPTION
We introduce a new flag, guard_last_turn_only, which applies the selective guardrail for only the last user message. For advanced use cases, we also allow the dev to pass in raw (Bedrock) message blocks.

Issue Link: https://github.com/langchain-ai/langchain-aws/issues/540