### PR TITLE
fix: Avoid ValidationException for empty content in ChatBedrockConverse

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -1305,7 +1305,13 @@ def _lc_content_to_bedrock(
     content: Union[str, List[Union[str, Dict[str, Any]]]],
 ) -> List[Dict[str, Any]]:
     if isinstance(content, str):
-        content = [{"text": content}]
+        if not content or content.isspace():
+            content = [{"text": "[empty]"}]
+        else:
+            content = [{"text": content}]
+    elif isinstance(content, list) and len(content) == 0:
+        content = [{"type": "text", "text": "[empty]"}]
+
     bedrock_content: List[Dict[str, Any]] = []
     for block in _snake_to_camel_keys(content):
         if isinstance(block, str):
@@ -1318,7 +1324,10 @@ def _lc_content_to_bedrock(
         ):
             bedrock_content.append(_format_data_content_block(block))
         elif block["type"] == "text":
-            bedrock_content.append({"text": block["text"]})
+            if not block["text"] or (isinstance(block["text"], str) and block["text"].isspace()):
+                bedrock_content.append({"text": "[empty]"})
+            else:
+                bedrock_content.append({"text": block["text"]})
         elif block["type"] == "image":
             # Assume block is already in bedrock format.
             if "image" in block:

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -1196,6 +1196,79 @@ def test__lc_content_to_bedrock_mime_types_invalid() -> None:
         ])
 
 
+def test__lc_content_to_bedrock_empty_content() -> None:
+    content = []
+    
+    bedrock_content = _lc_content_to_bedrock(content)
+    
+    assert len(bedrock_content) > 0
+    assert bedrock_content[0]["text"] == "[empty]"
+
+
+def test__lc_content_to_bedrock_whitespace_only_content() -> None:
+    content = "   \n  \t  "
+    
+    bedrock_content = _lc_content_to_bedrock(content)
+    
+    assert len(bedrock_content) > 0
+    assert bedrock_content[0]["text"] == "[empty]"
+
+
+def test__lc_content_to_bedrock_empty_string_content() -> None:
+    content = ""
+    
+    bedrock_content = _lc_content_to_bedrock(content)
+    
+    assert len(bedrock_content) > 0
+    assert bedrock_content[0]["text"] == "[empty]"
+
+
+def test__lc_content_to_bedrock_mixed_empty_content() -> None:
+    content = [
+        {"type": "text", "text": ""},
+        {"type": "text", "text": "   "},
+        {"type": "text", "text": ""}
+    ]
+    
+    bedrock_content = _lc_content_to_bedrock(content)
+
+    assert len(bedrock_content) > 0
+    assert bedrock_content[0]["text"] == "[empty]"
+
+
+def test__lc_content_to_bedrock_empty_text_block() -> None:
+    content = [{"type": "text", "text": ""}]
+    
+    bedrock_content = _lc_content_to_bedrock(content)
+    
+    assert len(bedrock_content) > 0
+    assert bedrock_content[0]["text"] == "[empty]"
+
+
+def test__lc_content_to_bedrock_whitespace_text_block() -> None:
+    content = [{"type": "text", "text": "  \n  "}]
+    
+    bedrock_content = _lc_content_to_bedrock(content)
+    
+    assert len(bedrock_content) > 0
+    assert bedrock_content[0]["text"] == "[empty]"
+
+
+def test__lc_content_to_bedrock_mixed_valid_and_empty_content() -> None:
+    content = [
+        {"type": "text", "text": "Valid text"},
+        {"type": "text", "text": ""},
+        {"type": "text", "text": "   "}
+    ]
+    
+    bedrock_content = _lc_content_to_bedrock(content)
+
+    assert len(bedrock_content) == 3
+    assert bedrock_content[0]["text"] == "Valid text"
+    assert bedrock_content[1]["text"] == "[empty]"
+    assert bedrock_content[2]["text"] == "[empty]"
+
+
 def test__get_provider() -> None:
     llm = ChatBedrockConverse(
         model="anthropic.claude-3-sonnet-20240229-v1:0", region_name="us-west-2"


### PR DESCRIPTION
Fixes #403 

Bedrock Converse API throws a `ValidationError` if it receives input messages with empty or whitespace-only content. This PR updates ChatBedrockConverse to update said message content to an acceptable placeholder string (`[empty]`) for Converse API.