### PR TITLE
build(aws): upgrade langchain-core version constraint to allow 1.2.5

### DIFF
--- a/libs/aws/pyproject.toml
+++ b/libs/aws/pyproject.toml
@@ -12,7 +12,7 @@ authors = []
 version = "1.1.1"
 requires-python = ">=3.10"
 dependencies = [
-    "langchain-core>=1.1.0,<1.2.5",
+    "langchain-core>=1.1.0,<1.3.0",
     "boto3>=1.42.5",
     "pydantic>=2.10.6,<3",
     "numpy>=2.2,<3; python_version>='3.12'",

--- a/libs/aws/uv.lock
+++ b/libs/aws/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.13' and platform_python_implementation == 'PyPy'",
@@ -702,7 +702,7 @@ requires-dist = [
     { name = "beautifulsoup4", marker = "extra == 'tools'", specifier = ">=4.13.4" },
     { name = "bedrock-agentcore", marker = "python_full_version >= '3.10' and extra == 'tools'", specifier = ">=0.1.0" },
     { name = "boto3", specifier = ">=1.42.5" },
-    { name = "langchain-core", specifier = ">=1.1.0,<1.2.5" },
+    { name = "langchain-core", specifier = ">=1.1.0,<1.3.0" },
     { name = "numpy", marker = "python_full_version < '3.12'", specifier = ">=1.0.0,<3" },
     { name = "numpy", marker = "python_full_version >= '3.12'", specifier = ">=2.2,<3" },
     { name = "playwright", marker = "extra == 'tools'", specifier = ">=1.53.0" },


### PR DESCRIPTION
Update the langchain-core dependency constraint from '>=1.1.0,<1.2.5' to '>=1.1.0,<1.3.0' to allow installation of langchain-core version 1.2.5 and future 1.2.x patch releases. This is necessary to address vulnerabilities in langchain-core < 1.2.5.

This change is backwards compatible as the minimum version remains 1.1.0.