### PR TITLE
Allow all claude models with thinking enabled to accept tool_choice = "auto" + update associated code and tests

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -349,16 +349,16 @@ class ChatBedrockConverse(BaseChatModel):
 
     model_id: str = Field(alias="model")
     """Id of the model to call.
-    
-    e.g., ``"anthropic.claude-3-sonnet-20240229-v1:0"``. This is equivalent to the 
-    modelID property in the list-foundation-models api. For custom and provisioned 
-    models, an ARN value is expected. See 
-    https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html#model-ids-arns 
+
+    e.g., ``"anthropic.claude-3-sonnet-20240229-v1:0"``. This is equivalent to the
+    modelID property in the list-foundation-models api. For custom and provisioned
+    models, an ARN value is expected. See
+    https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html#model-ids-arns
     for a list of all supported built-in models.
     """
 
     base_model_id: Optional[str] = Field(default=None, alias="base_model")
-    """An optional field to pass the base model id. If provided, this will be used over 
+    """An optional field to pass the base model id. If provided, this will be used over
     the value of model_id to identify the base model.
     """
 
@@ -373,73 +373,73 @@ class ChatBedrockConverse(BaseChatModel):
 
     top_p: Optional[float] = None
     """The percentage of most-likely candidates that are considered for the next token.
-    
+
     Must be 0 to 1.
-    
-    For example, if you choose a value of 0.8 for topP, the model selects from 
-    the top 80% of the probability distribution of tokens that could be next in the 
+
+    For example, if you choose a value of 0.8 for topP, the model selects from
+    the top 80% of the probability distribution of tokens that could be next in the
     sequence."""
 
     region_name: Optional[str] = None
-    """The aws region, e.g., `us-west-2`. 
-    
-    Falls back to AWS_REGION or AWS_DEFAULT_REGION env variable or region specified in 
+    """The aws region, e.g., `us-west-2`.
+
+    Falls back to AWS_REGION or AWS_DEFAULT_REGION env variable or region specified in
     ~/.aws/config in case it is not provided here.
     """
 
     credentials_profile_name: Optional[str] = Field(default=None, exclude=True)
     """The name of the profile in the ~/.aws/credentials or ~/.aws/config files.
-    
+
     Profile should either have access keys or role information specified.
     If not specified, the default credential profile or, if on an EC2 instance,
-    credentials from IMDS will be used. 
+    credentials from IMDS will be used.
     See: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html
     """
 
     aws_access_key_id: Optional[SecretStr] = Field(
         default_factory=secret_from_env("AWS_ACCESS_KEY_ID", default=None)
     )
-    """AWS access key id. 
-    
+    """AWS access key id.
+
     If provided, aws_secret_access_key must also be provided.
     If not specified, the default credential profile or, if on an EC2 instance,
     credentials from IMDS will be used.
     See: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html
-    
+
     If not provided, will be read from 'AWS_ACCESS_KEY_ID' environment variable.
     """
 
     aws_secret_access_key: Optional[SecretStr] = Field(
         default_factory=secret_from_env("AWS_SECRET_ACCESS_KEY", default=None)
     )
-    """AWS secret_access_key. 
-    
+    """AWS secret_access_key.
+
     If provided, aws_access_key_id must also be provided.
     If not specified, the default credential profile or, if on an EC2 instance,
     credentials from IMDS will be used.
     See: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html
-    
+
     If not provided, will be read from 'AWS_SECRET_ACCESS_KEY' environment variable.
     """
 
     aws_session_token: Optional[SecretStr] = Field(
         default_factory=secret_from_env("AWS_SESSION_TOKEN", default=None)
     )
-    """AWS session token. 
-    
-    If provided, aws_access_key_id and aws_secret_access_key must 
+    """AWS session token.
+
+    If provided, aws_access_key_id and aws_secret_access_key must
     also be provided. Not required unless using temporary credentials.
     See: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html
-    
+
     If not provided, will be read from 'AWS_SESSION_TOKEN' environment variable.
     """
 
     provider: str = ""
-    """The model provider, e.g., amazon, cohere, ai21, etc. 
-    
-    When not supplied, provider is extracted from the first part of the model_id, e.g. 
-    'amazon' in 'amazon.titan-text-express-v1'. This value should be provided for model 
-    ids that do not have the provider in them, like custom and provisioned models that 
+    """The model provider, e.g., amazon, cohere, ai21, etc.
+
+    When not supplied, provider is extracted from the first part of the model_id, e.g.
+    'amazon' in 'amazon.titan-text-express-v1'. This value should be provided for model
+    ids that do not have the provider in them, like custom and provisioned models that
     have an ARN associated with them.
     """
 
@@ -454,16 +454,16 @@ class ChatBedrockConverse(BaseChatModel):
 
     additional_model_request_fields: Optional[Dict[str, Any]] = None
     """Additional inference parameters that the model supports.
-    
+
     Parameters beyond the base set of inference parameters that Converse supports in the
     inferenceConfig field.
     """
 
     additional_model_response_field_paths: Optional[List[str]] = None
-    """Additional model parameters field paths to return in the response. 
-    
-    Converse returns the requested fields as a JSON Pointer object in the 
-    additionalModelResponseFields field. The following is example JSON for 
+    """Additional model parameters field paths to return in the response.
+
+    Converse returns the requested fields as a JSON Pointer object in the
+    additionalModelResponseFields field. The following is example JSON for
     additionalModelResponseFieldPaths.
     """
 
@@ -471,16 +471,16 @@ class ChatBedrockConverse(BaseChatModel):
         Sequence[Literal["auto", "any", "tool"]]
     ] = None
     """Which types of tool_choice values the model supports.
-    
-    Inferred if not specified. Inferred as ('auto', 'any', 'tool') if a 'claude-3' 
-    model is used, ('auto', 'any') if a 'mistral-large' model is used, 
+
+    Inferred if not specified. Inferred as ('auto', 'any', 'tool') if a 'claude-3'
+    model is used, ('auto', 'any') if a 'mistral-large' model is used,
     ('auto') if a 'nova' model is used, empty otherwise.
     """
 
     performance_config: Optional[Mapping[str, Any]] = Field(
         default=None,
         description="""Performance configuration settings for latency optimization.
-        
+
         Example:
             performance_config={'latency': 'optimized'}
         If not provided, defaults to standard latency.
@@ -675,13 +675,15 @@ class ChatBedrockConverse(BaseChatModel):
             bedrock_client_cfg = {}
             if self.client:
                 try:
-                    if hasattr(self.client, 'meta') and hasattr(self.client.meta, 'region_name'):
-                        bedrock_client_cfg['region_name'] = self.client.meta.region_name
+                    if hasattr(self.client, "meta") and hasattr(
+                        self.client.meta, "region_name"
+                    ):
+                        bedrock_client_cfg["region_name"] = self.client.meta.region_name
                 except (AttributeError, TypeError):
                     pass
-                
+
             self.bedrock_client = create_aws_client(
-                region_name=self.region_name or bedrock_client_cfg.get('region_name'),
+                region_name=self.region_name or bedrock_client_cfg.get("region_name"),
                 credentials_profile_name=self.credentials_profile_name,
                 aws_access_key_id=self.aws_access_key_id,
                 aws_secret_access_key=self.aws_secret_access_key,
@@ -692,9 +694,12 @@ class ChatBedrockConverse(BaseChatModel):
             )
 
         # For AIPs, pull base model ID via GetInferenceProfile API call
-        if self.base_model_id is None and 'application-inference-profile' in self.model_id:
+        if (
+            self.base_model_id is None
+            and "application-inference-profile" in self.model_id
+        ):
             response = self.bedrock_client.get_inference_profile(
-                inferenceProfileIdentifier = self.model_id
+                inferenceProfileIdentifier=self.model_id
             )
             if "models" in response and len(response["models"]) > 0:
                 model_arn = response["models"][0]["modelArn"]
@@ -712,14 +717,19 @@ class ChatBedrockConverse(BaseChatModel):
             base_model = self._get_base_model()
             if "claude" in base_model:
                 # Tool choice not supported when thinking is enabled
+                thinking_claude_models = (
+                    "claude-3-7-sonnet",
+                    "claude-sonnet-4",
+                    "claude-opus-4",
+                )
                 thinking_params = (self.additional_model_request_fields or {}).get(
                     "thinking", {}
                 )
                 if (
-                    "claude-3-7-sonnet" in base_model
+                    any(model in base_model for model in thinking_claude_models)
                     and thinking_params.get("type") == "enabled"
                 ):
-                    self.supports_tool_choice_values = ()
+                    self.supports_tool_choice_values = ("auto",)
                 else:
                     self.supports_tool_choice_values = ("auto", "any", "tool")
             elif "llama4" in base_model:
@@ -810,7 +820,9 @@ class ChatBedrockConverse(BaseChatModel):
         )
 
         # Check for tool blocks without toolConfig and handle conversion
-        if params.get("toolConfig") is None and _has_tool_use_or_result_blocks(bedrock_messages):
+        if params.get("toolConfig") is None and _has_tool_use_or_result_blocks(
+            bedrock_messages
+        ):
             logger.warning(
                 "Tool messages (toolUse/toolResult) detected without toolConfig. "
                 "Converting tool blocks to text format to avoid ValidationException."
@@ -857,7 +869,9 @@ class ChatBedrockConverse(BaseChatModel):
         )
 
         # Check for tool blocks without toolConfig and handle conversion
-        if params.get("toolConfig") is None and _has_tool_use_or_result_blocks(bedrock_messages):
+        if params.get("toolConfig") is None and _has_tool_use_or_result_blocks(
+            bedrock_messages
+        ):
             logger.warning(
                 "Tool messages (toolUse/toolResult) detected without toolConfig. "
                 "Converting tool blocks to text format to avoid ValidationException."
@@ -981,9 +995,16 @@ class ChatBedrockConverse(BaseChatModel):
             tool_choice = "any"
         else:
             tool_choice = None
-        if tool_choice is None and "claude-3-7-sonnet" in self._get_base_model():
-            # TODO: remove restriction to Claude 3.7. If a model does not support
-            # forced tool calling, we we should raise an exception instead of
+        thinking_claude_models = (
+            "claude-3-7-sonnet",
+            "claude-sonnet-4",
+            "claude-opus-4",
+        )
+        if tool_choice is None and any(
+            model in self._get_base_model() for model in thinking_claude_models
+        ):
+            # TODO: remove restriction to thinking Claude models. If a model does not
+            # support forced tool calling, we we should raise an exception instead of
             # returning None when no tool calls are generated.
             llm = self._get_llm_for_structured_output_no_tool_choice(schema)
         else:
@@ -1125,7 +1146,7 @@ def _messages_to_bedrock(
     bedrock_system: List[Dict[str, Any]] = []
     trimmed_messages = trim_message_whitespace(messages)
     messages = merge_message_runs(trimmed_messages)
-    
+
     for msg in messages:
         content = _lc_content_to_bedrock(msg.content)
         if isinstance(msg, HumanMessage):
@@ -1172,7 +1193,7 @@ def _messages_to_bedrock(
             bedrock_messages.append(curr)
         else:
             raise ValueError(f"Unsupported message type {type(msg)}")
-        
+
     if not bedrock_messages:
         bedrock_messages.append({"role": "user", "content": [{"text": EMPTY_CONTENT}]})
 
@@ -1388,7 +1409,9 @@ def _lc_content_to_bedrock(
         ):
             bedrock_content.append(_format_data_content_block(block))
         elif block["type"] == "text":
-            if not block["text"] or (isinstance(block["text"], str) and block["text"].isspace()):
+            if not block["text"] or (
+                isinstance(block["text"], str) and block["text"].isspace()
+            ):
                 bedrock_content.append({"text": EMPTY_CONTENT})
             else:
                 text_block = {"text": block["text"]}
@@ -1646,11 +1669,7 @@ def _bedrock_to_lc(content: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
 
         elif "citation" in block:  # streaming citations
             lc_content.append(
-                {
-                    "type": "text",
-                    "text": "",
-                    "citations": [block["citation"]]
-                }
+                {"type": "text", "text": "", "citations": [block["citation"]]}
             )
 
         else:

--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
@@ -1,7 +1,7 @@
 """Standard LangChain interface tests"""
 
 import base64
-from typing import Any, Literal, Type, Optional
+from typing import Any, Literal, Optional, Type
 
 import httpx
 import pytest
@@ -12,7 +12,7 @@ from langchain_core.messages import (
     AIMessageChunk,
     BaseMessageChunk,
     HumanMessage,
-    SystemMessage
+    SystemMessage,
 )
 from langchain_core.tools import BaseTool
 from langchain_tests.integration_tests import ChatModelIntegrationTests
@@ -193,8 +193,7 @@ class TestBedrockMetaStandard(ChatModelIntegrationTests):
 
 def test_multiple_system_messages_anthropic() -> None:
     model = ChatBedrockConverse(
-        model="us.anthropic.claude-3-7-sonnet-20250219-v1:0",
-        temperature=0
+        model="us.anthropic.claude-3-7-sonnet-20250219-v1:0", temperature=0
     )
 
     system1 = SystemMessage(content="You are a helpful assistant.")
@@ -422,8 +421,16 @@ def test_guardrails() -> None:
     assert response.response_metadata["trace"] is not None
 
 
-def test_structured_output_tool_choice_not_supported() -> None:
-    llm = ChatBedrockConverse(model="us.anthropic.claude-3-7-sonnet-20250219-v1:0")
+@pytest.mark.parametrize(
+    "thinking_model",
+    [
+        "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+        "us.anthropic.claude-sonnet-4-20250514-v1:0",
+        "us.anthropic.claude-opus-4-20250514-v1:0",
+    ],
+)
+def test_structured_output_tool_choice_not_supported(thinking_model) -> None:
+    llm = ChatBedrockConverse(model=thinking_model)
     with pytest.warns(None) as record:  # type: ignore[call-overload]
         structured_llm = llm.with_structured_output(ClassifyQuery)
         response = structured_llm.invoke("How big are cats?")
@@ -432,7 +439,7 @@ def test_structured_output_tool_choice_not_supported() -> None:
 
     # Unsupported params
     llm = ChatBedrockConverse(
-        model="us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+        model=thinking_model,
         max_tokens=5000,
         additional_model_request_fields={
             "thinking": {"type": "enabled", "budget_tokens": 2000}
@@ -523,7 +530,10 @@ def test_thinking() -> None:
     next_message = {"role": "user", "content": "Thanks!"}
     response = llm.invoke([input_message, full, next_message])
 
-    assert [block["type"] for block in response.content] == ["reasoning_content", "text"]  # type: ignore[index,union-attr]
+    assert [block["type"] for block in response.content] == [
+        "reasoning_content",
+        "text",
+    ]  # type: ignore[index,union-attr]
     assert "text" in response.content[0]["reasoning_content"]  # type: ignore[index,union-attr]
     assert "signature" in response.content[0]["reasoning_content"]  # type: ignore[index,union-attr]
 
@@ -570,10 +580,10 @@ STANDARD_PDF_DOCUMENT = {
     "name": "my-pdf",  # Converse requires a filename
 }
 
+
 @pytest.mark.vcr
 @pytest.mark.parametrize("document", [PLAINTEXT_DOCUMENT, BLOCKS_DOCUMENT])
 def test_citations(document: dict[str, Any]) -> None:
-
     llm = ChatBedrockConverse(model="us.anthropic.claude-sonnet-4-20250514-v1:0")
 
     input_message = {
@@ -581,7 +591,7 @@ def test_citations(document: dict[str, Any]) -> None:
         "content": [
             document,
             {"type": "text", "text": "How many days of annual leave do employees get?"},
-        ]
+        ],
     }
 
     full: Optional[BaseMessageChunk] = None

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -9,11 +9,11 @@ import pytest
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import (
     AIMessage,
+    BaseMessage,
     HumanMessage,
     SystemMessage,
     ToolCall,
     ToolMessage,
-    BaseMessage
 )
 from langchain_core.runnables import RunnableBinding
 from langchain_tests.unit_tests import ChatModelUnitTests
@@ -114,6 +114,36 @@ def test_anthropic_bind_tools_tool_choice() -> None:
     }
 
 
+@pytest.mark.parametrize(
+    "thinking_model",
+    [
+        "anthropic.claude-3-7-sonnet-20250219-v1:0",
+        "anthropic.claude-sonnet-4-20250514-v1:0",
+        "anthropic.claude-opus-4-20250514-v1:0",
+    ],
+)
+def test_anthropic_thinking_bind_tools_tool_choice(thinking_model: str) -> None:
+    chat_model = ChatBedrockConverse(
+        model=thinking_model,
+        region_name="us-west-2",
+        additional_model_request_fields={
+            "thinking": {"type": "enabled", "budget_tokens": 1024},
+        },
+    )
+    chat_model_with_tools = chat_model.bind_tools([GetWeather], tool_choice="auto")
+    assert cast(RunnableBinding, chat_model_with_tools).kwargs["tool_choice"] == {
+        "auto": {}
+    }
+    with pytest.raises(ValueError):
+        chat_model.bind_tools([GetWeather], tool_choice="any")
+    with pytest.raises(ValueError):
+        chat_model.bind_tools([GetWeather], tool_choice="GetWeather")
+    with pytest.raises(ValueError):
+        chat_model.bind_tools(
+            [GetWeather], tool_choice={"tool": {"name": "GetWeather"}}
+        )
+
+
 def test_amazon_bind_tools_tool_choice() -> None:
     chat_model = ChatBedrockConverse(
         model="us.amazon.nova-lite-v1:0", region_name="us-east-1"
@@ -142,14 +172,13 @@ def test_amazon_bind_tools_tool_choice() -> None:
         ("us.meta.llama3-2-90b-instruct-v1:0", True),
         ("us.meta.llama3-2-1b-instruct-v1:0", False),
         ("us.meta.llama3-1-405b-instruct-v1:0", True),
-        ("meta.llama3-70b-instruct-v1:0", False)
+        ("meta.llama3-70b-instruct-v1:0", False),
     ],
 )
-def test_llama_bind_tools_tool_choice_variants(model: str, should_support_auto: bool) -> None:
-    chat_model = ChatBedrockConverse(
-        model=model,
-        region_name="us-east-1"
-    )  # type: ignore[call-arg]
+def test_llama_bind_tools_tool_choice_variants(
+    model: str, should_support_auto: bool
+) -> None:
+    chat_model = ChatBedrockConverse(model=model, region_name="us-east-1")  # type: ignore[call-arg]
 
     if should_support_auto:
         chat_model_with_tools = chat_model.bind_tools([GetWeather], tool_choice="auto")
@@ -423,9 +452,7 @@ def test__messages_to_bedrock_empty_list() -> None:
     messages: List[BaseMessage] = []
     actual_messages, actual_system = _messages_to_bedrock(messages)
 
-    expected_messages: List[Dict] = [
-        {"role": "user", "content": [{"text": "."}]}
-    ]
+    expected_messages: List[Dict] = [{"role": "user", "content": [{"text": "."}]}]
     expected_system: List[Dict] = []
 
     assert expected_messages == actual_messages
@@ -438,12 +465,8 @@ def test__messages_to_bedrock_system_only() -> None:
     ]
     actual_messages, actual_system = _messages_to_bedrock(messages)
 
-    expected_messages: List[Dict] = [
-        {"role": "user", "content": [{"text": "."}]}
-    ]
-    expected_system: List[Dict] = [
-        {"text": "You are a helpful assistant."}
-    ]
+    expected_messages: List[Dict] = [{"role": "user", "content": [{"text": "."}]}]
+    expected_system: List[Dict] = [{"text": "You are a helpful assistant."}]
 
     assert expected_messages == actual_messages
     assert expected_system == actual_system
@@ -1266,27 +1289,27 @@ def test__lc_content_to_bedrock_mime_types_invalid() -> None:
 
 def test__lc_content_to_bedrock_empty_content() -> None:
     content: List[Union[str, Dict[str, Any]]] = []
-    
+
     bedrock_content = _lc_content_to_bedrock(content)
-    
+
     assert len(bedrock_content) > 0
     assert bedrock_content[0]["text"] == "."
 
 
 def test__lc_content_to_bedrock_whitespace_only_content() -> None:
     content = "   \n  \t  "
-    
+
     bedrock_content = _lc_content_to_bedrock(content)
-    
+
     assert len(bedrock_content) > 0
     assert bedrock_content[0]["text"] == "."
 
 
 def test__lc_content_to_bedrock_empty_string_content() -> None:
     content = ""
-    
+
     bedrock_content = _lc_content_to_bedrock(content)
-    
+
     assert len(bedrock_content) > 0
     assert bedrock_content[0]["text"] == "."
 
@@ -1295,9 +1318,9 @@ def test__lc_content_to_bedrock_mixed_empty_content() -> None:
     content: List[Union[str, Dict[str, Any]]] = [
         {"type": "text", "text": ""},
         {"type": "text", "text": "   "},
-        {"type": "text", "text": ""}
+        {"type": "text", "text": ""},
     ]
-    
+
     bedrock_content = _lc_content_to_bedrock(content)
 
     assert len(bedrock_content) > 0
@@ -1305,23 +1328,19 @@ def test__lc_content_to_bedrock_mixed_empty_content() -> None:
 
 
 def test__lc_content_to_bedrock_empty_text_block() -> None:
-    content: List[Union[str, Dict[str, Any]]] = [
-        {"type": "text", "text": ""}
-    ]
-    
+    content: List[Union[str, Dict[str, Any]]] = [{"type": "text", "text": ""}]
+
     bedrock_content = _lc_content_to_bedrock(content)
-    
+
     assert len(bedrock_content) > 0
     assert bedrock_content[0]["text"] == "."
 
 
 def test__lc_content_to_bedrock_whitespace_text_block() -> None:
-    content: List[Union[str, Dict[str, Any]]] = [
-        {"type": "text", "text": "  \n  "}
-    ]
-    
+    content: List[Union[str, Dict[str, Any]]] = [{"type": "text", "text": "  \n  "}]
+
     bedrock_content = _lc_content_to_bedrock(content)
-    
+
     assert len(bedrock_content) > 0
     assert bedrock_content[0]["text"] == "."
 
@@ -1330,9 +1349,9 @@ def test__lc_content_to_bedrock_mixed_valid_and_empty_content() -> None:
     content: List[Union[str, Dict[str, Any]]] = [
         {"type": "text", "text": "Valid text"},
         {"type": "text", "text": ""},
-        {"type": "text", "text": "   "}
+        {"type": "text", "text": "   "},
     ]
-    
+
     bedrock_content = _lc_content_to_bedrock(content)
 
     assert len(bedrock_content) == 3
@@ -1350,21 +1369,21 @@ def test__lc_content_to_bedrock_mixed_types_with_empty_content() -> None:
             "input": {"arg1": "val1"},
             "name": "tool1",
         },
-        {"type": "text", "text": "   "}
+        {"type": "text", "text": "   "},
     ]
 
     expected = [
-        {'text': 'Valid text'},
+        {"text": "Valid text"},
         {
-            'toolUse': {
-                'toolUseId': 'tool_call1',
-                'input': {'arg1': 'val1'},
-                'name': 'tool1'
+            "toolUse": {
+                "toolUseId": "tool_call1",
+                "input": {"arg1": "val1"},
+                "name": "tool1",
             }
         },
-        {'text': '.'}
+        {"text": "."},
     ]
-    
+
     bedrock_content = _lc_content_to_bedrock(content)
 
     assert len(bedrock_content) == 3
@@ -1589,7 +1608,10 @@ def _create_mock_llm_guard_last_turn_only() -> (
 
 
 def test_guard_last_turn_only_no_guardrail_config() -> None:
-    """Test that an error is raised if guard_last_turn_only is True but no guardrail_config is provided."""
+    """
+    Test that an error is raised if guard_last_turn_only is True but no
+    guardrail_config is provided.
+    """
     with pytest.raises(ValueError):
         ChatBedrockConverse(
             client=mock.MagicMock(),
@@ -1857,67 +1879,104 @@ def test_nova_provider_extraction() -> None:
 
 
 def test__messages_to_bedrock_strips_trailing_whitespace_string() -> None:
-    """Test that _messages_to_bedrock strips trailing whitespace from string AIMessage content."""
+    """
+    Test that _messages_to_bedrock strips trailing whitespace from string
+    AIMessage content.
+    """
     messages = [
         SystemMessage(content="System message"),
         HumanMessage(content="Human message"),
         AIMessage(content="AI message with trailing whitespace    \n  \t  "),
     ]
-    
+
     bedrock_messages, _ = _messages_to_bedrock(messages)
 
-    assert bedrock_messages[1]["content"][0]["text"] == "AI message with trailing whitespace"
+    assert (
+        bedrock_messages[1]["content"][0]["text"]
+        == "AI message with trailing whitespace"
+    )
 
 
 def test__messages_to_bedrock_strips_trailing_whitespace_blocks() -> None:
-    """Test that _messages_to_bedrock strips trailing whitespace from block AIMessage content."""
+    """
+    Test that _messages_to_bedrock strips trailing whitespace from block
+    AIMessage content.
+    """
     messages = [
         SystemMessage(content="System message"),
         HumanMessage(content="Human message"),
-        AIMessage(content=[
-            {"type": "text", "text": "AI message with trailing whitespace    \n  \t  "},
-            {"type": "text", "text": "Another text block with whitespace  \n "}
-        ]),
+        AIMessage(
+            content=[
+                {
+                    "type": "text",
+                    "text": "AI message with trailing whitespace    \n  \t  ",
+                },
+                {"type": "text", "text": "Another text block with whitespace  \n "},
+            ]
+        ),
     ]
-    
+
     bedrock_messages, _ = _messages_to_bedrock(messages)
 
-    assert bedrock_messages[1]["content"][0]["text"] == "AI message with trailing whitespace"
-    assert bedrock_messages[1]["content"][1]["text"] == "Another text block with whitespace"
+    assert (
+        bedrock_messages[1]["content"][0]["text"]
+        == "AI message with trailing whitespace"
+    )
+    assert (
+        bedrock_messages[1]["content"][1]["text"]
+        == "Another text block with whitespace"
+    )
 
 
 def test__messages_to_bedrock_preserves_whitespace_non_last_aimessage_string() -> None:
-    """Test that _messages_to_bedrock preserves trailing whitespace in non-last AIMessages."""
+    """
+    Test that _messages_to_bedrock preserves trailing whitespace in non-last AIMessages.
+    """
     messages = [
         SystemMessage(content="System message"),
         HumanMessage(content="First human message"),
         AIMessage(content="AI message with trailing whitespace    \n  \t  "),
         HumanMessage(content="Second human message"),
     ]
-    
+
     bedrock_messages, _ = _messages_to_bedrock(messages)
 
-    assert bedrock_messages[1]["content"][0]["text"] == "AI message with trailing whitespace    \n  \t  "
+    assert (
+        bedrock_messages[1]["content"][0]["text"]
+        == "AI message with trailing whitespace    \n  \t  "
+    )
 
 
 def test__messages_to_bedrock_preserves_whitespace_non_last_aimessage_blocks() -> None:
-    """Test that _messages_to_bedrock preserves trailing whitespace in non-last AIMessages."""
+    """
+    Test that _messages_to_bedrock preserves trailing whitespace in non-last AIMessages.
+    """
     messages = [
         SystemMessage(content="System message"),
         HumanMessage(content="First human message"),
-        AIMessage(content=[
-            {"type": "text", "text": "AI message with trailing whitespace    \n  \t  "},
-        ]),
+        AIMessage(
+            content=[
+                {
+                    "type": "text",
+                    "text": "AI message with trailing whitespace    \n  \t  ",
+                },
+            ]
+        ),
         HumanMessage(content="Second human message"),
     ]
-    
+
     bedrock_messages, _ = _messages_to_bedrock(messages)
 
-    assert bedrock_messages[1]["content"][0]["text"] == "AI message with trailing whitespace    \n  \t  "
+    assert (
+        bedrock_messages[1]["content"][0]["text"]
+        == "AI message with trailing whitespace    \n  \t  "
+    )
 
 
 @mock.patch("langchain_aws.chat_models.bedrock_converse.create_aws_client")
-def test_bedrock_client_inherits_from_runtime_client(mock_create_client: mock.Mock) -> None:
+def test_bedrock_client_inherits_from_runtime_client(
+    mock_create_client: mock.Mock,
+) -> None:
     """Test that bedrock_client inherits region and config from runtime client."""
     mock_runtime_client = mock.Mock()
     mock_bedrock_client = mock.Mock()
@@ -1935,8 +1994,7 @@ def test_bedrock_client_inherits_from_runtime_client(mock_create_client: mock.Mo
     mock_create_client.side_effect = side_effect
 
     chat_model = ChatBedrockConverse(
-        model="us.meta.llama3-3-70b-instruct-v1:0",
-        client=mock_runtime_client
+        model="us.meta.llama3-3-70b-instruct-v1:0", client=mock_runtime_client
     )
 
     mock_create_client.assert_called_with(
@@ -1947,12 +2005,14 @@ def test_bedrock_client_inherits_from_runtime_client(mock_create_client: mock.Mo
         aws_session_token=None,
         endpoint_url=None,
         config=None,
-        service_name="bedrock"
+        service_name="bedrock",
     )
 
 
 @mock.patch("langchain_aws.chat_models.bedrock_converse.create_aws_client")
-def test_bedrock_client_uses_explicit_values_over_runtime_client(mock_create_client: mock.Mock) -> None:
+def test_bedrock_client_uses_explicit_values_over_runtime_client(
+    mock_create_client: mock.Mock,
+) -> None:
     """Test that explicitly provided values override those from runtime client."""
     mock_runtime_client = mock.Mock()
     mock_bedrock_client = mock.Mock()
@@ -1985,7 +2045,7 @@ def test_bedrock_client_uses_explicit_values_over_runtime_client(mock_create_cli
         aws_session_token=None,
         endpoint_url=None,
         config=None,
-        service_name="bedrock"
+        service_name="bedrock",
     )
 
 


### PR DESCRIPTION
Here are the docs on extended thinking: https://docs.aws.amazon.com/bedrock/latest/userguide/claude-messages-extended-thinking.html

Of particular note is the section about Extended Thinking with Tool Use: https://docs.aws.amazon.com/bedrock/latest/userguide/claude-messages-extended-thinking.html#claude-messages-extended-thinking-tool-use

Right now the BedrockConverse chat model:
- doesn't treat Claude 4 Sonnet and Opus with thinking enabled identically to Claude 3.7 Sonnet with thinking enabled, when the docs suggest (and manual testing confirms) that they all have the same tool binding / structured output behavior
- doesn't support tool_choice = "auto" for all Claude models with thinking enabled

This PR fixes that + adds some tests

And it also fixes some linting issues in the files I modified