### PR TITLE
Enable ChatBedrockConverse streaming for Qwen3 and DeepSeek-V3.1

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -578,6 +578,12 @@ class ChatBedrockConverse(BaseChatModel):
             or
             # Cohere Command R models
             (provider == "cohere" and "command-r" in model_id_lower)
+            or
+            # DeepSeek-V3 models
+            (provider == "deepseek" and "v3" in model_id_lower)
+            or
+            # Qwen3 models
+            (provider == "qwen" and "qwen3" in model_id_lower)
         ):
             return True
         elif (

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -608,8 +608,10 @@ def test_standard_tracing_params() -> None:
         ("us.amazon.nova-lite-v1:0", False),
         ("us.amazon.nonstreaming-model-v1:0", True),
         ("us.deepseek.r1-v1:0", "tool_calling"),
+        ("deepseek.v3-v1:0", False),
         ("openai.gpt-oss-120b-1:0", False),
         ("openai.gpt-oss-20b-1:0", False),
+        ("qwen.qwen3-32b-v1:0", False),
     ],
 )
 def test_set_disable_streaming(


### PR DESCRIPTION
See:
- https://www.aboutamazon.com/news/aws/alibaba-qwen3-deepseek-v3-amazon-bedrock
- https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html

Testing:
- Confirmed that all `qwen3` serverless models work with streaming + tools and `disable_streaming=False` set manually with ChatBedrockConverse.
- Tool calling (for both single invocation and stream calls) are currently broken on Bedrock's serverless `deepseek.v3-v1:0`, but this model does support tools per the newspost. Enabling streaming+tools on this model with the assumption that this will be fixed later.