### PR TITLE
 feat: Add 1h Prompt Caching to ChatBedrock

### DIFF
--- a/examples/prompt_caching_1h_example.py
+++ b/examples/prompt_caching_1h_example.py
@@ -1,0 +1,104 @@
+"""Example demonstrating 1-hour prompt caching with ChatBedrockConverse.
+
+This example shows how to use extended cache TTL (1 hour) with Anthropic models
+through AWS Bedrock's Converse API.
+"""
+
+from langchain_aws import ChatBedrockConverse
+from langchain_core.messages import HumanMessage, SystemMessage
+
+
+def main():
+    # Initialize the model with beta header for extended cache TTL
+    llm = ChatBedrockConverse(
+        model="anthropic.claude-3-sonnet-20240229-v1:0",
+        region_name="us-west-2",  # Update to your region
+        additional_model_request_fields={
+            "anthropicBeta": ["extended-cache-ttl-2025-04-11"]
+        }
+    )
+    
+    # Create cache points with different TTLs
+    cache_1h = ChatBedrockConverse.create_cache_point(ttl="1h")
+    cache_5m = ChatBedrockConverse.create_cache_point()  # Default 5-minute cache
+    
+    # Example 1: Using cache points in messages
+    print("Example 1: Using cache points in message content")
+    print("-" * 50)
+    
+    # Important: 1-hour cache entries must appear before 5-minute cache entries
+    messages = [
+        HumanMessage(content=[
+            # Long system prompt that doesn't change often - cache for 1 hour
+            """You are an expert AI assistant with extensive knowledge in multiple domains.
+            You always provide helpful, accurate, and detailed responses.
+            You follow these guidelines:
+            1. Be concise but thorough
+            2. Use examples when helpful
+            3. Admit when you don't know something
+            4. Provide sources when possible""",
+            cache_1h,  # Cache the above content for 1 hour
+            
+            # Context that might change more frequently - cache for 5 minutes
+            "Today's date is January 17, 2025. The user is located in Seattle.",
+            cache_5m,  # Cache this for 5 minutes
+            
+            # The actual user question (not cached)
+            "What's the weather typically like in Seattle in January?"
+        ])
+    ]
+    
+    response = llm.invoke(messages)
+    print(f"Response: {response.content}")
+    
+    # Check cache usage
+    if hasattr(response, 'usage_metadata') and response.usage_metadata:
+        print(f"\nToken usage:")
+        print(f"  Input tokens: {response.usage_metadata.get('input_tokens', 0)}")
+        print(f"  Output tokens: {response.usage_metadata.get('output_tokens', 0)}")
+        
+        if 'input_token_details' in response.usage_metadata:
+            details = response.usage_metadata['input_token_details']
+            print(f"  Cache read tokens: {details.get('cache_read', 0)}")
+            print(f"  Cache creation tokens: {details.get('cache_creation', 0)}")
+    
+    # Example 2: Using SystemMessage and HumanMessage separately
+    print("\n\nExample 2: Using separate SystemMessage with caching")
+    print("-" * 50)
+    
+    messages2 = [
+        SystemMessage(content=[
+            "You are a helpful coding assistant specialized in Python.",
+            cache_1h
+        ]),
+        HumanMessage(content=[
+            "Current Python version is 3.11",
+            cache_5m,
+            "How do I use type hints in Python?"
+        ])
+    ]
+    
+    response2 = llm.invoke(messages2)
+    print(f"Response: {response2.content[:200]}...")  # Show first 200 chars
+    
+    # Example 3: Multiple invocations to see cache benefits
+    print("\n\nExample 3: Second invocation (should use cached content)")
+    print("-" * 50)
+    
+    # Make the same request again - should use cached content
+    response3 = llm.invoke(messages)
+    
+    if hasattr(response3, 'usage_metadata') and response3.usage_metadata:
+        print(f"Token usage (2nd call):")
+        print(f"  Input tokens: {response3.usage_metadata.get('input_tokens', 0)}")
+        
+        if 'input_token_details' in response3.usage_metadata:
+            details = response3.usage_metadata['input_token_details']
+            cache_read = details.get('cache_read', 0)
+            print(f"  Cache read tokens: {cache_read}")
+            if cache_read > 0:
+                print("  ✓ Successfully used cached content!")
+
+
+if __name__ == "__main__":
+    main()

--- a/libs/aws/examples/chatbedrock_prompt_caching_1h_example.py
+++ b/libs/aws/examples/chatbedrock_prompt_caching_1h_example.py
@@ -1,0 +1,114 @@
+"""Example demonstrating 1-hour prompt caching with ChatBedrock.
+
+This example shows how to use extended cache TTL (1 hour) with Anthropic models
+through AWS Bedrock's legacy API.
+"""
+
+from langchain_aws import ChatBedrock
+from langchain_core.messages import HumanMessage, SystemMessage
+
+
+def main():
+    # Initialize the model with beta header for extended cache TTL
+    llm = ChatBedrock(
+        model_id="anthropic.claude-3-sonnet-20240229-v1:0",
+        region_name="us-west-2",  # Update to your region
+        additional_model_request_fields={
+            "anthropic_beta": ["prompt-caching-2024-07-31"]
+        },
+    )
+
+    # Create cache points with different TTLs
+    cache_1h = ChatBedrock.create_cache_point(ttl="1h")
+    cache_5m = ChatBedrock.create_cache_point()  # Default 5-minute cache
+
+    # Example 1: Using cache points in messages
+    print("Example 1: Using cache points in message content")
+    print("-" * 50)
+
+    # Important: 1-hour cache entries must appear before 5-minute cache entries
+    messages = [
+        HumanMessage(
+            content=[
+                # Long system prompt that doesn't change often - cache for 1 hour
+                """You are an expert AI assistant with extensive knowledge in multiple domains.
+            You always provide helpful, accurate, and detailed responses.
+            You follow these guidelines:
+            1. Be concise but thorough
+            2. Use examples when helpful
+            3. Admit when you don't know something
+            4. Provide sources when possible""",
+                cache_1h,  # Cache the above content for 1 hour
+                # Context that might change more frequently - cache for 5 minutes
+                "Today's date is January 17, 2025. The user is located in Seattle.",
+                cache_5m,  # Cache this for 5 minutes
+                # The actual user question (not cached)
+                "What's the weather typically like in Seattle in January?",
+            ]
+        )
+    ]
+
+    response = llm.invoke(messages)
+    print(f"Response: {response.content}")
+
+    # Check cache usage
+    if hasattr(response, "usage_metadata") and response.usage_metadata:
+        print(f"\nToken usage:")
+        print(f"  Input tokens: {response.usage_metadata.input_tokens}")
+        print(f"  Output tokens: {response.usage_metadata.output_tokens}")
+
+        if (
+            hasattr(response.usage_metadata, "input_token_details")
+            and response.usage_metadata.input_token_details
+        ):
+            details = response.usage_metadata.input_token_details
+            print(f"  Cache read tokens: {details.get('cache_read', 0)}")
+            print(f"  Cache creation tokens: {details.get('cache_creation', 0)}")
+
+    # Example 2: Using SystemMessage and HumanMessage separately
+    print("\n\nExample 2: Using separate SystemMessage with caching")
+    print("-" * 50)
+
+    messages2 = [
+        SystemMessage(
+            content=[
+                "You are a helpful coding assistant specialized in Python.",
+                cache_1h,
+            ]
+        ),
+        HumanMessage(
+            content=[
+                "Current Python version is 3.11",
+                cache_5m,
+                "How do I use type hints in Python?",
+            ]
+        ),
+    ]
+
+    response2 = llm.invoke(messages2)
+    print(f"Response: {response2.content[:200]}...")  # Show first 200 chars
+
+    # Example 3: Multiple invocations to see cache benefits
+    print("\n\nExample 3: Second invocation (should use cached content)")
+    print("-" * 50)
+
+    # Make the same request again - should use cached content
+    response3 = llm.invoke(messages)
+
+    if hasattr(response3, "usage_metadata") and response3.usage_metadata:
+        print(f"Token usage (2nd call):")
+        print(f"  Input tokens: {response3.usage_metadata.input_tokens}")
+
+        if (
+            hasattr(response3.usage_metadata, "input_token_details")
+            and response3.usage_metadata.input_token_details
+        ):
+            details = response3.usage_metadata.input_token_details
+            cache_read = details.get("cache_read", 0)
+            print(f"  Cache read tokens: {cache_read}")
+            if cache_read > 0:
+                print("  ✓ Successfully used cached content!")
+
+
+if __name__ == "__main__":
+    main()

--- a/libs/aws/pyproject.toml
+++ b/libs/aws/pyproject.toml
@@ -113,5 +113,6 @@ markers = [
   "asyncio: mark tests as requiring asyncio",
   "compile: mark placeholder test used to compile integration tests without running them",
   "scheduled: mark tests to run in scheduled testing",
+  "integration: mark tests as integration tests",
 ]
 asyncio_mode = "auto"

--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse_caching.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse_caching.py
@@ -1,7 +1,7 @@
 """Integration tests for prompt caching with ChatBedrockConverse."""
 
 import pytest
-from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 
 from langchain_aws import ChatBedrockConverse
 
@@ -38,7 +38,11 @@ def test_prompt_caching_with_1h_ttl() -> None:
     assert hasattr(response1, "usage_metadata")
 
     # Check if cache was created
-    if response1.usage_metadata and "input_token_details" in response1.usage_metadata:
+    if (
+        hasattr(response1, "usage_metadata")
+        and response1.usage_metadata
+        and "input_token_details" in response1.usage_metadata
+    ):
         cache_creation = response1.usage_metadata["input_token_details"].get(
             "cache_creation", 0
         )
@@ -49,7 +53,11 @@ def test_prompt_caching_with_1h_ttl() -> None:
     assert response2.content
 
     # Check if cache was used
-    if response2.usage_metadata and "input_token_details" in response2.usage_metadata:
+    if (
+        hasattr(response2, "usage_metadata")
+        and response2.usage_metadata
+        and "input_token_details" in response2.usage_metadata
+    ):
         cache_read = response2.usage_metadata["input_token_details"].get(
             "cache_read", 0
         )
@@ -129,4 +137,7 @@ def test_mixed_message_types_with_caching() -> None:
 
     response = llm.invoke(messages)
     assert response.content
-    assert "def" in response.content or "factorial" in response.content.lower()
+    content_str = (
+        response.content if isinstance(response.content, str) else str(response.content)
+    )
+    assert "def" in content_str or "factorial" in content_str.lower()

--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse_caching.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse_caching.py
@@ -1,0 +1,125 @@
+"""Integration tests for prompt caching with ChatBedrockConverse."""
+
+import pytest
+from langchain_core.messages import HumanMessage, SystemMessage
+
+from langchain_aws import ChatBedrockConverse
+
+
+@pytest.mark.integration
+def test_prompt_caching_with_1h_ttl():
+    """Test prompt caching with 1-hour TTL."""
+    llm = ChatBedrockConverse(
+        model="anthropic.claude-3-sonnet-20240229-v1:0",
+        additional_model_request_fields={
+            "anthropicBeta": ["extended-cache-ttl-2025-04-11"]
+        }
+    )
+    
+    # Create cache points
+    cache_1h = ChatBedrockConverse.create_cache_point(ttl="1h")
+    cache_5m = ChatBedrockConverse.create_cache_point()
+    
+    messages = [
+        HumanMessage(content=[
+            "You are a helpful assistant.",
+            cache_1h,
+            "Current context.",
+            cache_5m,
+            "What is 2+2?"
+        ])
+    ]
+    
+    # First invocation - should create cache
+    response1 = llm.invoke(messages)
+    assert response1.content
+    assert hasattr(response1, 'usage_metadata')
+    
+    # Check if cache was created
+    if response1.usage_metadata and 'input_token_details' in response1.usage_metadata:
+        cache_creation = response1.usage_metadata['input_token_details'].get('cache_creation', 0)
+        assert cache_creation > 0, "Expected cache creation on first call"
+    
+    # Second invocation - should use cache
+    response2 = llm.invoke(messages)
+    assert response2.content
+    
+    # Check if cache was used
+    if response2.usage_metadata and 'input_token_details' in response2.usage_metadata:
+        cache_read = response2.usage_metadata['input_token_details'].get('cache_read', 0)
+        assert cache_read > 0, "Expected cache read on second call"
+
+
+@pytest.mark.integration
+def test_cache_ordering_validation():
+    """Test that 1-hour cache entries must appear before 5-minute entries."""
+    llm = ChatBedrockConverse(
+        model="anthropic.claude-3-sonnet-20240229-v1:0",
+        additional_model_request_fields={
+            "anthropicBeta": ["extended-cache-ttl-2025-04-11"]
+        }
+    )
+    
+    cache_1h = ChatBedrockConverse.create_cache_point(ttl="1h")
+    cache_5m = ChatBedrockConverse.create_cache_point()
+    
+    # Correct ordering: 1h before 5m
+    messages_correct = [
+        HumanMessage(content=[
+            "Long-term context",
+            cache_1h,
+            "Short-term context",
+            cache_5m,
+            "Question"
+        ])
+    ]
+    
+    # This should work fine
+    response = llm.invoke(messages_correct)
+    assert response.content
+    
+    # Incorrect ordering: 5m before 1h (might fail based on Anthropic's requirements)
+    messages_incorrect = [
+        HumanMessage(content=[
+            "Short-term context",
+            cache_5m,
+            "Long-term context",
+            cache_1h,  # This violates the ordering requirement
+            "Question"
+        ])
+    ]
+    
+    # Note: Whether this fails depends on Anthropic's validation
+    # The documentation states 1h cache must come before 5m cache
+    try:
+        response = llm.invoke(messages_incorrect)
+        # If it succeeds, we should at least verify response is valid
+        assert response.content
+    except Exception as e:
+        # Expected behavior if Anthropic enforces ordering
+        assert "cache" in str(e).lower() or "order" in str(e).lower()
+
+
+@pytest.mark.integration
+def test_mixed_message_types_with_caching():
+    """Test caching with SystemMessage and HumanMessage."""
+    llm = ChatBedrockConverse(
+        model="anthropic.claude-3-sonnet-20240229-v1:0",
+        additional_model_request_fields={
+            "anthropicBeta": ["extended-cache-ttl-2025-04-11"]
+        }
+    )
+    
+    cache_1h = ChatBedrockConverse.create_cache_point(ttl="1h")
+    
+    messages = [
+        SystemMessage(content=[
+            "You are an expert Python programmer.",
+            cache_1h
+        ]),
+        HumanMessage("Write a function to calculate factorial.")
+    ]
+    
+    response = llm.invoke(messages)
+    assert response.content
+    assert "def" in response.content or "factorial" in response.content.lower()

--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse_caching.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse_caching.py
@@ -13,40 +13,46 @@ def test_prompt_caching_with_1h_ttl():
         model="anthropic.claude-3-sonnet-20240229-v1:0",
         additional_model_request_fields={
             "anthropicBeta": ["extended-cache-ttl-2025-04-11"]
-        }
+        },
     )
-    
+
     # Create cache points
     cache_1h = ChatBedrockConverse.create_cache_point(ttl="1h")
     cache_5m = ChatBedrockConverse.create_cache_point()
-    
+
     messages = [
-        HumanMessage(content=[
-            "You are a helpful assistant.",
-            cache_1h,
-            "Current context.",
-            cache_5m,
-            "What is 2+2?"
-        ])
+        HumanMessage(
+            content=[
+                "You are a helpful assistant.",
+                cache_1h,
+                "Current context.",
+                cache_5m,
+                "What is 2+2?",
+            ]
+        )
     ]
-    
+
     # First invocation - should create cache
     response1 = llm.invoke(messages)
     assert response1.content
-    assert hasattr(response1, 'usage_metadata')
-    
+    assert hasattr(response1, "usage_metadata")
+
     # Check if cache was created
-    if response1.usage_metadata and 'input_token_details' in response1.usage_metadata:
-        cache_creation = response1.usage_metadata['input_token_details'].get('cache_creation', 0)
+    if response1.usage_metadata and "input_token_details" in response1.usage_metadata:
+        cache_creation = response1.usage_metadata["input_token_details"].get(
+            "cache_creation", 0
+        )
         assert cache_creation > 0, "Expected cache creation on first call"
-    
+
     # Second invocation - should use cache
     response2 = llm.invoke(messages)
     assert response2.content
-    
+
     # Check if cache was used
-    if response2.usage_metadata and 'input_token_details' in response2.usage_metadata:
-        cache_read = response2.usage_metadata['input_token_details'].get('cache_read', 0)
+    if response2.usage_metadata and "input_token_details" in response2.usage_metadata:
+        cache_read = response2.usage_metadata["input_token_details"].get(
+            "cache_read", 0
+        )
         assert cache_read > 0, "Expected cache read on second call"
 
 
@@ -57,38 +63,42 @@ def test_cache_ordering_validation():
         model="anthropic.claude-3-sonnet-20240229-v1:0",
         additional_model_request_fields={
             "anthropicBeta": ["extended-cache-ttl-2025-04-11"]
-        }
+        },
     )
-    
+
     cache_1h = ChatBedrockConverse.create_cache_point(ttl="1h")
     cache_5m = ChatBedrockConverse.create_cache_point()
-    
+
     # Correct ordering: 1h before 5m
     messages_correct = [
-        HumanMessage(content=[
-            "Long-term context",
-            cache_1h,
-            "Short-term context",
-            cache_5m,
-            "Question"
-        ])
+        HumanMessage(
+            content=[
+                "Long-term context",
+                cache_1h,
+                "Short-term context",
+                cache_5m,
+                "Question",
+            ]
+        )
     ]
-    
+
     # This should work fine
     response = llm.invoke(messages_correct)
     assert response.content
-    
+
     # Incorrect ordering: 5m before 1h (might fail based on Anthropic's requirements)
     messages_incorrect = [
-        HumanMessage(content=[
-            "Short-term context",
-            cache_5m,
-            "Long-term context",
-            cache_1h,  # This violates the ordering requirement
-            "Question"
-        ])
+        HumanMessage(
+            content=[
+                "Short-term context",
+                cache_5m,
+                "Long-term context",
+                cache_1h,  # This violates the ordering requirement
+                "Question",
+            ]
+        )
     ]
-    
+
     # Note: Whether this fails depends on Anthropic's validation
     # The documentation states 1h cache must come before 5m cache
     try:
@@ -107,19 +117,16 @@ def test_mixed_message_types_with_caching():
         model="anthropic.claude-3-sonnet-20240229-v1:0",
         additional_model_request_fields={
             "anthropicBeta": ["extended-cache-ttl-2025-04-11"]
-        }
+        },
     )
-    
+
     cache_1h = ChatBedrockConverse.create_cache_point(ttl="1h")
-    
+
     messages = [
-        SystemMessage(content=[
-            "You are an expert Python programmer.",
-            cache_1h
-        ]),
-        HumanMessage("Write a function to calculate factorial.")
+        SystemMessage(content=["You are an expert Python programmer.", cache_1h]),
+        HumanMessage("Write a function to calculate factorial."),
     ]
-    
+
     response = llm.invoke(messages)
     assert response.content
     assert "def" in response.content or "factorial" in response.content.lower()

--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse_caching.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse_caching.py
@@ -7,7 +7,7 @@ from langchain_aws import ChatBedrockConverse
 
 
 @pytest.mark.integration
-def test_prompt_caching_with_1h_ttl():
+def test_prompt_caching_with_1h_ttl() -> None:
     """Test prompt caching with 1-hour TTL."""
     llm = ChatBedrockConverse(
         model="anthropic.claude-3-sonnet-20240229-v1:0",
@@ -57,7 +57,7 @@ def test_prompt_caching_with_1h_ttl():
 
 
 @pytest.mark.integration
-def test_cache_ordering_validation():
+def test_cache_ordering_validation() -> None:
     """Test that 1-hour cache entries must appear before 5-minute entries."""
     llm = ChatBedrockConverse(
         model="anthropic.claude-3-sonnet-20240229-v1:0",
@@ -111,7 +111,7 @@ def test_cache_ordering_validation():
 
 
 @pytest.mark.integration
-def test_mixed_message_types_with_caching():
+def test_mixed_message_types_with_caching() -> None:
     """Test caching with SystemMessage and HumanMessage."""
     llm = ChatBedrockConverse(
         model="anthropic.claude-3-sonnet-20240229-v1:0",

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -1338,21 +1338,23 @@ def test_messages_with_cache_points():
     """Test that messages with cache points are properly formatted."""
     cache_1h = ChatBedrockConverse.create_cache_point(ttl="1h")
     cache_5m = ChatBedrockConverse.create_cache_point()
-    
+
     messages = [
-        HumanMessage(content=[
-            "System context to cache for 1 hour",
-            cache_1h,
-            "Context to cache for 5 minutes",
-            cache_5m,
-            "User question"
-        ])
+        HumanMessage(
+            content=[
+                "System context to cache for 1 hour",
+                cache_1h,
+                "Context to cache for 5 minutes",
+                cache_5m,
+                "User question",
+            ]
+        )
     ]
-    
+
     bedrock_messages, _ = _messages_to_bedrock(messages)
     assert len(bedrock_messages) == 1
     assert bedrock_messages[0]["role"] == "user"
-    
+
     content = bedrock_messages[0]["content"]
     assert len(content) == 5
     assert content[0] == {"text": "System context to cache for 1 hour"}
@@ -1369,7 +1371,7 @@ def test_beta_header_in_additional_fields():
         region_name="us-west-2",
         additional_model_request_fields={
             "anthropicBeta": ["extended-cache-ttl-2025-04-11"]
-        }
+        },
     )
     assert llm.additional_model_request_fields == {
         "anthropicBeta": ["extended-cache-ttl-2025-04-11"]
@@ -1451,61 +1453,63 @@ def test_stream_guard_last_turn_only() -> None:
         "guardContent": {"text": {"text": "How are you?"}}
     }
 
+
 @mock.patch("langchain_aws.chat_models.bedrock_converse.create_aws_client")
 def test_bedrock_client_creation(mock_create_client: mock.Mock) -> None:
     """Test that bedrock_client is created during validation."""
     mock_bedrock_client = mock.Mock()
     mock_runtime_client = mock.Mock()
-    
+
     def side_effect(service_name: str, **kwargs: Any) -> mock.Mock:
         if service_name == "bedrock":
             return mock_bedrock_client
         elif service_name == "bedrock-runtime":
             return mock_runtime_client
         return mock.Mock()
-    
+
     mock_create_client.side_effect = side_effect
-    
+
     chat_model = ChatBedrockConverse(
-        model="anthropic.claude-3-sonnet-20240229-v1:0",
-        region_name="us-west-2"
+        model="anthropic.claude-3-sonnet-20240229-v1:0", region_name="us-west-2"
     )
-    
+
     assert chat_model.bedrock_client == mock_bedrock_client
     assert chat_model.client == mock_runtime_client
     assert mock_create_client.call_count == 2
 
 
 @mock.patch("langchain_aws.chat_models.bedrock_converse.create_aws_client")
-def test_get_base_model_with_application_inference_profile(mock_create_client: mock.Mock) -> None:
+def test_get_base_model_with_application_inference_profile(
+    mock_create_client: mock.Mock,
+) -> None:
     """Test _get_base_model method with application inference profile."""
     mock_bedrock_client = mock.Mock()
     mock_runtime_client = mock.Mock()
-    
+
     # Mock the get_inference_profile response
     mock_bedrock_client.get_inference_profile.return_value = {
-        'models': [
+        "models": [
             {
-                'modelArn': 'arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-sonnet-20240229-v1:0'
+                "modelArn": "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-sonnet-20240229-v1:0"
             }
         ]
     }
-    
+
     def side_effect(service_name: str, **kwargs: Any) -> mock.Mock:
         if service_name == "bedrock":
             return mock_bedrock_client
         elif service_name == "bedrock-runtime":
             return mock_runtime_client
         return mock.Mock()
-    
+
     mock_create_client.side_effect = side_effect
-    
+
     chat_model = ChatBedrockConverse(
         model="arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/test-profile",
         region_name="us-west-2",
-        provider="anthropic"
+        provider="anthropic",
     )
-    
+
     base_model = chat_model._get_base_model()
     assert base_model == "anthropic.claude-3-sonnet-20240229-v1:0"
     mock_bedrock_client.get_inference_profile.assert_called_once_with(
@@ -1514,26 +1518,28 @@ def test_get_base_model_with_application_inference_profile(mock_create_client: m
 
 
 @mock.patch("langchain_aws.chat_models.bedrock_converse.create_aws_client")
-def test_get_base_model_without_application_inference_profile(mock_create_client: mock.Mock) -> None:
+def test_get_base_model_without_application_inference_profile(
+    mock_create_client: mock.Mock,
+) -> None:
     """Test _get_base_model method without application inference profile."""
     mock_bedrock_client = mock.Mock()
     mock_runtime_client = mock.Mock()
-    
+
     def side_effect(service_name: str, **kwargs: Any) -> mock.Mock:
         if service_name == "bedrock":
             return mock_bedrock_client
         elif service_name == "bedrock-runtime":
             return mock_runtime_client
         return mock.Mock()
-    
+
     mock_create_client.side_effect = side_effect
-    
+
     chat_model = ChatBedrockConverse(
         model="anthropic.claude-3-sonnet-20240229-v1:0",
         region_name="us-west-2",
-        provider="anthropic"
+        provider="anthropic",
     )
-    
+
     base_model = chat_model._get_base_model()
     assert base_model == "anthropic.claude-3-sonnet-20240229-v1:0"
     mock_bedrock_client.get_inference_profile.assert_not_called()
@@ -1544,98 +1550,102 @@ def test_configure_streaming_for_resolved_model(mock_create_client: mock.Mock) -
     """Test _configure_streaming_for_resolved_model method."""
     mock_bedrock_client = mock.Mock()
     mock_runtime_client = mock.Mock()
-    
+
     # Mock the get_inference_profile response for a model with full streaming support
     mock_bedrock_client.get_inference_profile.return_value = {
-        'models': [
+        "models": [
             {
-                'modelArn': 'arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-sonnet-20240229-v1:0'
+                "modelArn": "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-sonnet-20240229-v1:0"
             }
         ]
     }
-    
+
     def side_effect(service_name: str, **kwargs: Any) -> mock.Mock:
         if service_name == "bedrock":
             return mock_bedrock_client
         elif service_name == "bedrock-runtime":
             return mock_runtime_client
         return mock.Mock()
-    
+
     mock_create_client.side_effect = side_effect
-    
+
     chat_model = ChatBedrockConverse(
         model="arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/test-profile",
         region_name="us-west-2",
-        provider="anthropic"
+        provider="anthropic",
     )
-    
+
     # The streaming should be configured based on the resolved model
     assert chat_model.disable_streaming is False
 
 
 @mock.patch("langchain_aws.chat_models.bedrock_converse.create_aws_client")
-def test_configure_streaming_for_resolved_model_no_tools(mock_create_client: mock.Mock) -> None:
+def test_configure_streaming_for_resolved_model_no_tools(
+    mock_create_client: mock.Mock,
+) -> None:
     """Test _configure_streaming_for_resolved_model method with no-tools streaming."""
     mock_bedrock_client = mock.Mock()
     mock_runtime_client = mock.Mock()
-    
+
     # Mock the get_inference_profile response for a model with no-tools streaming support
     mock_bedrock_client.get_inference_profile.return_value = {
-        'models': [
+        "models": [
             {
-                'modelArn': 'arn:aws:bedrock:us-east-1::foundation-model/amazon.titan-text-express-v1'
+                "modelArn": "arn:aws:bedrock:us-east-1::foundation-model/amazon.titan-text-express-v1"
             }
         ]
     }
-    
+
     def side_effect(service_name: str, **kwargs: Any) -> mock.Mock:
         if service_name == "bedrock":
             return mock_bedrock_client
         elif service_name == "bedrock-runtime":
             return mock_runtime_client
         return mock.Mock()
-    
+
     mock_create_client.side_effect = side_effect
-    
+
     chat_model = ChatBedrockConverse(
         model="arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/test-profile",
         region_name="us-west-2",
-        provider="amazon"
+        provider="amazon",
     )
-    
+
     # The streaming should be configured as "tool_calling" for no-tools models
     assert chat_model.disable_streaming == "tool_calling"
 
 
 @mock.patch("langchain_aws.chat_models.bedrock_converse.create_aws_client")
-def test_configure_streaming_for_resolved_model_no_streaming(mock_create_client: mock.Mock) -> None:
+def test_configure_streaming_for_resolved_model_no_streaming(
+    mock_create_client: mock.Mock,
+) -> None:
     """Test _configure_streaming_for_resolved_model method with no streaming support."""
     mock_bedrock_client = mock.Mock()
     mock_runtime_client = mock.Mock()
-    
+
     # Mock the get_inference_profile response for a model with no streaming support
     mock_bedrock_client.get_inference_profile.return_value = {
-        'models': [
+        "models": [
             {
-                'modelArn': 'arn:aws:bedrock:us-east-1::foundation-model/stability.stable-image-core-v1:0'
+                "modelArn": "arn:aws:bedrock:us-east-1::foundation-model/stability.stable-image-core-v1:0"
             }
         ]
     }
-    
+
     def side_effect(service_name: str, **kwargs: Any) -> mock.Mock:
         if service_name == "bedrock":
             return mock_bedrock_client
         elif service_name == "bedrock-runtime":
             return mock_runtime_client
         return mock.Mock()
-    
+
     mock_create_client.side_effect = side_effect
-    
+
     chat_model = ChatBedrockConverse(
         model="arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/test-profile",
         region_name="us-west-2",
-        provider="stability"
+        provider="stability",
     )
-    
+
     # The streaming should be disabled for models with no streaming support
     assert chat_model.disable_streaming is True

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -9,6 +9,7 @@ import pytest
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import (
     AIMessage,
+    BaseMessage,
     HumanMessage,
     SystemMessage,
     ToolCall,
@@ -487,8 +488,7 @@ def test__snake_to_camel_keys() -> None:
     assert _snake_to_camel_keys(_SNAKE_DICT) == _CAMEL_DICT
 
 
-def test__format_openai_image_url() -> None:
-    ...
+def test__format_openai_image_url() -> None: ...
 
 
 def test_standard_tracing_params() -> None:
@@ -1339,7 +1339,7 @@ def test_messages_with_cache_points() -> None:
     cache_1h = ChatBedrockConverse.create_cache_point(ttl="1h")
     cache_5m = ChatBedrockConverse.create_cache_point()
 
-    messages = [
+    messages: List[BaseMessage] = [
         HumanMessage(
             content=[
                 "System context to cache for 1 hour",

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -1230,7 +1230,7 @@ def test_disable_streaming_with_arn(
 def test_create_cache_point() -> None:
     """Test creating a cache point configuration"""
     cache_point = ChatBedrockConverse.create_cache_point()
-    assert cache_point["cachePoint"]["type"] == "default"
+    assert cache_point["cachePoint"]["type"] == "ephemeral"
 
 
 def test_anthropic_tool_with_cache_point() -> None:
@@ -1307,6 +1307,73 @@ def test_model_kwargs() -> None:
     )
     assert llm.additional_model_request_fields == {"temperature": 0.2}
     assert llm.temperature is None
+
+
+def test_create_cache_point_default():
+    """Test creating a default cache point."""
+    cache_point = ChatBedrockConverse.create_cache_point()
+    assert cache_point == {"cachePoint": {"type": "ephemeral"}}
+
+
+def test_create_cache_point_with_ttl():
+    """Test creating a cache point with TTL."""
+    cache_point = ChatBedrockConverse.create_cache_point(ttl="1h")
+    assert cache_point == {"cachePoint": {"type": "ephemeral", "ttl": "1h"}}
+
+
+def test_create_cache_point_default_type():
+    """Test creating a cache point with default type (no TTL support)."""
+    cache_point = ChatBedrockConverse.create_cache_point(cache_type="default")
+    assert cache_point == {"cachePoint": {"type": "default"}}
+
+
+def test_create_cache_point_ttl_only_with_ephemeral():
+    """Test that TTL is only added with ephemeral type."""
+    cache_point = ChatBedrockConverse.create_cache_point(cache_type="default", ttl="1h")
+    assert cache_point == {"cachePoint": {"type": "default"}}
+    # TTL should not be included with default type
+
+
+def test_messages_with_cache_points():
+    """Test that messages with cache points are properly formatted."""
+    cache_1h = ChatBedrockConverse.create_cache_point(ttl="1h")
+    cache_5m = ChatBedrockConverse.create_cache_point()
+    
+    messages = [
+        HumanMessage(content=[
+            "System context to cache for 1 hour",
+            cache_1h,
+            "Context to cache for 5 minutes",
+            cache_5m,
+            "User question"
+        ])
+    ]
+    
+    bedrock_messages, _ = _messages_to_bedrock(messages)
+    assert len(bedrock_messages) == 1
+    assert bedrock_messages[0]["role"] == "user"
+    
+    content = bedrock_messages[0]["content"]
+    assert len(content) == 5
+    assert content[0] == {"text": "System context to cache for 1 hour"}
+    assert content[1] == {"cachePoint": {"type": "ephemeral", "ttl": "1h"}}
+    assert content[2] == {"text": "Context to cache for 5 minutes"}
+    assert content[3] == {"cachePoint": {"type": "ephemeral"}}
+    assert content[4] == {"text": "User question"}
+
+
+def test_beta_header_in_additional_fields():
+    """Test that beta headers can be passed through additional_model_request_fields."""
+    llm = ChatBedrockConverse(
+        model="anthropic.claude-3-sonnet-20240229-v1:0",
+        region_name="us-west-2",
+        additional_model_request_fields={
+            "anthropicBeta": ["extended-cache-ttl-2025-04-11"]
+        }
+    )
+    assert llm.additional_model_request_fields == {
+        "anthropicBeta": ["extended-cache-ttl-2025-04-11"]
+    }
 
 
 def _create_mock_llm_guard_last_turn_only() -> (

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -1309,32 +1309,32 @@ def test_model_kwargs() -> None:
     assert llm.temperature is None
 
 
-def test_create_cache_point_default():
+def test_create_cache_point_default() -> None:
     """Test creating a default cache point."""
     cache_point = ChatBedrockConverse.create_cache_point()
     assert cache_point == {"cachePoint": {"type": "ephemeral"}}
 
 
-def test_create_cache_point_with_ttl():
+def test_create_cache_point_with_ttl() -> None:
     """Test creating a cache point with TTL."""
     cache_point = ChatBedrockConverse.create_cache_point(ttl="1h")
     assert cache_point == {"cachePoint": {"type": "ephemeral", "ttl": "1h"}}
 
 
-def test_create_cache_point_default_type():
+def test_create_cache_point_default_type() -> None:
     """Test creating a cache point with default type (no TTL support)."""
     cache_point = ChatBedrockConverse.create_cache_point(cache_type="default")
     assert cache_point == {"cachePoint": {"type": "default"}}
 
 
-def test_create_cache_point_ttl_only_with_ephemeral():
+def test_create_cache_point_ttl_only_with_ephemeral() -> None:
     """Test that TTL is only added with ephemeral type."""
     cache_point = ChatBedrockConverse.create_cache_point(cache_type="default", ttl="1h")
     assert cache_point == {"cachePoint": {"type": "default"}}
     # TTL should not be included with default type
 
 
-def test_messages_with_cache_points():
+def test_messages_with_cache_points() -> None:
     """Test that messages with cache points are properly formatted."""
     cache_1h = ChatBedrockConverse.create_cache_point(ttl="1h")
     cache_5m = ChatBedrockConverse.create_cache_point()
@@ -1364,7 +1364,7 @@ def test_messages_with_cache_points():
     assert content[4] == {"text": "User question"}
 
 
-def test_beta_header_in_additional_fields():
+def test_beta_header_in_additional_fields() -> None:
     """Test that beta headers can be passed through additional_model_request_fields."""
     llm = ChatBedrockConverse(
         model="anthropic.claude-3-sonnet-20240229-v1:0",


### PR DESCRIPTION
## Add 1-Hour Prompt Caching Support for ChatBedrock

Implements extended TTL support for prompt caching with ChatBedrock, bringing feature parity with ChatBedrockConverse for 1-hour cache durations.

### Changes

- **API Enhancement**: Added `create_cache_point()` method with `ttl` parameter support
- **Cache Control**: Updated cache_control handling to support dict-based configurations with TTL
- **Beta Header**: Added support for `anthropic_beta` header through `additional_model_request_fields`
- **Backward Compatibility**: Maintains existing boolean `cache_control` functionality

### Usage

```python
# Enable 1-hour caching
llm = ChatBedrock(
    model_id="anthropic.claude-3-sonnet-20240229-v1:0",
    additional_model_request_fields={
        "anthropic_beta": ["prompt-caching-2024-07-31"]
    }
)

cache_1h = ChatBedrock.create_cache_point(ttl="1h")
cache_5m = ChatBedrock.create_cache_point()  # Default 5min

messages = [HumanMessage(content=[
    "Long system prompt", cache_1h,
    "Short context", cache_5m, 
    "User question"
])]
```

### Tests

- 8 new unit tests covering all caching functionality
- Example script demonstrating 1-hour caching usage
- All tests pass with proper error handling

Fixes #493