### PR TITLE
fix(aws): Require minimum langchain-core 1.2.5 which fixes "LangGrinch" CVE.

### DIFF
--- a/libs/aws/pyproject.toml
+++ b/libs/aws/pyproject.toml
@@ -12,7 +12,7 @@ authors = []
 version = "1.1.1"
 requires-python = ">=3.10"
 dependencies = [
-    "langchain-core>=1.1.0,<1.3.0",
+    "langchain-core>=1.2.5,<1.3.0",
     "boto3>=1.42.5",
     "pydantic>=2.10.6,<3",
     "numpy>=2.2,<3; python_version>='3.12'",


### PR DESCRIPTION
This will break backwards compatibility but will gently push downstream AI consumers/users to take security more seriously.