### PR TITLE
Enable ChatBedrockConverse streaming for OpenAI gpt-oss models

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -565,6 +565,9 @@ class ChatBedrockConverse(BaseChatModel):
                 )
             )
             or
+            # OpenAI gpt-oss models
+            (provider == "openai" and "gpt-oss" in model_id_lower)
+            or
             # Cohere Command R models
             (provider == "cohere" and "command-r" in model_id_lower)
         ):

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -518,6 +518,8 @@ def test_standard_tracing_params() -> None:
         ("us.amazon.nova-lite-v1:0", False),
         ("us.amazon.nonstreaming-model-v1:0", True),
         ("us.deepseek.r1-v1:0", "tool_calling"),
+        ("openai.gpt-oss-120b-1:0", False),
+        ("openai.gpt-oss-20b-1:0", False),
     ],
 )
 def test_set_disable_streaming(


### PR DESCRIPTION
Fixes: #573 

Updating ChatBedrockConverse to set `disable_streaming=False` by default for `gpt-oss`, as Bedrock now supports streaming (with tool calls) for these models.