### PR TITLE
feat: Add property descriptions support to Neptune graph classes

### DIFF
--- a/libs/aws/langchain_aws/graphs/neptune_graph.py
+++ b/libs/aws/langchain_aws/graphs/neptune_graph.py
@@ -179,13 +179,13 @@ class BaseNeptuneGraph(ABC):
         """Inject property descriptions into node and edge properties."""
         if not self.property_descriptions:
             return properties_list
-        
+
         for item in properties_list:
-            for prop in item['properties']:
-                key_field = 'labels' if 'labels' in item else 'type'
-                key = (item[key_field], prop['property'])
+            for prop in item["properties"]:
+                key_field = "labels" if "labels" in item else "type"
+                key = (item[key_field], prop["property"])
                 if key in self.property_descriptions:
-                    prop['description'] = self.property_descriptions[key]
+                    prop["description"] = self.property_descriptions[key]
         return properties_list
 
     def _refresh_schema(self) -> None:


### PR DESCRIPTION
### Problem
When working with Neptune graphs in LangChain applications, the auto-generated schema lacks meaningful descriptions for node and edge properties. This makes it difficult for LLMs to understand the semantic meaning of properties, leading to suboptimal query generation and reduced accuracy in graph-based RAG applications.

### Solution
Add optional `property_descriptions` parameter to Neptune graph classes that allows users to inject custom descriptions for specific properties in the schema output.

### API Design
```python
property_descriptions = {
    ("Person", "name"): "Full name of the person",
    ("Company", "founded"): "Year the company was founded", 
    ("WORKS_FOR", "since"): "Start date of employment"
}

graph = NeptuneGraph(
    host="my-cluster",
    property_descriptions=property_descriptions
)
```

### Usage Patterns
- **Domain-specific graphs**: Add business context to technical property names
- **Multi-tenant applications**: Provide consistent property semantics across different graph schemas
- **LLM applications**: Improve query generation accuracy with meaningful property descriptions

### Implementation Details
- Added `property_descriptions` parameter to `BaseNeptuneGraph`, `NeptuneGraph`, and `NeptuneAnalyticsGraph`
- Implemented `_inject_property_descriptions()` helper method in base class
- Maintains backward compatibility with optional parameter defaulting to empty dict
- Follows existing code patterns and minimal design philosophy

### Integration Considerations
- **Existing features**: No breaking changes, purely additive functionality
- **Performance**: Minimal overhead - only processes descriptions when provided
- **Dependencies**: No new dependencies introduced
- **Security**: No security implications - operates on user-provided metadata only

---

**Note**: This addresses a common pain point when using Neptune graphs with LLMs, where property names like `emp_dt` or `org_id` lack semantic context needed for accurate query generation.