### PR TITLE
feat(aws): Add optional system parameter to ChatBedrockConverse

### DIFF
--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -2071,15 +2071,49 @@ def test__messages_to_bedrock_preserves_whitespace_non_last_aimessage_blocks() -
 @pytest.mark.parametrize(
     "system_prompt_parameter, expected_system",
     [
-        (None, [{"text": "System message"}]),  # from messages list
+        # No system parameter → use only the system message from messages
+        (None, [{"text": "System message"}]),
+        # Simple string input → converted into a dict with text
         (
             ["System message from param"],
-            [{"text": "System message from param"}, {"text": "System message"}],
+            [
+                {"text": "System message from param"},
+                {"text": "System message"},
+            ],
+        ),
+        # Dict input → passed through as-is
+        (
+            [
+                {
+                    "text": "Structured system message",
+                    "guardContent": {"text": {"text": "guarded"}},
+                }
+            ],
+            [
+                {
+                    "text": "Structured system message",
+                    "guardContent": {"text": {"text": "guarded"}},
+                },
+                {"text": "System message"},
+            ],
+        ),
+        # Mixed string and dict → both should be handled correctly
+        (
+            [
+                "Simple system prompt",
+                {"text": "Advanced system prompt", "cachePoint": {"type": "default"}},
+            ],
+            [
+                {"text": "Simple system prompt"},
+                {"text": "Advanced system prompt", "cachePoint": {"type": "default"}},
+                {"text": "System message"},
+            ],
         ),
     ],
 )
 def test__messages_to_bedrock_appends_system_prompt_from_parameter(
-    system_prompt_parameter: List[str] | None, expected_system: List[Dict[str, str]]
+    system_prompt_parameter: List[str | Dict[str, Any]] | None,
+    expected_system: List[Dict[str, Any]],
 ) -> None:
     messages = [
         SystemMessage(content="System message"),


### PR DESCRIPTION
### Summary
related to [#731](https://github.com/langchain-ai/langchain-aws/issues/731)

This PR introduces a new optional `system_prompt` parameter to the `ChatBedrockConverse` class and the internal `_messages_to_bedrock` helper.

When provided, this parameter explicitly defines the system message used by the LLM.
If not provided, the system message continues to be inferred from the messages list, maintaining backward compatibility.

### Changes

- Added `system_prompt` field to `ChatBedrockConverse` with documentation.
- Updated `_messages_to_bedrock` to accept and prioritize the `system_prompt` parameter.
- `_messages_to_bedrock` is now always called with `self.system_prompt` inside `ChatBedrockConverse`
- Added new unit tests to verify correct handling and precedence of the system prompt parameter.

### Testing

- Added `test__messages_to_bedrock_prefers_parameter_over_system_message` to confirm the parameter takes precedence.
- Extended `test_model_kwargs` to validate initialization and storage of the system_prompt.
- Existing Tests passed

### Validation
Testing with the new parameter:
<img width="1125" height="657" alt="image" src="https://github.com/user-attachments/assets/4b8edef0-9e2f-43d5-8d37-e4e45a11f87d" />

Testing the existing behaviour and backward compatibility:
<img width="1124" height="678" alt="image" src="https://github.com/user-attachments/assets/136a0305-c8a8-4f97-bdc0-9b4448a6ea23" />


### Potential Side Effects
When defining the `ChatBedrockConverse` as an LLM for an agent, the `system_prompt` parameter of `ChatBedrockConverse` will be prioritized:
<img width="1090" height="631" alt="image" src="https://github.com/user-attachments/assets/eba362cb-c0b5-405a-9331-04ed2dc503dc" />

Just in case if that would be a problem. I looked into the `create_agent` function. Right at the start it checks if `model` is a str:
```python
# init chat model
if isinstance(model, str):
    model = init_chat_model(model)
```

 and a possible solution could be to also handle the case where model is of type `BaseChatModel`:
```python
# init chat model
if isinstance(model, str):
    model = init_chat_model(model)
elif isinstance(model, BaseChatModel):
    # do something e.g. raise error or override system_prompt
```
