### PR TITLE
fix: add support for 'global' cross-region inference profile

### DIFF
--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -838,7 +838,7 @@ class BedrockBase(BaseLanguageModel, ABC):
         parts = self.model_id.split(".", maxsplit=2)
         return (
             parts[1]
-            if (len(parts) > 1 and parts[0].lower() in {"eu", "us", "us-gov", "apac", "sa"})
+            if (len(parts) > 1 and parts[0].lower() in {"eu", "us", "us-gov", "apac", "sa", "global"})
             else parts[0]
         )
 


### PR DESCRIPTION
**Description:**  
AWS recently introduced a **Global cross-region inference profile** for Amazon Bedrock, which is currently supported with the Anthropic Claude Sonnet 4 model. This profile allows requests from specific source Regions (US West (Oregon), US East (N. Virginia), US East (Ohio), Europe (Ireland), Asia Pacific (Tokyo)) to perform inference across **all commercial AWS Regions**.  

To support this new feature, this PR updates the parsing logic in `libs/aws/langchain_aws/llms/bedrock.py` so that `'global'` is recognized as a valid region prefix when extracting the region from `model_id`. This ensures that applications using LangChain AWS integrations can seamlessly take advantage of the new global inference capability.  

**Change summary:**  
- Updated region-parsing logic to add `"global"` as a valid prefix in `model_id` handling.  
- Aligns library behavior with the newly released AWS Bedrock inference profile.  

**References:**  
- [AWS Bedrock – Global cross-region inference profile (Claude Sonnet 4)](https://aws.amazon.com/about-aws/whats-new/2025/09/amazon-bedrock-global-cross-region-inference-anthropic-claude-sonnet-4/)  
