### PR TITLE
Enable ChatBedrockConverse streaming for Qwen qwen3 models

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -580,8 +580,7 @@ class ChatBedrockConverse(BaseChatModel):
             (provider == "cohere" and "command-r" in model_id_lower)
             or
             # Qwen models
-            (provider == "qwen" and "qwen3" in model_id_lower)
-            
+            (provider == "qwen" and "qwen3" in model_id_lower)   
         ):
             return True
         elif (

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -578,6 +578,10 @@ class ChatBedrockConverse(BaseChatModel):
             or
             # Cohere Command R models
             (provider == "cohere" and "command-r" in model_id_lower)
+            or
+            # Qwen models
+            (provider == "qwen" and "qwen3" in model_id_lower)
+            
         ):
             return True
         elif (

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -610,6 +610,10 @@ def test_standard_tracing_params() -> None:
         ("us.deepseek.r1-v1:0", "tool_calling"),
         ("openai.gpt-oss-120b-1:0", False),
         ("openai.gpt-oss-20b-1:0", False),
+        ("qwen.qwen3-235b-a22b-2507-v1:0", False),
+        ("qwen.qwen3-32b-v1:0", False),
+        ("qwen.qwen3-coder-480b-a35b-v1:0", False),
+        ("qwen.qwen3-coder-30b-a3b-v1:0", False),
     ],
 )
 def test_set_disable_streaming(


### PR DESCRIPTION
Updating ChatBedrockConverse to set disable_streaming=False by default for qwen3 models.