### PR TITLE
fix: Optimize base model identification for application inference profiles

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -668,6 +668,16 @@ class ChatBedrockConverse(BaseChatModel):
                 service_name="bedrock",
             )
 
+        # For AIPs, pull base model ID via GetInferenceProfile API call
+        if self.base_model_id is None and 'application-inference-profile' in self.model_id:
+            response = self.bedrock_client.get_inference_profile(
+                inferenceProfileIdentifier=self.model_id
+            )
+            if "models" in response and len(response["models"]) > 0:
+                model_arn = response["models"][0]["modelArn"]
+                # Format: arn:aws:bedrock:region::foundation-model/provider.model-name
+                self.base_model_id = model_arn.split("/")[-1]
+
         # Handle streaming configuration for application inference profiles
         if "application-inference-profile" in self.model_id:
             self._configure_streaming_for_resolved_model()
@@ -718,19 +728,6 @@ class ChatBedrockConverse(BaseChatModel):
         return self
 
     def _get_base_model(self) -> str:
-        # identify the base model id used in the application inference profile (AIP)
-        # Format: arn:aws:bedrock:us-east-1:<accountId>:application-inference-profile/<id>
-        if (
-            self.base_model_id is None
-            and "application-inference-profile" in self.model_id
-        ):
-            response = self.bedrock_client.get_inference_profile(
-                inferenceProfileIdentifier=self.model_id
-            )
-            if "models" in response and len(response["models"]) > 0:
-                model_arn = response["models"][0]["modelArn"]
-                # Format: arn:aws:bedrock:region::foundation-model/provider.model-name
-                self.base_model_id = model_arn.split("/")[-1]
         return self.base_model_id if self.base_model_id else self.model_id
 
     def _configure_streaming_for_resolved_model(self) -> None:

--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -803,6 +803,15 @@ class BedrockBase(BaseLanguageModel, ABC):
                 service_name="bedrock",
             )
 
+        if self.base_model_id is None and 'application-inference-profile' in self.model_id:
+            response = self.bedrock_client.get_inference_profile(
+                inferenceProfileIdentifier=self.model_id
+            )
+            if 'models' in response and len(response['models']) > 0:
+                model_arn = response['models'][0]['modelArn']
+                # Format: arn:aws:bedrock:region::foundation-model/provider.model-name
+                self.base_model_id = model_arn.split('/')[-1]
+
         return self
 
     @property
@@ -843,16 +852,6 @@ class BedrockBase(BaseLanguageModel, ABC):
         )
 
     def _get_base_model(self) -> str:
-        # identify the base model id used in the application inference profile (AIP)
-        # Format: arn:aws:bedrock:us-east-1:<accountId>:application-inference-profile/<id>
-        if self.base_model_id is None and 'application-inference-profile' in self.model_id:
-            response = self.bedrock_client.get_inference_profile(
-                inferenceProfileIdentifier=self.model_id
-            )
-            if 'models' in response and len(response['models']) > 0:
-                model_arn = response['models'][0]['modelArn']
-                # Format: arn:aws:bedrock:region::foundation-model/provider.model-name
-                self.base_model_id = model_arn.split('/')[-1]
         return self.base_model_id if self.base_model_id else self.model_id.split(".", maxsplit=1)[-1]
 
     @property

--- a/libs/aws/tests/unit_tests/llms/test_bedrock.py
+++ b/libs/aws/tests/unit_tests/llms/test_bedrock.py
@@ -820,7 +820,7 @@ def test_get_base_model_with_application_inference_profile(mock_create_client):
     mock_bedrock_client = MagicMock()
     mock_bedrock_client.get_inference_profile.return_value = {
         "models": [
-            {"modelArn": "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-sonnet-20240229-v1:0"}
+            {"modelArn": "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-4-20250514-v1:0"}
         ]
     }
     mock_create_client.side_effect = [mock_runtime_client, mock_bedrock_client]
@@ -837,5 +837,5 @@ def test_get_base_model_with_application_inference_profile(mock_create_client):
     mock_bedrock_client.get_inference_profile.assert_called_once_with(
         inferenceProfileIdentifier="arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/my-profile"
     )
-    assert result == "anthropic.claude-3-sonnet-20240229-v1:0"
-    assert llm.base_model_id == "anthropic.claude-3-sonnet-20240229-v1:0"
+    assert result == "anthropic.claude-sonnet-4-20250514-v1:0"
+    assert llm.base_model_id == "anthropic.claude-sonnet-4-20250514-v1:0"


### PR DESCRIPTION
This PR updates BedrockBase and ChatBedrockConverse to optimize the identification of base model IDs for application inference profiles. 

Currently, the `base_model_id` check and potential Bedrock GetInferenceProfile API call are done inside the `_get_base_model` method, which may cause a new API request to be executed on every invocation of the chat model. We can instead relocate this mechanism to the environment pre-validator method - this will ensure that we make the extra API request only once, on instantiation of ChatBedrock/ChatBedrockConverse.