### PR TITLE
Fix: fix the streaming issue for nova models

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -584,7 +584,7 @@ class ChatBedrockConverse(BaseChatModel):
         
         # Extract provider from the model_id
         # (e.g., "amazon", "anthropic", "ai21", "meta", "mistral")
-        if "provider" not in values:
+        if "provider" not in values or values["provider"] == "":
             if model_id.startswith("arn"):
                 raise ValueError(
                     "Model provider should be supplied when passing a model ARN as model_id."

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -1572,3 +1572,8 @@ def test_configure_streaming_for_resolved_model_no_streaming(mock_create_client:
     
     # The streaming should be disabled for models with no streaming support
     assert chat_model.disable_streaming is True
+    
+def test_nova_provider_extraction() -> None:
+    """Test that provider is correctly extracted from Nova model ID when not provided."""
+    model = ChatBedrockConverse(model="us.amazon.nova-pro-v1:0")
+    assert model.provider == "amazon"

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -1575,5 +1575,5 @@ def test_configure_streaming_for_resolved_model_no_streaming(mock_create_client:
     
 def test_nova_provider_extraction() -> None:
     """Test that provider is correctly extracted from Nova model ID when not provided."""
-    model = ChatBedrockConverse(model="us.amazon.nova-pro-v1:0")
+    model = ChatBedrockConverse(model="us.amazon.nova-pro-v1:0", region_name="us-west-2")
     assert model.provider == "amazon"

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -1575,5 +1575,5 @@ def test_configure_streaming_for_resolved_model_no_streaming(mock_create_client:
     
 def test_nova_provider_extraction() -> None:
     """Test that provider is correctly extracted from Nova model ID when not provided."""
-    model = ChatBedrockConverse(model="us.amazon.nova-pro-v1:0", region_name="us-west-2")
+    model = ChatBedrockConverse(client=mock.MagicMock(), model="us.amazon.nova-pro-v1:0", region_name="us-west-2")
     assert model.provider == "amazon"


### PR DESCRIPTION
### Description

This PR fixes the bug that cause streaming is broken for Amazon Nova model. The response was returned as a whole rather than streaming back chunks to customers, even though `.stream()` is used. 

### Root Cause and Fix

First of all, when using Amazon Nova model, langchain-aws will use ChatBedrockConverse even though we create ChatBedrock ([code](https://github.com/langchain-ai/langchain-aws/blob/main/libs/aws/langchain_aws/chat_models/bedrock.py#L704)). Inside ChatBedrockConverse, the input parameter `provider` is default to empty string rather than None ([code](https://github.com/langchain-ai/langchain-aws/blob/main/libs/aws/langchain_aws/chat_models/bedrock_converse.py#L407)), therefore, the [set_disable_streaming](https://github.com/langchain-ai/langchain-aws/blob/main/libs/aws/langchain_aws/chat_models/bedrock_converse.py#L582) function will use `provider=""` to disable the streaming, even though the model can support streaming. To fix it, this PR updates **set_disable_streaming** function to extract provider from model Id correctly when `provider` is empty string as default value, so it can  setup the streaming flag correctly. 

Alternatively, user can set the `provider` parameter explicitly when initializing the ChatBedrock as below, which can make streaming work for Nova models without any code change.
```
llm = ChatBedrock(
    provider="amazon",
    model="us.amazon.nova-pro-v1:0",
)

for chunk in llm.stream(prompt):
    print(chunk)
```

### Issue

https://github.com/langchain-ai/langchain-aws/issues/544
