### PR TITLE
fix(langgraph-checkpoint-aws): clean orphan tool_calls in AgentCoreMemorySaver to prevent Bedrock ValidationException

### DIFF
--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/agentcore/helpers.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/agentcore/helpers.py
@@ -386,6 +386,15 @@ def clean_orphan_tool_calls(messages: list[Any]) -> list[Any]:
             # If we removed some tool_calls, create a new message with cleaned
             # tool_calls
             if len(valid_tool_calls) != len(msg.tool_calls):
+                removed_tool_calls = [
+                    tc.get("id")
+                    for tc in msg.tool_calls
+                    if tc.get("id") not in resolved_tool_call_ids
+                ]
+                logger.warning(
+                    f"Removed {len(removed_tool_calls)} orphaned tool_call(s) "
+                    f"from AIMessage during checkpoint load: {removed_tool_calls}"
+                )
                 cleaned_msg = msg.model_copy(update={"tool_calls": valid_tool_calls})
                 cleaned_messages.append(cleaned_msg)
             else:


### PR DESCRIPTION
Fixed [#726](https://github.com/langchain-ai/langchain-aws/issues/726)