### PR TITLE
feat(checkpointer): add session parameter support

### DIFF
--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/async_saver.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/async_saver.py
@@ -3,6 +3,7 @@ import json
 from collections.abc import AsyncIterator, Sequence
 from typing import Any, Optional
 
+import boto3
 from botocore.config import Config
 from botocore.exceptions import ClientError
 from langchain_core.runnables import RunnableConfig
@@ -48,6 +49,7 @@ class AsyncBedrockSessionSaver(BaseCheckpointSaver):
     It handles creating invocations, managing checkpoint data, and tracking pending writes.
 
     Args:
+        session: Pre-configured boto3 session instance for custom credential
         region_name: AWS region name
         credentials_profile_name: AWS credentials profile name
         aws_access_key_id: AWS access key ID
@@ -59,6 +61,7 @@ class AsyncBedrockSessionSaver(BaseCheckpointSaver):
 
     def __init__(
         self,
+        session: Optional["boto3.Session"] = None,
         region_name: Optional[str] = None,
         credentials_profile_name: Optional[str] = None,
         aws_access_key_id: Optional[SecretStr] = None,
@@ -69,6 +72,7 @@ class AsyncBedrockSessionSaver(BaseCheckpointSaver):
     ) -> None:
         super().__init__()
         self.session_client = AsyncBedrockAgentRuntimeSessionClient(
+            session=session,
             region_name=region_name,
             credentials_profile_name=credentials_profile_name,
             aws_access_key_id=aws_access_key_id,

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/async_saver.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/async_saver.py
@@ -61,7 +61,7 @@ class AsyncBedrockSessionSaver(BaseCheckpointSaver):
 
     def __init__(
         self,
-        session: Optional["boto3.Session"] = None,
+        session: Optional[boto3.Session] = None,
         region_name: Optional[str] = None,
         credentials_profile_name: Optional[str] = None,
         aws_access_key_id: Optional[SecretStr] = None,

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/async_session.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/async_session.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Optional
 
 import boto3
 from botocore.config import Config
@@ -24,10 +24,10 @@ from langgraph_checkpoint_aws.models import (
     PutInvocationStepResponse,
 )
 from langgraph_checkpoint_aws.utils import (
+    create_client_config,
     process_aws_client_args,
     run_boto3_in_executor,
     to_boto_params,
-    create_client_config,
 )
 
 

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/async_session.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/async_session.py
@@ -24,7 +24,6 @@ from langgraph_checkpoint_aws.models import (
     PutInvocationStepResponse,
 )
 from langgraph_checkpoint_aws.utils import (
-    create_client_config,
     process_aws_client_args,
     run_boto3_in_executor,
     to_boto_params,
@@ -60,34 +59,27 @@ class AsyncBedrockAgentRuntimeSessionClient:
             endpoint_url: Custom endpoint URL
             config: Boto3 config object
         """
+        _session_kwargs, self._client_kwargs = process_aws_client_args(
+            region_name,
+            credentials_profile_name,
+            aws_access_key_id,
+            aws_secret_access_key,
+            aws_session_token,
+            endpoint_url,
+            config,
+        )
+
         if session is not None:
             # Use provided session directly
-            client_kwargs = {}
-            if endpoint_url is not None:
-                client_kwargs["endpoint_url"] = endpoint_url
-
-            client_kwargs["config"] = create_client_config(config)
-
             self.session = session
-            self.client = session.client("bedrock-agent-runtime", **client_kwargs)
         else:
-            # Create session using provided credentials
-            _session_kwargs, self._client_kwargs = process_aws_client_args(
-                region_name,
-                credentials_profile_name,
-                aws_access_key_id,
-                aws_secret_access_key,
-                aws_session_token,
-                endpoint_url,
-                config,
-            )
-
             # Create a standard boto3 session
             self.session = boto3.Session(**_session_kwargs)
-            # Pre-create the client to avoid creating it for each operation
-            self.client = self.session.client(
-                "bedrock-agent-runtime", **self._client_kwargs
-            )
+
+        # Pre-create the client to avoid creating it for each operation
+        self.client = self.session.client(
+            "bedrock-agent-runtime", **self._client_kwargs
+        )
 
     async def create_session(
         self, request: Optional[CreateSessionRequest] = None

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/saver.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/saver.py
@@ -61,7 +61,7 @@ class BedrockSessionSaver(BaseCheckpointSaver):
 
     def __init__(
         self,
-        session: Optional["boto3.Session"] = None,
+        session: Optional[boto3.Session] = None,
         region_name: Optional[str] = None,
         credentials_profile_name: Optional[str] = None,
         aws_access_key_id: Optional[SecretStr] = None,

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/saver.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/saver.py
@@ -3,6 +3,7 @@ import json
 from collections.abc import Iterator, Sequence
 from typing import Any, Optional
 
+import boto3
 from botocore.config import Config
 from botocore.exceptions import ClientError
 from langchain_core.runnables import RunnableConfig
@@ -48,6 +49,7 @@ class BedrockSessionSaver(BaseCheckpointSaver):
     It handles creating invocations, managing checkpoint data, and tracking pending writes.
 
     Args:
+        session: Pre-configured session instance for custom credential
         region_name: AWS region name
         credentials_profile_name: AWS credentials profile name
         aws_access_key_id: AWS access key ID
@@ -59,6 +61,7 @@ class BedrockSessionSaver(BaseCheckpointSaver):
 
     def __init__(
         self,
+        session: Optional["boto3.Session"] = None,
         region_name: Optional[str] = None,
         credentials_profile_name: Optional[str] = None,
         aws_access_key_id: Optional[SecretStr] = None,
@@ -69,6 +72,7 @@ class BedrockSessionSaver(BaseCheckpointSaver):
     ) -> None:
         super().__init__()
         self.session_client = BedrockAgentRuntimeSessionClient(
+            session=session,
             region_name=region_name,
             credentials_profile_name=credentials_profile_name,
             aws_access_key_id=aws_access_key_id,

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/session.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/session.py
@@ -23,7 +23,11 @@ from langgraph_checkpoint_aws.models import (
     PutInvocationStepRequest,
     PutInvocationStepResponse,
 )
-from langgraph_checkpoint_aws.utils import process_aws_client_args, to_boto_params, create_client_config
+from langgraph_checkpoint_aws.utils import (
+    create_client_config,
+    process_aws_client_args,
+    to_boto_params,
+)
 
 
 class BedrockAgentRuntimeSessionClient:

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/session.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/session.py
@@ -24,7 +24,6 @@ from langgraph_checkpoint_aws.models import (
     PutInvocationStepResponse,
 )
 from langgraph_checkpoint_aws.utils import (
-    create_client_config,
     process_aws_client_args,
     to_boto_params,
 )
@@ -70,27 +69,23 @@ class BedrockAgentRuntimeSessionClient:
             endpoint_url: Custom endpoint URL
             config: Boto3 config object
         """
+        _session_kwargs, _client_kwargs = process_aws_client_args(
+            region_name,
+            credentials_profile_name,
+            aws_access_key_id,
+            aws_secret_access_key,
+            aws_session_token,
+            endpoint_url,
+            config,
+        )
         if session is not None:
             # Use provided session directly
-            client_kwargs = {}
-            if endpoint_url is not None:
-                client_kwargs["endpoint_url"] = endpoint_url
-
-            client_kwargs["config"] = create_client_config(config)
-            self.client = session.client("bedrock-agent-runtime", **client_kwargs)
+            self.session = session
         else:
-            # Create session using provided credentials
-            _session_kwargs, _client_kwargs = process_aws_client_args(
-                region_name,
-                credentials_profile_name,
-                aws_access_key_id,
-                aws_secret_access_key,
-                aws_session_token,
-                endpoint_url,
-                config,
-            )
-            session = boto3.Session(**_session_kwargs)
-            self.client = session.client("bedrock-agent-runtime", **_client_kwargs)
+            # Create a standard boto3 session
+            self.session = boto3.Session(**_session_kwargs)
+
+        self.client = self.session.client("bedrock-agent-runtime", **_client_kwargs)
 
     def create_session(
         self, request: Optional[CreateSessionRequest] = None

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/utils.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/utils.py
@@ -447,9 +447,9 @@ def create_client_config(config: Optional[Config] = None) -> Config:
     config_kwargs = {}
     existing_user_agent = getattr(config, "user_agent_extra", "") if config else ""
     new_user_agent = (
-    f"{existing_user_agent} x-client-framework:langgraph-checkpoint-aws "
-    f"md/sdk_user_agent/{SDK_USER_AGENT}".strip()
-)
+        f"{existing_user_agent} x-client-framework:langgraph-checkpoint-aws "
+        f"md/sdk_user_agent/{SDK_USER_AGENT}".strip()
+    )
 
     return Config(user_agent_extra=new_user_agent, **config_kwargs)
 

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/test_async_saver.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/test_async_saver.py
@@ -37,6 +37,19 @@ class TestAsyncBedrockSessionSaver:
             }
         )
 
+    def test_init_with_custom_session(self, mock_boto_client):
+        """Test AsyncBedrockSessionSaver initialization with custom session"""
+        # Arrange
+        mock_custom_session = Mock()
+        mock_custom_session.client.return_value = mock_boto_client
+
+        # Act
+        saver = AsyncBedrockSessionSaver(session=mock_custom_session)
+
+        # Assert
+        assert saver.session_client.session == mock_custom_session
+        assert saver.session_client.client == mock_boto_client
+
     @pytest.mark.asyncio
     async def test__create_session_invocation_success(
         self, mock_boto_client, session_saver, sample_create_invocation_response

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/test_async_session.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/test_async_session.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import patch, Mock, ANY
 
 import pytest
 
@@ -30,6 +30,30 @@ class TestAsyncBedrockAgentRuntimeSessionClient:
         with patch("boto3.Session") as mock_aioboto_session:
             mock_aioboto_session.return_value.client.return_value = mock_boto_client
             yield AsyncBedrockAgentRuntimeSessionClient()
+
+    def test_init_with_custom_session(self, mock_boto_client):
+        """Test initialization with a custom boto3 session"""
+        # Arrange
+        mock_custom_session = Mock()
+        mock_custom_session.client.return_value = mock_boto_client
+
+        # Act
+        client = AsyncBedrockAgentRuntimeSessionClient(session=mock_custom_session)
+
+        # Assert
+        mock_custom_session.client.assert_called_once_with("bedrock-agent-runtime", config=ANY)
+        assert client.client == mock_boto_client
+
+    def test_init_without_session(self, mock_boto_client):
+        """Test initialization without custom session (default behavior)"""
+        # Arrange & Act
+        with patch("boto3.Session") as mock_boto3_session:
+            mock_boto3_session.return_value.client.return_value = mock_boto_client
+            client = AsyncBedrockAgentRuntimeSessionClient()
+
+            # Assert
+            mock_boto3_session.assert_called_once()
+            assert client.client == mock_boto_client
 
     class TestSession:
         @pytest.mark.asyncio

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/test_async_session.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/test_async_session.py
@@ -41,7 +41,9 @@ class TestAsyncBedrockAgentRuntimeSessionClient:
         client = AsyncBedrockAgentRuntimeSessionClient(session=mock_custom_session)
 
         # Assert
-        mock_custom_session.client.assert_called_once_with("bedrock-agent-runtime", config=ANY)
+        mock_custom_session.client.assert_called_once_with(
+            "bedrock-agent-runtime", config=ANY
+        )
         assert client.client == mock_boto_client
 
     def test_init_without_session(self, mock_boto_client):

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/test_saver.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/test_saver.py
@@ -73,6 +73,19 @@ class TestBedrockSessionSaver:
                 "bedrock-agent-runtime", endpoint_url=endpoint_url, config=ANY
             )
 
+    def test_init_with_custom_session(self, mock_boto_client):
+        """Test BedrockSessionSaver initialization with custom session"""
+        # Arrange
+        mock_custom_session = Mock()
+        mock_custom_session.client.return_value = mock_boto_client
+
+        # Act
+        saver = BedrockSessionSaver(session=mock_custom_session)
+
+        # Assert
+        mock_custom_session.client.assert_called_once_with("bedrock-agent-runtime", config=ANY)
+        assert saver.session_client.client == mock_boto_client
+
     def test__create_session_invocation_success(
         self, mock_boto_client, session_saver, sample_create_invocation_response
     ):

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/test_saver.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/test_saver.py
@@ -83,7 +83,9 @@ class TestBedrockSessionSaver:
         saver = BedrockSessionSaver(session=mock_custom_session)
 
         # Assert
-        mock_custom_session.client.assert_called_once_with("bedrock-agent-runtime", config=ANY)
+        mock_custom_session.client.assert_called_once_with(
+            "bedrock-agent-runtime", config=ANY
+        )
         assert saver.session_client.client == mock_boto_client
 
     def test__create_session_invocation_success(

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/test_session.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/test_session.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import patch, Mock, ANY
 
 import pytest
 
@@ -30,6 +30,30 @@ class TestBedrockAgentRuntimeSessionClient:
         with patch("boto3.Session") as mock_boto3_session:
             mock_boto3_session.return_value.client.return_value = mock_boto_client
             yield BedrockAgentRuntimeSessionClient()
+
+    def test_init_with_custom_session(self, mock_boto_client):
+        """Test initialization with a custom boto3 session"""
+        # Arrange
+        mock_custom_session = Mock()
+        mock_custom_session.client.return_value = mock_boto_client
+
+        # Act
+        client = BedrockAgentRuntimeSessionClient(session=mock_custom_session)
+
+        # Assert
+        mock_custom_session.client.assert_called_once_with("bedrock-agent-runtime", config=ANY)
+        assert client.client == mock_boto_client
+
+    def test_init_without_session(self, mock_boto_client):
+        """Test initialization without custom session (default behavior)"""
+        # Arrange & Act
+        with patch("boto3.Session") as mock_boto3_session:
+            mock_boto3_session.return_value.client.return_value = mock_boto_client
+            client = BedrockAgentRuntimeSessionClient()
+
+            # Assert
+            mock_boto3_session.assert_called_once()
+            assert client.client == mock_boto_client
 
     class TestSession:
         def test_create_session(

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/test_session.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/test_session.py
@@ -41,7 +41,9 @@ class TestBedrockAgentRuntimeSessionClient:
         client = BedrockAgentRuntimeSessionClient(session=mock_custom_session)
 
         # Assert
-        mock_custom_session.client.assert_called_once_with("bedrock-agent-runtime", config=ANY)
+        mock_custom_session.client.assert_called_once_with(
+            "bedrock-agent-runtime", config=ANY
+        )
         assert client.client == mock_boto_client
 
     def test_init_without_session(self, mock_boto_client):


### PR DESCRIPTION

Fixes: #619

Added an extra parameter as input for the BedrockSessionSaver to pass customized credential session info.

This will allow users to pass their own pre configured boto3 session like this:

```
# Before
saver = BedrockSessionSaver(region_name="us-west-2", aws_access_key_id=..., aws_secret_access_key=...)

# Now: Can pass custom session with any credential
session = boto3.Session(profile_name="my-custom-profile")
saver = BedrockSessionSaver(session=session)
```

So when a session is provided, it's used directly instead of creating a new one from individual credential parameters.


