### PR TITLE
fix: Support `jp` cross region inference profiles

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -772,7 +772,9 @@ class ChatBedrockConverse(BaseChatModel):
 
         # For regional model IDs (e.g., us.anthropic.claude-3-5-haiku-20241022-v1:0),
         # get the base model ID by removing the regional prefix
-        if self.model_id.startswith(("eu.", "us.", "us-gov.", "apac.", "sa.", "amer.", "global.")):
+        if self.model_id.startswith(
+            ("eu.", "us.", "us-gov.", "apac.", "sa.", "amer.", "global.", "jp.")
+        ):
             return self.model_id.partition(".")[2]
 
         return self.model_id

--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -875,7 +875,7 @@ class BedrockBase(BaseLanguageModel, ABC):
             if (
                 len(parts) > 1
                 and parts[0].lower()
-                in {"eu", "us", "us-gov", "apac", "sa", "amer", "global"}
+                in {"eu", "us", "us-gov", "apac", "sa", "amer", "global", "jp"}
             )
             else parts[0]
         )

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
@@ -742,6 +742,13 @@ def test_beta_use_converse_api_with_inference_profile_as_nova_model(
             "us-west-2",
         ),
         (
+            "jp.anthropic.claude-sonnet-4-5-20250929-v1:0",
+            None,
+            "anthropic",
+            nullcontext(),
+            "ap-northeast-1",
+        ),
+        (
             "global.anthropic.claude-sonnet-4-20250514-v1:0",
             None,
             "anthropic",


### PR DESCRIPTION
Addresses #669.

Updated ChatBedrock/ChatBedrockConverse to account for new `jp`Claude Sonnet 4.5 inference profiles.

See: https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html