### PR TITLE
fix: Final assistant content cannot end with trailing whitespace

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -429,7 +429,17 @@ def _format_anthropic_messages(
     system: Optional[Union[str, List[Dict]]] = None
     formatted_messages: List[Dict] = []
 
-    merged_messages = _merge_messages(messages)
+    # Check if the last message is an AIMessage with trailing whitespace
+    messages_copy = messages.copy()
+    if messages_copy and isinstance(messages_copy[-1], AIMessage):
+        if isinstance(messages_copy[-1].content, str):
+            messages_copy[-1].content = messages_copy[-1].content.rstrip()
+        elif isinstance(messages_copy[-1].content, list):
+            for j, block in enumerate(messages_copy[-1].content):
+                if isinstance(block, dict) and block.get("type") == "text" and isinstance(block.get("text"), str):
+                    messages_copy[-1].content[j]["text"] = block["text"].rstrip()
+
+    merged_messages = _merge_messages(messages_copy)
     for i, message in enumerate(merged_messages):
         if message.type == "system":
             if i != 0:

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -1776,3 +1776,63 @@ def test_nova_provider_extraction() -> None:
     """Test that provider is correctly extracted from Nova model ID when not provided."""
     model = ChatBedrockConverse(client=mock.MagicMock(), model="us.amazon.nova-pro-v1:0", region_name="us-west-2")
     assert model.provider == "amazon"
+
+
+def test__messages_to_bedrock_strips_trailing_whitespace_string() -> None:
+    """Test that _messages_to_bedrock strips trailing whitespace from string AIMessage content."""
+    messages = [
+        SystemMessage(content="System message"),
+        HumanMessage(content="Human message"),
+        AIMessage(content="AI message with trailing whitespace    \n  \t  "),
+    ]
+    
+    bedrock_messages, _ = _messages_to_bedrock(messages)
+
+    assert bedrock_messages[1]["content"][0]["text"] == "AI message with trailing whitespace"
+
+
+def test__messages_to_bedrock_strips_trailing_whitespace_blocks() -> None:
+    """Test that _messages_to_bedrock strips trailing whitespace from block AIMessage content."""
+    messages = [
+        SystemMessage(content="System message"),
+        HumanMessage(content="Human message"),
+        AIMessage(content=[
+            {"type": "text", "text": "AI message with trailing whitespace    \n  \t  "},
+            {"type": "text", "text": "Another text block with whitespace  \n "}
+        ]),
+    ]
+    
+    bedrock_messages, _ = _messages_to_bedrock(messages)
+
+    assert bedrock_messages[1]["content"][0]["text"] == "AI message with trailing whitespace"
+    assert bedrock_messages[1]["content"][1]["text"] == "Another text block with whitespace"
+
+
+def test__messages_to_bedrock_preserves_whitespace_non_last_aimessage_string() -> None:
+    """Test that _messages_to_bedrock preserves trailing whitespace in non-last AIMessages."""
+    messages = [
+        SystemMessage(content="System message"),
+        HumanMessage(content="First human message"),
+        AIMessage(content="AI message with trailing whitespace    \n  \t  "),
+        HumanMessage(content="Second human message"),
+    ]
+    
+    bedrock_messages, _ = _messages_to_bedrock(messages)
+
+    assert bedrock_messages[1]["content"][0]["text"] == "AI message with trailing whitespace    \n  \t  "
+
+
+def test__messages_to_bedrock_preserves_whitespace_non_last_aimessage_blocks() -> None:
+    """Test that _messages_to_bedrock preserves trailing whitespace in non-last AIMessages."""
+    messages = [
+        SystemMessage(content="System message"),
+        HumanMessage(content="First human message"),
+        AIMessage(content=[
+            {"type": "text", "text": "AI message with trailing whitespace    \n  \t  "},
+        ]),
+        HumanMessage(content="Second human message"),
+    ]
+    
+    bedrock_messages, _ = _messages_to_bedrock(messages)
+
+    assert bedrock_messages[1]["content"][0]["text"] == "AI message with trailing whitespace    \n  \t  "


### PR DESCRIPTION
Fixes #532 

Currently, Bedrock Invoke and Converse API will fail if the penultimate message in conversation history input is an AIMessage with trailing whitespace content:
```
ValidationException: An error occurred (ValidationException) when calling the InvokeModelWithResponseStream operation: messages: final assistant content cannot end with trailing whitespace
```

This PR updates ChatBedrock and ChatBedrockConverse to check for the presence of and strip said whitespace before submission to the Bedrock APIs.