### PR TITLE
fix(aws): (v1) Remove beta_use_converse_api from ChatBedrock

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,11 @@ pip install langgraph-checkpoint-aws
 Here's a simple example of how to use the `langchain-aws` package.
 
 ```python
-from langchain_aws import ChatBedrock
+from langchain_aws import ChatBedrockConverse
 
 # Initialize the Bedrock chat model
-llm = ChatBedrock(
-    model="anthropic.claude-3-sonnet-20240229-v1:0",
-    beta_use_converse_api=True
+llm = ChatBedrockConverse(
+    model="us.anthropic.claude-sonnet-4-20250514-v1:0",
 )
 
 # Invoke the llm

--- a/libs/aws/README.md
+++ b/libs/aws/README.md
@@ -16,12 +16,14 @@ Alternatively, set the `AWS_BEARER_TOKEN_BEDROCK` environment variable locally f
 
 ## Chat Models
 
-`ChatBedrock` class exposes chat models from Bedrock.
+`ChatBedrockConverse` class exposes chat models from Bedrock.
 
 ```python
-from langchain_aws import ChatBedrock
+from langchain_aws import ChatBedrockConverse
 
-llm = ChatBedrock()
+llm = ChatBedrockConverse(
+    model="us.anthropic.claude-sonnet-4-20250514-v1:0",
+)
 llm.invoke("Sing a ballad of LangChain.")
 ```
 

--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock.py
@@ -594,7 +594,6 @@ def test_guardrails() -> None:
             "guardrailVersion": "1",
             "trace": "enabled",
         },
-        "beta_use_converse_api": True,
     }
     chat_model = ChatBedrock(**params)  # type: ignore[arg-type]
     messages = [
@@ -684,7 +683,6 @@ def test_guardrails_streaming_trace() -> None:
         guardrails=guardrail_config,
         callbacks=[guardrail_callback],
         region_name="us-west-2",
-        beta_use_converse_api=False,  # Use legacy API for this test
     )  # type: ignore[call-arg]
 
     # Test message that should trigger guardrail intervention
@@ -698,7 +696,6 @@ def test_guardrails_streaming_trace() -> None:
         guardrails=guardrail_config,
         callbacks=[invoke_callback],
         region_name="us-west-2",
-        beta_use_converse_api=False,
     )  # type: ignore[call-arg]
 
     try:

--- a/libs/aws/tests/integration_tests/chat_models/test_standard.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_standard.py
@@ -29,31 +29,3 @@ class TestBedrockStandard(ChatModelIntegrationTests):
     @pytest.mark.xfail(reason="Not implemented.")
     def test_double_messages_conversation(self, model: BaseChatModel) -> None:
         super().test_double_messages_conversation(model)
-
-
-class TestBedrockUseConverseStandard(ChatModelIntegrationTests):
-    @property
-    def chat_model_class(self) -> Type[BaseChatModel]:
-        return ChatBedrock
-
-    @property
-    def chat_model_params(self) -> dict:
-        return {
-            "model_id": "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
-            "beta_use_converse_api": True,
-        }
-
-    @property
-    def standard_chat_model_params(self) -> dict:
-        return {
-            "temperature": 0,
-            "max_tokens": 100,
-            "stop_sequences": [],
-            "model_kwargs": {
-                "stop": [],
-            },
-        }
-
-    @property
-    def supports_image_inputs(self) -> bool:
-        return True

--- a/libs/aws/tests/unit_tests/__snapshots__/test_standard.ambr
+++ b/libs/aws/tests/unit_tests/__snapshots__/test_standard.ambr
@@ -1,47 +1,4 @@
 # serializer version: 1
-# name: TestBedrockAsConverseStandard.test_serdes[serialized]
-  dict({
-    'id': list([
-      'langchain',
-      'chat_models',
-      'bedrock',
-      'ChatBedrock',
-    ]),
-    'kwargs': dict({
-      'beta_use_converse_api': True,
-      'guardrails': dict({
-        'guardrailIdentifier': None,
-        'guardrailVersion': None,
-        'trace': None,
-      }),
-      'max_tokens': 100,
-      'model_id': 'anthropic.claude-3-sonnet-20240229-v1:0',
-      'model_kwargs': dict({
-        'stop': list([
-        ]),
-      }),
-      'provider_stop_reason_key_map': dict({
-        'ai21': 'finishReason',
-        'amazon': 'completionReason',
-        'anthropic': 'stop_reason',
-        'cohere': 'finish_reason',
-        'mistral': 'stop_reason',
-      }),
-      'provider_stop_sequence_key_name_map': dict({
-        'ai21': 'stop_sequences',
-        'amazon': 'stopSequences',
-        'anthropic': 'stop_sequences',
-        'cohere': 'stop_sequences',
-        'mistral': 'stop_sequences',
-      }),
-      'region_name': 'us-east-1',
-      'temperature': 0,
-    }),
-    'lc': 1,
-    'name': 'ChatBedrock',
-    'type': 'constructor',
-  })
-# ---
 # name: TestBedrockStandard.test_serdes[serialized]
   dict({
     'id': list([

--- a/libs/aws/tests/unit_tests/test_standard.py
+++ b/libs/aws/tests/unit_tests/test_standard.py
@@ -28,31 +28,3 @@ class TestBedrockStandard(ChatModelUnitTests):
     @pytest.mark.xfail(reason="Not implemented.")
     def test_standard_params(self, model: BaseChatModel) -> None:
         super().test_standard_params(model)
-
-
-class TestBedrockAsConverseStandard(ChatModelUnitTests):
-    @property
-    def chat_model_class(self) -> Type[BaseChatModel]:
-        return ChatBedrock
-
-    @property
-    def chat_model_params(self) -> dict:
-        return {
-            "model_id": "anthropic.claude-3-sonnet-20240229-v1:0",
-            "region_name": "us-east-1",
-            "beta_use_converse_api": True,
-        }
-
-    @property
-    def standard_chat_model_params(self) -> dict:
-        return {
-            "model_kwargs": {
-                "temperature": 0,
-                "max_tokens": 100,
-                "stop": [],
-            }
-        }
-
-    @pytest.mark.xfail(reason="Not implemented.")
-    def test_standard_params(self, model: BaseChatModel) -> None:
-        super().test_standard_params(model)


### PR DESCRIPTION
**Note:** Do not merge until week of Oct. 20.

This PR makes two changes to the ChatBedrock chat model in order to encourage users to migrate to the new, dedicated ChatBedrockConverse class:
- Removes the [`beta_use_converse_api`](https://python.langchain.com/api_reference/aws/chat_models/langchain_aws.chat_models.bedrock.ChatBedrock.html#langchain_aws.chat_models.bedrock.ChatBedrock.beta_use_converse_api) parameter.
- Adds a new `check_unsupported_model` Pydantic validator, which will immediately throw an exception if attempting to use a model that we don't support in ChatBedrock (ex. Nova models.)