### PR TITLE
feat(checkpointer): add client parameter to BedrockSessionSaver

### DIFF
--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/async_saver.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/async_saver.py
@@ -49,6 +49,7 @@ class AsyncBedrockSessionSaver(BaseCheckpointSaver):
     It handles creating invocations, managing checkpoint data, and tracking pending writes.
 
     Args:
+        client: Pre-configured bedrock-agent-runtime client instance
         session: Pre-configured boto3 session instance for custom credential
         region_name: AWS region name
         credentials_profile_name: AWS credentials profile name
@@ -61,6 +62,7 @@ class AsyncBedrockSessionSaver(BaseCheckpointSaver):
 
     def __init__(
         self,
+        client: Optional[Any] = None,
         session: Optional[boto3.Session] = None,
         region_name: Optional[str] = None,
         credentials_profile_name: Optional[str] = None,
@@ -72,6 +74,7 @@ class AsyncBedrockSessionSaver(BaseCheckpointSaver):
     ) -> None:
         super().__init__()
         self.session_client = AsyncBedrockAgentRuntimeSessionClient(
+            client=client,
             session=session,
             region_name=region_name,
             credentials_profile_name=credentials_profile_name,

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/saver.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/saver.py
@@ -49,6 +49,7 @@ class BedrockSessionSaver(BaseCheckpointSaver):
     It handles creating invocations, managing checkpoint data, and tracking pending writes.
 
     Args:
+        client: Pre-configured bedrock-agent-runtime client instance
         session: Pre-configured session instance for custom credential
         region_name: AWS region name
         credentials_profile_name: AWS credentials profile name
@@ -61,6 +62,7 @@ class BedrockSessionSaver(BaseCheckpointSaver):
 
     def __init__(
         self,
+        client: Optional[Any] = None,
         session: Optional[boto3.Session] = None,
         region_name: Optional[str] = None,
         credentials_profile_name: Optional[str] = None,
@@ -72,6 +74,7 @@ class BedrockSessionSaver(BaseCheckpointSaver):
     ) -> None:
         super().__init__()
         self.session_client = BedrockAgentRuntimeSessionClient(
+            client=client,
             session=session,
             region_name=region_name,
             credentials_profile_name=credentials_profile_name,

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/session.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/session.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Any, Optional
 
 import boto3
 from botocore.config import Config
@@ -24,6 +24,7 @@ from langgraph_checkpoint_aws.models import (
     PutInvocationStepResponse,
 )
 from langgraph_checkpoint_aws.utils import (
+    _validate_bedrock_client,
     process_aws_client_args,
     to_boto_params,
 )
@@ -47,6 +48,7 @@ class BedrockAgentRuntimeSessionClient:
 
     def __init__(
         self,
+        client: Optional[Any] = None,
         session: Optional[boto3.Session] = None,
         region_name: Optional[str] = None,
         credentials_profile_name: Optional[str] = None,
@@ -60,6 +62,7 @@ class BedrockAgentRuntimeSessionClient:
         Initialize BedrockAgentRuntime with AWS configuration
 
         Args:
+            client: Pre-configured bedrock-agent-runtime client instance
             session: Pre-configured boto3 session instance
             region_name: AWS region (e.g., us-west-2)
             credentials_profile_name: AWS credentials profile name
@@ -69,23 +72,29 @@ class BedrockAgentRuntimeSessionClient:
             endpoint_url: Custom endpoint URL
             config: Boto3 config object
         """
-        _session_kwargs, _client_kwargs = process_aws_client_args(
-            region_name,
-            credentials_profile_name,
-            aws_access_key_id,
-            aws_secret_access_key,
-            aws_session_token,
-            endpoint_url,
-            config,
-        )
-        if session is not None:
-            # Use provided session directly
-            self.session = session
+        if client is not None:
+            # Use provided client directly
+            _validate_bedrock_client(client)
+            self.client = client
         else:
-            # Create a standard boto3 session
-            self.session = boto3.Session(**_session_kwargs)
+            _session_kwargs, _client_kwargs = process_aws_client_args(
+                region_name,
+                credentials_profile_name,
+                aws_access_key_id,
+                aws_secret_access_key,
+                aws_session_token,
+                endpoint_url,
+                config,
+            )
 
-        self.client = self.session.client("bedrock-agent-runtime", **_client_kwargs)
+            if session is not None:
+                # Use provided session directly
+                self.session = session
+            else:
+                # Create a standard boto3 session
+                self.session = boto3.Session(**_session_kwargs)
+
+            self.client = self.session.client("bedrock-agent-runtime", **_client_kwargs)
 
     def create_session(
         self, request: Optional[CreateSessionRequest] = None

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/utils.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/utils.py
@@ -464,3 +464,17 @@ async def run_boto3_in_executor(func: Callable[..., T], *args: Any, **kwargs: An
             partial(copy_context().run, lambda: func(*args, **kwargs)),
         ),
     )
+
+
+def _validate_bedrock_client(client: Any) -> None:
+    """Validate that the provided client is a bedrock-agent-runtime client."""
+    try:
+        service_name = client.meta.service_model.service_name
+    except AttributeError:
+        raise ValueError("Invalid client: must be a boto3 client instance")
+
+    if service_name != "bedrock-agent-runtime":
+        raise ValueError(
+            f"Invalid client: expected 'bedrock-agent-runtime' client, got '{service_name}' client. "
+            "Please provide a bedrock-agent-runtime client."
+        )

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/test_async_saver.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/test_async_saver.py
@@ -50,6 +50,31 @@ class TestAsyncBedrockSessionSaver:
         assert saver.session_client.session == mock_custom_session
         assert saver.session_client.client == mock_boto_client
 
+    def test_init_with_pre_configured_client(self):
+        """Test AsyncBedrockSessionSaver initialization with pre-configured client"""
+        # Arrange
+        mock_client = Mock()
+        mock_client.meta.service_model.service_name = "bedrock-agent-runtime"
+
+        # Act
+        saver = AsyncBedrockSessionSaver(client=mock_client)
+
+        # Assert
+        assert saver.session_client.client == mock_client
+
+    def test_init_with_wrong_service_client(self):
+        """Test AsyncBedrockSessionSaver raises error with wrong service client"""
+        # Arrange
+        mock_wrong_client = Mock()
+        mock_wrong_client.meta.service_model.service_name = "some-other-service"
+
+        # Act & Assert
+        with pytest.raises(
+            ValueError,
+            match="Invalid client: expected 'bedrock-agent-runtime' client, got 'some-other-service' client. Please provide a bedrock-agent-runtime client.",
+        ):
+            AsyncBedrockSessionSaver(client=mock_wrong_client)
+
     @pytest.mark.asyncio
     async def test__create_session_invocation_success(
         self, mock_boto_client, session_saver, sample_create_invocation_response

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/test_saver.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/test_saver.py
@@ -88,6 +88,31 @@ class TestBedrockSessionSaver:
         )
         assert saver.session_client.client == mock_boto_client
 
+    def test_init_with_pre_configured_client(self):
+        """Test initialization with a pre-configured bedrock-agent-runtime client."""
+        # Arrange
+        mock_client = Mock()
+        mock_client.meta.service_model.service_name = "bedrock-agent-runtime"
+
+        # Act
+        saver = BedrockSessionSaver(client=mock_client)
+
+        # Assert
+        assert saver.session_client.client == mock_client
+
+    def test_init_with_wrong_service_client(self):
+        """Test that client for wrong service raises ValueError."""
+        # Arrange
+        s3_client = Mock()
+        s3_client.meta.service_model.service_name = "s3"
+
+        # Act & Assert
+        with pytest.raises(
+            ValueError,
+            match="Invalid client: expected 'bedrock-agent-runtime' client, got 's3' client. Please provide a bedrock-agent-runtime client.",
+        ):
+            BedrockSessionSaver(client=s3_client)
+
     def test__create_session_invocation_success(
         self, mock_boto_client, session_saver, sample_create_invocation_response
     ):


### PR DESCRIPTION
Added client parameter to BedrockSessionSaver so users can pass a pre-configured **bedrock-agent-runtime** boto3 client directly.

Usage:
```
# Before
saver = BedrockSessionSaver(region_name="us-east-1”, aws_access_key_id=..., aws_secret_access_key=...)

# Now: pass a pre-configured client
client = boto3.client("bedrock-agent-runtime", region_name="us-east-1”)
saver = BedrockSessionSaver(client=client)
# or
async_saver = AsyncBedrockSessionSaver(client=client)
```