### PR TITLE
feat: add Nova model support for AWS Bedrock

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -851,7 +851,7 @@ class ChatBedrockConverse(BaseChatModel):
                 "disable `guard_last_turn_only`."
             )
 
-# Validate reasoning effort for Nova 2.0 Lite model
+        # Validate reasoning effort for Nova 2.0 Lite model
         base_model = self._get_base_model().lower()
         if "nova-2-lite" in base_model:
             additional_fields = self.additional_model_request_fields or {}

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -2356,3 +2356,39 @@ def test_get_num_tokens_from_messages_api_error_fallback() -> None:
         token_count = llm.get_num_tokens_from_messages(messages)
         assert token_count == 5
         mock_base.assert_called_once()
+
+
+def test_nova_reasoning_effort_validation() -> None:
+    """Test validation of reasoning effort parameters for
+    amazon.nova-2-lite-v1:0 model."""
+    # Test missing maxReasoningEffort when enabled
+    with pytest.raises(ValueError, match="'maxReasoningEffort' must be set"):
+        ChatBedrockConverse(
+            model="amazon.nova-2-lite-v1:0",
+            region_name="us-east-1",
+            additional_model_request_fields={"reasoningConfig": {"type": "enabled"}},
+        )
+
+    # Test invalid maxReasoningEffort value
+    with pytest.raises(ValueError, match="'maxReasoningEffort' must be set"):
+        ChatBedrockConverse(
+            model="amazon.nova-2-lite-v1:0",
+            region_name="us-east-1",
+            additional_model_request_fields={
+                "reasoningConfig": {"type": "enabled", "maxReasoningEffort": "invalid"}
+            },
+        )
+
+    # Test valid configuration
+    model = ChatBedrockConverse(
+        model="amazon.nova-2-lite-v1:0",
+        region_name="us-east-1",
+        additional_model_request_fields={
+            "reasoningConfig": {"type": "enabled", "maxReasoningEffort": "low"}
+        },
+    )
+    assert model.additional_model_request_fields is not None
+    assert (
+        model.additional_model_request_fields["reasoningConfig"]["maxReasoningEffort"]
+        == "low"
+    )


### PR DESCRIPTION
Implement support for the Nova 2.0 lite model in AWS Bedrock.