### PR TITLE
fix: add support for `amer` and `global` bedrock cross region inference profiles

### DIFF
--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -838,7 +838,7 @@ class BedrockBase(BaseLanguageModel, ABC):
         parts = self.model_id.split(".", maxsplit=2)
         return (
             parts[1]
-            if (len(parts) > 1 and parts[0].lower() in {"eu", "us", "us-gov", "apac", "sa"})
+            if (len(parts) > 1 and parts[0].lower() in {"eu", "us", "us-gov", "apac", "sa","amer"})
             else parts[0]
         )
 

--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -838,7 +838,7 @@ class BedrockBase(BaseLanguageModel, ABC):
         parts = self.model_id.split(".", maxsplit=2)
         return (
             parts[1]
-            if (len(parts) > 1 and parts[0].lower() in {"eu", "us", "us-gov", "apac", "sa","amer"})
+            if (len(parts) > 1 and parts[0].lower() in {"eu", "us", "us-gov", "apac", "sa", "amer", "global"})
             else parts[0]
         )
 

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
@@ -558,6 +558,20 @@ def test_beta_use_converse_api() -> None:
     "model_id, provider, expected_provider, expectation, region_name",
     [
         (
+            "amer.amazon.nova-pro-v1:0",
+            None,
+            "amazon",
+            nullcontext(),
+            "us-west-2",
+        ),
+        (
+            "global.anthropic.claude-sonnet-4-20250514-v1:0",
+            None,
+            "anthropic",
+            nullcontext(),
+            "us-west-2",
+        ),
+        (
             "eu.anthropic.claude-3-haiku-20240307-v1:0",
             None,
             "anthropic",


### PR DESCRIPTION
AWS has added inference profiles that begin with "amer" and "global". This change allow ChatBedrock to correctly recognize such inference profiles