### PR TITLE
fix: release

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -132,11 +132,13 @@ jobs:
         #   sometimes a delay in availability on test pypi
         run: |
           uv pip install \
+            --index-strategy unsafe-best-match \
             --extra-index-url https://test.pypi.org/simple/ \
             "$PKG_NAME==$VERSION" || \
           ( \
             sleep 5 && \
             uv pip install \
+              --index-strategy unsafe-best-match \
               --extra-index-url https://test.pypi.org/simple/ \
               "$PKG_NAME==$VERSION" \
           )
@@ -160,6 +162,7 @@ jobs:
           VERSION: ${{ needs.build.outputs.version }}
         run: |
           uv pip install \
+            --index-strategy unsafe-best-match \
             --extra-index-url https://test.pypi.org/simple/ \
             "$PKG_NAME==$VERSION"
 


### PR DESCRIPTION
1. uv pip install --extra-index-url https://test.pypi.org/simple/ langchain-aws==1.0.0
2. uv looks for boto3 (a dependency)
3. Finds boto3==1.4.0 on TestPyPI (old/stale version)
4. Refuses to check PyPI for boto3>=1.40.19 (security policy)
5. Resolution fails: "only boto3==1.4.0 is available"

The fix tells uv: "Both indexes are equally trusted, check them all"