### PR TITLE
fix(aws): Correctly handle serialization for model_kwargs in ChatBedrockConverse

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -543,12 +543,14 @@ class ChatBedrockConverse(BaseChatModel):
             "additional_model_request_fields", {}
         )
         if model_kwargs:
-            model_kwargs_msg = (
-                "Please use additional_model_request_fields instead of "
-                "model_kwargs for any extra inference parameters."
-            )
-            logger.warning(model_kwargs_msg)
-            warnings.warn(model_kwargs_msg)
+            if model_kwargs:
+                warnings.warn(
+                    "ChatBedrockConverse uses 'additional_model_request_fields' "
+                    "instead of 'model_kwargs'. Your parameters have been automatically"
+                    " converted.",
+                    UserWarning,
+                    stacklevel=2,
+                )
 
         all_required_field_names = get_pydantic_field_names(cls)
         values = _build_model_kwargs(values, all_required_field_names)

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -1627,7 +1627,10 @@ def test_model_kwargs() -> None:
     assert llm.region_name == "us-west-2"
     assert llm.additional_model_request_fields == {"foo": "bar"}
 
-    with pytest.warns(match="additional_model_request_fields instead of model_kwargs"):
+    with pytest.warns(
+        UserWarning,
+        match="uses 'additional_model_request_fields' instead of 'model_kwargs'",
+    ):
         llm = ChatBedrockConverse(
             model="my-model",
             region_name="us-west-2",


### PR DESCRIPTION
Fixes: #713

Updated the `build_extra` model args validator in `ChatBedrockConverse` to correctly handle direct `model_kwargs` user input. Previously, this would interfere with the call to `langchain-core`'s [`_build_model_kwargs`](https://github.com/langchain-ai/langchain/blob/d9e659ca4f020908a360118e7a2a225d86e4b555/libs/core/langchain_core/utils/utils.py#L217), which would throw a `Circular reference detected` error during JSON serialization.

Also added a user warning to switch to the correct `additional_model_request_fields` accepted by both `ChatBedrockConverse`, per the underlying API.