### PR TITLE
Fix: Bedrock Application Inference Profile (AIP) is not streaming response with ChatBedrockConverse

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -505,7 +505,7 @@ class ChatBedrockConverse(BaseChatModel):
         return values
 
     @classmethod
-    def _get_streaming_support(cls, provider: str, model_id_lower: str) -> bool | str:
+    def _get_streaming_support(cls, provider: str, model_id_lower: str) -> Union[bool, str]:
         """Determine streaming support for a given provider and model.
         
         Returns:

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -1383,3 +1383,192 @@ def test_stream_guard_last_turn_only() -> None:
     assert bedrock_msgs[-1]["content"][0] == {
         "guardContent": {"text": {"text": "How are you?"}}
     }
+
+@mock.patch("langchain_aws.chat_models.bedrock_converse.create_aws_client")
+def test_bedrock_client_creation(mock_create_client) -> None:
+    """Test that bedrock_client is created during validation."""
+    mock_bedrock_client = mock.Mock()
+    mock_runtime_client = mock.Mock()
+    
+    def side_effect(service_name, **kwargs):
+        if service_name == "bedrock":
+            return mock_bedrock_client
+        elif service_name == "bedrock-runtime":
+            return mock_runtime_client
+        return mock.Mock()
+    
+    mock_create_client.side_effect = side_effect
+    
+    chat_model = ChatBedrockConverse(
+        model="anthropic.claude-3-sonnet-20240229-v1:0",
+        region_name="us-west-2"
+    )
+    
+    assert chat_model.bedrock_client == mock_bedrock_client
+    assert chat_model.client == mock_runtime_client
+    assert mock_create_client.call_count == 2
+
+
+@mock.patch("langchain_aws.chat_models.bedrock_converse.create_aws_client")
+def test_get_base_model_with_application_inference_profile(mock_create_client) -> None:
+    """Test _get_base_model method with application inference profile."""
+    mock_bedrock_client = mock.Mock()
+    mock_runtime_client = mock.Mock()
+    
+    # Mock the get_inference_profile response
+    mock_bedrock_client.get_inference_profile.return_value = {
+        'models': [
+            {
+                'modelArn': 'arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-sonnet-20240229-v1:0'
+            }
+        ]
+    }
+    
+    def side_effect(service_name, **kwargs):
+        if service_name == "bedrock":
+            return mock_bedrock_client
+        elif service_name == "bedrock-runtime":
+            return mock_runtime_client
+        return mock.Mock()
+    
+    mock_create_client.side_effect = side_effect
+    
+    chat_model = ChatBedrockConverse(
+        model="arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/test-profile",
+        region_name="us-west-2",
+        provider="anthropic"
+    )
+    
+    base_model = chat_model._get_base_model()
+    assert base_model == "anthropic.claude-3-sonnet-20240229-v1:0"
+    mock_bedrock_client.get_inference_profile.assert_called_once_with(
+        inferenceProfileIdentifier="arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/test-profile"
+    )
+
+
+@mock.patch("langchain_aws.chat_models.bedrock_converse.create_aws_client")
+def test_get_base_model_without_application_inference_profile(mock_create_client) -> None:
+    """Test _get_base_model method without application inference profile."""
+    mock_bedrock_client = mock.Mock()
+    mock_runtime_client = mock.Mock()
+    
+    def side_effect(service_name, **kwargs):
+        if service_name == "bedrock":
+            return mock_bedrock_client
+        elif service_name == "bedrock-runtime":
+            return mock_runtime_client
+        return mock.Mock()
+    
+    mock_create_client.side_effect = side_effect
+    
+    chat_model = ChatBedrockConverse(
+        model="anthropic.claude-3-sonnet-20240229-v1:0",
+        region_name="us-west-2",
+        provider="anthropic"
+    )
+    
+    base_model = chat_model._get_base_model()
+    assert base_model == "anthropic.claude-3-sonnet-20240229-v1:0"
+    mock_bedrock_client.get_inference_profile.assert_not_called()
+
+
+@mock.patch("langchain_aws.chat_models.bedrock_converse.create_aws_client")
+def test_configure_streaming_for_resolved_model(mock_create_client) -> None:
+    """Test _configure_streaming_for_resolved_model method."""
+    mock_bedrock_client = mock.Mock()
+    mock_runtime_client = mock.Mock()
+    
+    # Mock the get_inference_profile response for a model with full streaming support
+    mock_bedrock_client.get_inference_profile.return_value = {
+        'models': [
+            {
+                'modelArn': 'arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-sonnet-20240229-v1:0'
+            }
+        ]
+    }
+    
+    def side_effect(service_name, **kwargs):
+        if service_name == "bedrock":
+            return mock_bedrock_client
+        elif service_name == "bedrock-runtime":
+            return mock_runtime_client
+        return mock.Mock()
+    
+    mock_create_client.side_effect = side_effect
+    
+    chat_model = ChatBedrockConverse(
+        model="arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/test-profile",
+        region_name="us-west-2",
+        provider="anthropic"
+    )
+    
+    # The streaming should be configured based on the resolved model
+    assert chat_model.disable_streaming is False
+
+
+@mock.patch("langchain_aws.chat_models.bedrock_converse.create_aws_client")
+def test_configure_streaming_for_resolved_model_no_tools(mock_create_client) -> None:
+    """Test _configure_streaming_for_resolved_model method with no-tools streaming."""
+    mock_bedrock_client = mock.Mock()
+    mock_runtime_client = mock.Mock()
+    
+    # Mock the get_inference_profile response for a model with no-tools streaming support
+    mock_bedrock_client.get_inference_profile.return_value = {
+        'models': [
+            {
+                'modelArn': 'arn:aws:bedrock:us-east-1::foundation-model/amazon.titan-text-express-v1'
+            }
+        ]
+    }
+    
+    def side_effect(service_name, **kwargs):
+        if service_name == "bedrock":
+            return mock_bedrock_client
+        elif service_name == "bedrock-runtime":
+            return mock_runtime_client
+        return mock.Mock()
+    
+    mock_create_client.side_effect = side_effect
+    
+    chat_model = ChatBedrockConverse(
+        model="arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/test-profile",
+        region_name="us-west-2",
+        provider="amazon"
+    )
+    
+    # The streaming should be configured as "tool_calling" for no-tools models
+    assert chat_model.disable_streaming == "tool_calling"
+
+
+@mock.patch("langchain_aws.chat_models.bedrock_converse.create_aws_client")
+def test_configure_streaming_for_resolved_model_no_streaming(mock_create_client) -> None:
+    """Test _configure_streaming_for_resolved_model method with no streaming support."""
+    mock_bedrock_client = mock.Mock()
+    mock_runtime_client = mock.Mock()
+    
+    # Mock the get_inference_profile response for a model with no streaming support
+    mock_bedrock_client.get_inference_profile.return_value = {
+        'models': [
+            {
+                'modelArn': 'arn:aws:bedrock:us-east-1::foundation-model/stability.stable-image-core-v1:0'
+            }
+        ]
+    }
+    
+    def side_effect(service_name, **kwargs):
+        if service_name == "bedrock":
+            return mock_bedrock_client
+        elif service_name == "bedrock-runtime":
+            return mock_runtime_client
+        return mock.Mock()
+    
+    mock_create_client.side_effect = side_effect
+    
+    chat_model = ChatBedrockConverse(
+        model="arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/test-profile",
+        region_name="us-west-2",
+        provider="stability"
+    )
+    
+    # The streaming should be disabled for models with no streaming support
+    assert chat_model.disable_streaming is True

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -1385,12 +1385,12 @@ def test_stream_guard_last_turn_only() -> None:
     }
 
 @mock.patch("langchain_aws.chat_models.bedrock_converse.create_aws_client")
-def test_bedrock_client_creation(mock_create_client) -> None:
+def test_bedrock_client_creation(mock_create_client: mock.Mock) -> None:
     """Test that bedrock_client is created during validation."""
     mock_bedrock_client = mock.Mock()
     mock_runtime_client = mock.Mock()
     
-    def side_effect(service_name, **kwargs):
+    def side_effect(service_name: str, **kwargs: Any) -> mock.Mock:
         if service_name == "bedrock":
             return mock_bedrock_client
         elif service_name == "bedrock-runtime":
@@ -1410,7 +1410,7 @@ def test_bedrock_client_creation(mock_create_client) -> None:
 
 
 @mock.patch("langchain_aws.chat_models.bedrock_converse.create_aws_client")
-def test_get_base_model_with_application_inference_profile(mock_create_client) -> None:
+def test_get_base_model_with_application_inference_profile(mock_create_client: mock.Mock) -> None:
     """Test _get_base_model method with application inference profile."""
     mock_bedrock_client = mock.Mock()
     mock_runtime_client = mock.Mock()
@@ -1424,7 +1424,7 @@ def test_get_base_model_with_application_inference_profile(mock_create_client) -
         ]
     }
     
-    def side_effect(service_name, **kwargs):
+    def side_effect(service_name: str, **kwargs: Any) -> mock.Mock:
         if service_name == "bedrock":
             return mock_bedrock_client
         elif service_name == "bedrock-runtime":
@@ -1447,12 +1447,12 @@ def test_get_base_model_with_application_inference_profile(mock_create_client) -
 
 
 @mock.patch("langchain_aws.chat_models.bedrock_converse.create_aws_client")
-def test_get_base_model_without_application_inference_profile(mock_create_client) -> None:
+def test_get_base_model_without_application_inference_profile(mock_create_client: mock.Mock) -> None:
     """Test _get_base_model method without application inference profile."""
     mock_bedrock_client = mock.Mock()
     mock_runtime_client = mock.Mock()
     
-    def side_effect(service_name, **kwargs):
+    def side_effect(service_name: str, **kwargs: Any) -> mock.Mock:
         if service_name == "bedrock":
             return mock_bedrock_client
         elif service_name == "bedrock-runtime":
@@ -1473,7 +1473,7 @@ def test_get_base_model_without_application_inference_profile(mock_create_client
 
 
 @mock.patch("langchain_aws.chat_models.bedrock_converse.create_aws_client")
-def test_configure_streaming_for_resolved_model(mock_create_client) -> None:
+def test_configure_streaming_for_resolved_model(mock_create_client: mock.Mock) -> None:
     """Test _configure_streaming_for_resolved_model method."""
     mock_bedrock_client = mock.Mock()
     mock_runtime_client = mock.Mock()
@@ -1487,7 +1487,7 @@ def test_configure_streaming_for_resolved_model(mock_create_client) -> None:
         ]
     }
     
-    def side_effect(service_name, **kwargs):
+    def side_effect(service_name: str, **kwargs: Any) -> mock.Mock:
         if service_name == "bedrock":
             return mock_bedrock_client
         elif service_name == "bedrock-runtime":
@@ -1507,7 +1507,7 @@ def test_configure_streaming_for_resolved_model(mock_create_client) -> None:
 
 
 @mock.patch("langchain_aws.chat_models.bedrock_converse.create_aws_client")
-def test_configure_streaming_for_resolved_model_no_tools(mock_create_client) -> None:
+def test_configure_streaming_for_resolved_model_no_tools(mock_create_client: mock.Mock) -> None:
     """Test _configure_streaming_for_resolved_model method with no-tools streaming."""
     mock_bedrock_client = mock.Mock()
     mock_runtime_client = mock.Mock()
@@ -1521,7 +1521,7 @@ def test_configure_streaming_for_resolved_model_no_tools(mock_create_client) -> 
         ]
     }
     
-    def side_effect(service_name, **kwargs):
+    def side_effect(service_name: str, **kwargs: Any) -> mock.Mock:
         if service_name == "bedrock":
             return mock_bedrock_client
         elif service_name == "bedrock-runtime":
@@ -1541,7 +1541,7 @@ def test_configure_streaming_for_resolved_model_no_tools(mock_create_client) -> 
 
 
 @mock.patch("langchain_aws.chat_models.bedrock_converse.create_aws_client")
-def test_configure_streaming_for_resolved_model_no_streaming(mock_create_client) -> None:
+def test_configure_streaming_for_resolved_model_no_streaming(mock_create_client: mock.Mock) -> None:
     """Test _configure_streaming_for_resolved_model method with no streaming support."""
     mock_bedrock_client = mock.Mock()
     mock_runtime_client = mock.Mock()
@@ -1555,7 +1555,7 @@ def test_configure_streaming_for_resolved_model_no_streaming(mock_create_client)
         ]
     }
     
-    def side_effect(service_name, **kwargs):
+    def side_effect(service_name: str, **kwargs: Any) -> mock.Mock:
         if service_name == "bedrock":
             return mock_bedrock_client
         elif service_name == "bedrock-runtime":


### PR DESCRIPTION
### Description

This PR fixed the streaming issue with ChatBedrockConverse when input is Application Inference Profile (AIP). The issue happened because langchain-aws fails to identify the foundation model used in AIP (e.g., `arn:aws:bedrock:us-east-1:111111484058:application-inference-profile/c3myu2h6fllr`), therefore, it cannot set the streaming_support flag for the AIP correctly. So the entire response was returned to user as a whole rather than streaming the response back. 

### Solution

We have to create a Bedrock client to call Bedrock get_inference_profile control plane [API](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedrock/client/get_inference_profile.html), and parse the foundation model id from the response. However, the existing `set_disable_streaming` function works on the raw user input before the ChatBedrockConverse object is instantiated, so we have to extract the logic of determining streaming_support for models into a common function `_get_streaming_support` and invoke it in both places (i.e., the original place that works on raw user input, and the new place that works on the resolved model Id from get_inference_profile API call).

### Issue 

https://github.com/langchain-ai/langchain-aws/issues/538

### Test

* add new unit tests in libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py and all passed
* run through the integration test for ChatBedrockConverse and all passed except one existing failure
   *  The main branch has failed this integration test already, which is not caused by new change. 
   ```
   FAILED tests/integration_tests/chat_models/test_bedrock_converse.py::test_structured_output_tool_choice_not_supported - assert 1 == 0
   ```