### PR TITLE
fix(bedrock_converse): handle tool blocks without toolConfig

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -65,7 +65,7 @@ _BM = TypeVar("_BM", bound=BaseModel)
 MIME_TO_FORMAT = {
     # Image formats
     "image/png": "png",
-    "image/jpeg": "jpeg", 
+    "image/jpeg": "jpeg",
     "image/gif": "gif",
     "image/webp": "webp",
     # File formats
@@ -533,9 +533,11 @@ class ChatBedrockConverse(BaseChatModel):
         return values
 
     @classmethod
-    def _get_streaming_support(cls, provider: str, model_id_lower: str) -> Union[bool, str]:
+    def _get_streaming_support(
+        cls, provider: str, model_id_lower: str
+    ) -> Union[bool, str]:
         """Determine streaming support for a given provider and model.
-        
+
         Returns:
             True: Full streaming support
             "no_tools": Streaming supported but not with tools
@@ -609,7 +611,7 @@ class ChatBedrockConverse(BaseChatModel):
     @classmethod
     def set_disable_streaming(cls, values: Dict) -> Any:
         model_id = values.get("model_id", values.get("model"))
-        
+
         # Extract provider from the model_id
         # (e.g., "amazon", "anthropic", "ai21", "meta", "mistral")
         if "provider" not in values or values["provider"] == "":
@@ -649,8 +651,8 @@ class ChatBedrockConverse(BaseChatModel):
     @model_validator(mode="after")
     def validate_environment(self) -> Self:
         """Validate that AWS credentials to and python package exists in environment."""
-        
-         # Create bedrock client for control plane API call
+
+        # Create bedrock client for control plane API call
         if self.bedrock_client is None:
             self.bedrock_client = create_aws_client(
                 region_name=self.region_name,
@@ -662,7 +664,7 @@ class ChatBedrockConverse(BaseChatModel):
                 config=self.config,
                 service_name="bedrock",
             )
-            
+
         # Handle streaming configuration for application inference profiles
         if "application-inference-profile" in self.model_id:
             self._configure_streaming_for_resolved_model()
@@ -709,27 +711,30 @@ class ChatBedrockConverse(BaseChatModel):
                 "Provide a guardrail via `guardrail_config` or "
                 "disable `guard_last_turn_only`."
             )
-            
+
         return self
 
     def _get_base_model(self) -> str:
         # identify the base model id used in the application inference profile (AIP)
         # Format: arn:aws:bedrock:us-east-1:<accountId>:application-inference-profile/<id>
-        if self.base_model_id is None and 'application-inference-profile' in self.model_id:
+        if (
+            self.base_model_id is None
+            and "application-inference-profile" in self.model_id
+        ):
             response = self.bedrock_client.get_inference_profile(
                 inferenceProfileIdentifier=self.model_id
             )
-            if 'models' in response and len(response['models']) > 0:
-                model_arn = response['models'][0]['modelArn']
+            if "models" in response and len(response["models"]) > 0:
+                model_arn = response["models"][0]["modelArn"]
                 # Format: arn:aws:bedrock:region::foundation-model/provider.model-name
-                self.base_model_id = model_arn.split('/')[-1]
+                self.base_model_id = model_arn.split("/")[-1]
         return self.base_model_id if self.base_model_id else self.model_id
-        
+
     def _configure_streaming_for_resolved_model(self) -> None:
         """Configure streaming support after resolving the base model for application inference profiles."""
         base_model = self._get_base_model()
         model_id_lower = base_model.lower()
-        
+
         streaming_support = self._get_streaming_support(self.provider, model_id_lower)
 
         # Set the disable_streaming flag accordingly
@@ -780,6 +785,23 @@ class ChatBedrockConverse(BaseChatModel):
                 kwargs, excluded_keys={"inputSchema", "properties", "thinking"}
             ),
         )
+
+        # Check for tool blocks without toolConfig and handle conversion
+        has_tool_blocks = _has_tool_use_or_result_blocks(bedrock_messages)
+        has_tool_config = params.get("toolConfig") is not None
+
+        if has_tool_blocks and not has_tool_config:
+            logger.warning(
+                "Tool messages (toolUse/toolResult) detected without toolConfig. Converting tool blocks to text format to avoid ValidationException."
+            )
+            warnings.warn(
+                "Tool messages were passed without toolConfig, converting to text format",
+                RuntimeWarning,
+            )
+
+            bedrock_messages = _convert_tool_blocks_to_text(bedrock_messages)
+            logger.debug(f"converted input messages: {bedrock_messages}")
+
         logger.debug(f"Input params: {params}")
         logger.info("Using Bedrock Converse API to generate response")
         response = self.client.converse(
@@ -812,6 +834,24 @@ class ChatBedrockConverse(BaseChatModel):
                 kwargs, excluded_keys={"inputSchema", "properties", "thinking"}
             ),
         )
+
+        # Check if toolConfig is missing but tool blocks are present
+        has_tool_blocks = _has_tool_use_or_result_blocks(bedrock_messages)
+        has_tool_config = params.get("toolConfig") is not None
+
+        # Handle conversion
+        if has_tool_blocks and not has_tool_config:
+            logger.warning(
+                "Tool messages (toolUse/toolResult) detected without toolConfig. Converting tool blocks to text format to avoid ValidationException."
+            )
+            warnings.warn(
+                "Tool messages were passed without toolConfig, converting to text format",
+                RuntimeWarning,
+            )
+
+            bedrock_messages = _convert_tool_blocks_to_text(bedrock_messages)
+            logger.debug(f"converted input messages: {bedrock_messages}")
+
         response = self.client.converse_stream(
             messages=bedrock_messages, system=system, **params
         )
@@ -1191,7 +1231,7 @@ def _parse_stream_event(event: Dict[str, Any]) -> Optional[BaseMessageChunk]:
             )
         # always keep block inside a list to preserve merging compatibility
         content = [block]
-        
+
         return AIMessageChunk(content=content, tool_call_chunks=tool_call_chunks)
     elif "contentBlockDelta" in event:
         block = {
@@ -1210,7 +1250,7 @@ def _parse_stream_event(event: Dict[str, Any]) -> Optional[BaseMessageChunk]:
             )
         # always keep block inside a list to preserve merging compatibility
         content = [block]
-        
+
         return AIMessageChunk(content=content, tool_call_chunks=tool_call_chunks)
     elif "contentBlockStop" in event:
         # TODO: needed?
@@ -1241,13 +1281,13 @@ def _mime_type_to_format(mime_type: str) -> str:
 
     if mime_type in MIME_TO_FORMAT:
         return MIME_TO_FORMAT[mime_type]
-    
+
     # Fallback to original method of splitting on "/" for simple cases
     all_formats = set(MIME_TO_FORMAT.values())
     format_part = mime_type.split("/")[1]
     if format_part in all_formats:
         return format_part
-    
+
     raise ValueError(
         f"Unsupported MIME type: {mime_type}. Please refer to the Bedrock Converse API documentation for supported formats."
     )
@@ -1327,7 +1367,9 @@ def _lc_content_to_bedrock(
                 bedrock_content.append(
                     {
                         "image": {
-                            "format": _mime_type_to_format(block["source"]["mediaType"]),
+                            "format": _mime_type_to_format(
+                                block["source"]["mediaType"]
+                            ),
                             "source": {
                                 "bytes": _b64str_to_bytes(block["source"]["data"])
                             },
@@ -1348,7 +1390,9 @@ def _lc_content_to_bedrock(
                     bedrock_content.append(
                         {
                             "video": {
-                                "format": _mime_type_to_format(block["source"]["mediaType"]),
+                                "format": _mime_type_to_format(
+                                    block["source"]["mediaType"]
+                                ),
                                 "source": {
                                     "bytes": _b64str_to_bytes(block["source"]["data"])
                                 },
@@ -1359,7 +1403,9 @@ def _lc_content_to_bedrock(
                     bedrock_content.append(
                         {
                             "video": {
-                                "format": _mime_type_to_format(block["source"]["mediaType"]),
+                                "format": _mime_type_to_format(
+                                    block["source"]["mediaType"]
+                                ),
                                 "source": {"s3Location": block["source"]["data"]},
                             }
                         }
@@ -1750,3 +1796,61 @@ def _is_cache_point(cache_point: Any) -> bool:
         and "cachePoint" in cache_point
         and cache_point.get("cachePoint").get("type") is not None
     )
+
+
+def _has_tool_use_or_result_blocks(messages: List[Dict[str, Any]]) -> bool:
+    """Check if messages contain toolUse or toolResult blocks."""
+    for message in messages:
+        for block in message.get("content", []):
+            if "toolUse" in block or "toolResult" in block:
+                return True
+    return False
+
+
+def _convert_tool_blocks_to_text(
+    messages: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Convert toolUse and toolResult blocks to text blocks preserving only necessary content."""
+    converted_messages = []
+
+    for message in messages:
+        converted_message = {"role": message["role"], "content": []}
+
+        for block in message.get("content", []):
+            if "toolUse" in block:
+                # convert toolUse to simple text
+                tool_use = block["toolUse"]
+                tool_name = tool_use.get("name", "function")
+                tool_inputs = tool_use.get("input", {})
+
+                # format function call description
+                if tool_inputs:
+                    tool_text = f"[Called {tool_name} with parameters: {json.dumps(tool_inputs)}]"
+                else:
+                    tool_text = f"[Called {tool_name}]"
+
+                converted_message["content"].append({"text": tool_text})
+
+            elif "toolResult" in block:
+                # convert toolResult to indicate it's tool output without exposing internal details
+                tool_result = block["toolResult"]
+
+                result_content = ""
+                for content_block in tool_result.get("content", []):
+                    if "text" in content_block:
+                        result_content += content_block["text"]
+                    elif "json" in content_block:
+                        result_content += json.dumps(content_block["json"])
+                    # skip other internal content types
+
+                # only include result if there's actual content, but mark it as tool output
+                if result_content.strip():
+                    tool_output_text = f"[Tool output: {result_content}]"
+                    converted_message["content"].append({"text": tool_output_text})
+            else:
+                # keep other blocks as they are
+                converted_message["content"].append(block)
+
+        converted_messages.append(converted_message)
+
+    return converted_messages

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -23,7 +23,9 @@ from langchain_aws.chat_models.bedrock_converse import (
     _bedrock_to_lc,
     _camel_to_snake,
     _camel_to_snake_keys,
+    _convert_tool_blocks_to_text,
     _extract_response_metadata,
+    _has_tool_use_or_result_blocks,
     _lc_content_to_bedrock,
     _messages_to_bedrock,
     _snake_to_camel,
@@ -1111,7 +1113,7 @@ def test__lc_content_to_bedrock_mime_types() -> None:
     video_data = base64.b64encode(b"video_test_data").decode("utf-8")
     image_data = base64.b64encode(b"image_test_data").decode("utf-8")
     file_data = base64.b64encode(b"file_test_data").decode("utf-8")
-    
+
     # Create content with one of each type
     content: List[Union[str, Dict[str, Any]]] = [
         {
@@ -1138,31 +1140,25 @@ def test__lc_content_to_bedrock_mime_types() -> None:
             "name": "test_document.pdf",
         },
     ]
-    
+
     expected_content = [
         {
             "video": {
                 "format": "mp4",
-                "source": {
-                    "bytes": base64.b64decode(video_data.encode("utf-8"))
-                },
+                "source": {"bytes": base64.b64decode(video_data.encode("utf-8"))},
             }
         },
         {
             "image": {
                 "format": "jpeg",
-                "source": {
-                    "bytes": base64.b64decode(image_data.encode("utf-8"))
-                },
+                "source": {"bytes": base64.b64decode(image_data.encode("utf-8"))},
             }
         },
         {
             "document": {
                 "format": "pdf",
                 "name": "test_document.pdf",
-                "source": {
-                    "bytes": base64.b64decode(file_data.encode("utf-8"))
-                },
+                "source": {"bytes": base64.b64decode(file_data.encode("utf-8"))},
             }
         },
     ]
@@ -1173,27 +1169,31 @@ def test__lc_content_to_bedrock_mime_types() -> None:
 
 def test__lc_content_to_bedrock_mime_types_invalid() -> None:
     with pytest.raises(ValueError, match="Invalid MIME type format"):
-        _lc_content_to_bedrock([
-            {
-                "type": "image",
-                "source": {
-                    "type": "base64",
-                    "mediaType": "invalidmimetype",
-                    "data": base64.b64encode(b"test_data").decode("utf-8"),
-                },
-            }
-        ])
-    
+        _lc_content_to_bedrock(
+            [
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "mediaType": "invalidmimetype",
+                        "data": base64.b64encode(b"test_data").decode("utf-8"),
+                    },
+                }
+            ]
+        )
+
     with pytest.raises(ValueError, match="Unsupported MIME type"):
-        _lc_content_to_bedrock([
-            {
-                "type": "file",
-                "sourceType": "base64",
-                "mimeType": "application/unknown-format",
-                "data": base64.b64encode(b"test_data").decode("utf-8"),
-                "name": "test_document.xyz",
-            }
-        ])
+        _lc_content_to_bedrock(
+            [
+                {
+                    "type": "file",
+                    "sourceType": "base64",
+                    "mimeType": "application/unknown-format",
+                    "data": base64.b64encode(b"test_data").decode("utf-8"),
+                    "name": "test_document.xyz",
+                }
+            ]
+        )
 
 
 def test__get_provider() -> None:
@@ -1473,61 +1473,63 @@ def test_stream_guard_last_turn_only() -> None:
         "guardContent": {"text": {"text": "How are you?"}}
     }
 
+
 @mock.patch("langchain_aws.chat_models.bedrock_converse.create_aws_client")
 def test_bedrock_client_creation(mock_create_client: mock.Mock) -> None:
     """Test that bedrock_client is created during validation."""
     mock_bedrock_client = mock.Mock()
     mock_runtime_client = mock.Mock()
-    
+
     def side_effect(service_name: str, **kwargs: Any) -> mock.Mock:
         if service_name == "bedrock":
             return mock_bedrock_client
         elif service_name == "bedrock-runtime":
             return mock_runtime_client
         return mock.Mock()
-    
+
     mock_create_client.side_effect = side_effect
-    
+
     chat_model = ChatBedrockConverse(
-        model="anthropic.claude-3-sonnet-20240229-v1:0",
-        region_name="us-west-2"
+        model="anthropic.claude-3-sonnet-20240229-v1:0", region_name="us-west-2"
     )
-    
+
     assert chat_model.bedrock_client == mock_bedrock_client
     assert chat_model.client == mock_runtime_client
     assert mock_create_client.call_count == 2
 
 
 @mock.patch("langchain_aws.chat_models.bedrock_converse.create_aws_client")
-def test_get_base_model_with_application_inference_profile(mock_create_client: mock.Mock) -> None:
+def test_get_base_model_with_application_inference_profile(
+    mock_create_client: mock.Mock,
+) -> None:
     """Test _get_base_model method with application inference profile."""
     mock_bedrock_client = mock.Mock()
     mock_runtime_client = mock.Mock()
-    
+
     # Mock the get_inference_profile response
     mock_bedrock_client.get_inference_profile.return_value = {
-        'models': [
+        "models": [
             {
-                'modelArn': 'arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-sonnet-20240229-v1:0'
+                "modelArn": "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-sonnet-20240229-v1:0"
             }
         ]
     }
-    
+
     def side_effect(service_name: str, **kwargs: Any) -> mock.Mock:
         if service_name == "bedrock":
             return mock_bedrock_client
         elif service_name == "bedrock-runtime":
             return mock_runtime_client
         return mock.Mock()
-    
+
     mock_create_client.side_effect = side_effect
-    
+
     chat_model = ChatBedrockConverse(
         model="arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/test-profile",
         region_name="us-west-2",
-        provider="anthropic"
+        provider="anthropic",
     )
-    
+
     base_model = chat_model._get_base_model()
     assert base_model == "anthropic.claude-3-sonnet-20240229-v1:0"
     mock_bedrock_client.get_inference_profile.assert_called_once_with(
@@ -1536,26 +1538,28 @@ def test_get_base_model_with_application_inference_profile(mock_create_client: m
 
 
 @mock.patch("langchain_aws.chat_models.bedrock_converse.create_aws_client")
-def test_get_base_model_without_application_inference_profile(mock_create_client: mock.Mock) -> None:
+def test_get_base_model_without_application_inference_profile(
+    mock_create_client: mock.Mock,
+) -> None:
     """Test _get_base_model method without application inference profile."""
     mock_bedrock_client = mock.Mock()
     mock_runtime_client = mock.Mock()
-    
+
     def side_effect(service_name: str, **kwargs: Any) -> mock.Mock:
         if service_name == "bedrock":
             return mock_bedrock_client
         elif service_name == "bedrock-runtime":
             return mock_runtime_client
         return mock.Mock()
-    
+
     mock_create_client.side_effect = side_effect
-    
+
     chat_model = ChatBedrockConverse(
         model="anthropic.claude-3-sonnet-20240229-v1:0",
         region_name="us-west-2",
-        provider="anthropic"
+        provider="anthropic",
     )
-    
+
     base_model = chat_model._get_base_model()
     assert base_model == "anthropic.claude-3-sonnet-20240229-v1:0"
     mock_bedrock_client.get_inference_profile.assert_not_called()
@@ -1566,104 +1570,183 @@ def test_configure_streaming_for_resolved_model(mock_create_client: mock.Mock) -
     """Test _configure_streaming_for_resolved_model method."""
     mock_bedrock_client = mock.Mock()
     mock_runtime_client = mock.Mock()
-    
+
     # Mock the get_inference_profile response for a model with full streaming support
     mock_bedrock_client.get_inference_profile.return_value = {
-        'models': [
+        "models": [
             {
-                'modelArn': 'arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-sonnet-20240229-v1:0'
+                "modelArn": "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-sonnet-20240229-v1:0"
             }
         ]
     }
-    
+
     def side_effect(service_name: str, **kwargs: Any) -> mock.Mock:
         if service_name == "bedrock":
             return mock_bedrock_client
         elif service_name == "bedrock-runtime":
             return mock_runtime_client
         return mock.Mock()
-    
+
     mock_create_client.side_effect = side_effect
-    
+
     chat_model = ChatBedrockConverse(
         model="arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/test-profile",
         region_name="us-west-2",
-        provider="anthropic"
+        provider="anthropic",
     )
-    
+
     # The streaming should be configured based on the resolved model
     assert chat_model.disable_streaming is False
 
 
 @mock.patch("langchain_aws.chat_models.bedrock_converse.create_aws_client")
-def test_configure_streaming_for_resolved_model_no_tools(mock_create_client: mock.Mock) -> None:
+def test_configure_streaming_for_resolved_model_no_tools(
+    mock_create_client: mock.Mock,
+) -> None:
     """Test _configure_streaming_for_resolved_model method with no-tools streaming."""
     mock_bedrock_client = mock.Mock()
     mock_runtime_client = mock.Mock()
-    
+
     # Mock the get_inference_profile response for a model with no-tools streaming support
     mock_bedrock_client.get_inference_profile.return_value = {
-        'models': [
+        "models": [
             {
-                'modelArn': 'arn:aws:bedrock:us-east-1::foundation-model/amazon.titan-text-express-v1'
+                "modelArn": "arn:aws:bedrock:us-east-1::foundation-model/amazon.titan-text-express-v1"
             }
         ]
     }
-    
+
     def side_effect(service_name: str, **kwargs: Any) -> mock.Mock:
         if service_name == "bedrock":
             return mock_bedrock_client
         elif service_name == "bedrock-runtime":
             return mock_runtime_client
         return mock.Mock()
-    
+
     mock_create_client.side_effect = side_effect
-    
+
     chat_model = ChatBedrockConverse(
         model="arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/test-profile",
         region_name="us-west-2",
-        provider="amazon"
+        provider="amazon",
     )
-    
+
     # The streaming should be configured as "tool_calling" for no-tools models
     assert chat_model.disable_streaming == "tool_calling"
 
 
 @mock.patch("langchain_aws.chat_models.bedrock_converse.create_aws_client")
-def test_configure_streaming_for_resolved_model_no_streaming(mock_create_client: mock.Mock) -> None:
+def test_configure_streaming_for_resolved_model_no_streaming(
+    mock_create_client: mock.Mock,
+) -> None:
     """Test _configure_streaming_for_resolved_model method with no streaming support."""
     mock_bedrock_client = mock.Mock()
     mock_runtime_client = mock.Mock()
-    
+
     # Mock the get_inference_profile response for a model with no streaming support
     mock_bedrock_client.get_inference_profile.return_value = {
-        'models': [
+        "models": [
             {
-                'modelArn': 'arn:aws:bedrock:us-east-1::foundation-model/stability.stable-image-core-v1:0'
+                "modelArn": "arn:aws:bedrock:us-east-1::foundation-model/stability.stable-image-core-v1:0"
             }
         ]
     }
-    
+
     def side_effect(service_name: str, **kwargs: Any) -> mock.Mock:
         if service_name == "bedrock":
             return mock_bedrock_client
         elif service_name == "bedrock-runtime":
             return mock_runtime_client
         return mock.Mock()
-    
+
     mock_create_client.side_effect = side_effect
-    
+
     chat_model = ChatBedrockConverse(
         model="arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/test-profile",
         region_name="us-west-2",
-        provider="stability"
+        provider="stability",
     )
-    
+
     # The streaming should be disabled for models with no streaming support
     assert chat_model.disable_streaming is True
 
-    
+
 def test_nova_provider_extraction() -> None:
     """Test that provider is correctly extracted from Nova model ID when not provided."""
-    model = ChatBedrockConverse(client=mock.MagicMock(), model="us.amazon.nova-pro-v1:0", region_name="us-west-2")
+    model = ChatBedrockConverse(
+        client=mock.MagicMock(),
+        model="us.amazon.nova-pro-v1:0",
+        region_name="us-west-2",
+    )
     assert model.provider == "amazon"
+
+
+def test__has_tool_use_or_result_blocks() -> None:
+    """Test detection of toolUse and toolResult blocks in messages."""
+    # No tool blocks
+    messages_no_tools = [{"role": "user", "content": [{"text": "Hello"}]}]
+    assert not _has_tool_use_or_result_blocks(messages_no_tools)
+
+    # With toolUse blocks
+    messages_with_tools = [
+        {"role": "assistant", "content": [{"toolUse": {"name": "calc"}}]}
+    ]
+    assert _has_tool_use_or_result_blocks(messages_with_tools)
+
+
+def test__convert_tool_blocks_to_text() -> None:
+    """Test conversion of toolUse and toolResult blocks to text format."""
+    input_messages: List[Dict[str, Any]] = [
+        {
+            "role": "assistant",
+            "content": [
+                {"text": "Calculating..."},
+                {"toolUse": {"toolUseId": "1", "name": "calc", "input": {"a": 5}}},
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {"toolResult": {"toolUseId": "1", "content": [{"text": "10"}]}}
+            ],
+        },
+    ]
+
+    result = _convert_tool_blocks_to_text(input_messages)
+
+    # Check toolUse converted to text
+    assert '[Called calc with parameters: {"a": 5}]' in result[0]["content"][1]["text"]
+
+    # Check toolResult converted to text
+    assert "[Tool output: 10]" in result[1]["content"][0]["text"]
+
+
+def test_tool_conversion_warning_integration() -> None:
+    """Test that tool blocks without toolConfig trigger conversion and warning."""
+    mocked_client = mock.MagicMock()
+    mocked_client.converse.return_value = {
+        "output": {"message": {"content": [{"text": "Done"}]}},
+        "usage": {"inputTokens": 1, "outputTokens": 1, "totalTokens": 2},
+    }
+
+    llm = ChatBedrockConverse(
+        client=mocked_client,
+        model="anthropic.claude-3-sonnet-20240229-v1:0",
+        region_name="us-west-2",
+    )
+
+    messages = [
+        AIMessage(
+            content="",
+            tool_calls=[ToolCall(name="calc", args={"x": 1}, id="1", type="tool_call")],
+        )
+    ]
+
+    with pytest.warns(
+        RuntimeWarning, match="Tool messages were passed without toolConfig"
+    ):
+        llm.invoke(messages)
+
+    # Verify conversion happened
+    call_args = mocked_client.converse.call_args[1]["messages"]
+    assert any("Called calc" in str(block) for block in call_args[0]["content"])


### PR DESCRIPTION
Fixes: #591 


The ToolConfig ValidationException happens when using summarization nodes with `create_react_agent`. The issue is that the summarization node gets messages from the react agent that contain tool calls, but the summarizer is usually a different LLM client and isn't bound with the main agent's tools. So when the summarization model calls Bedrock Converse API, it fails because there are tool blocks but no `toolConfig`.

Instead of just throwing a ValidationException, this change converts tool blocks to text format when `toolConfig` is missing. This way the summarization model still gets the tool call context but in a text format.

I considered just removing the tool messages completely, but that would make the summarization node lose context about what tools were called and their results.

This fix happens at API call level so it won't interfere with other LangChain/LangGraph modules, and it only runs when there is a mismatch between having tool blocks but no toolConfig, which shouldn't happen in normal circumstances where llms are properly bound with tools.