### PR TITLE
fix(aws): handling of falsey numeric values for temperature and topP in ChatBedrockConverse

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -1404,8 +1404,8 @@ class ChatBedrockConverse(BaseChatModel):
                 "maxTokens": None
                 if should_unset_max_tokens
                 else (maxTokens or self.max_tokens),
-                "temperature": temperature or self.temperature,
-                "topP": self.top_p or topP,
+                "temperature": self.temperature if temperature is None else temperature,
+                "topP": self.top_p if topP is None else topP,
                 "stopSequences": stop or stopSequences or self.stop_sequences,
             }
         if not toolConfig and tools:


### PR DESCRIPTION
Fixes #832 

# Summary

This PR fixes an issue in `ChatBedrockConverse` where explicitly passing valid numeric values such as `0` or `0.0` for `temperature` and `topP` was incorrectly treated as falsey and replaced by the instance defaults.

As a result, these parameters were omitted from the `inferenceConfig` sent to AWS Bedrock, preventing users from explicitly setting them to zero.

# Root Cause

The issue was caused by using boolean or checks when building the `inferenceConfig` dictionary:

```py
"temperature": temperature or self.temperature,
"topP": self.top_p or topP,
```

In Python, `0` evaluates to `False`, causing the code to fall back to the default values even when a valid value was explicitly provided.

# Fix

This PR replaces the boolean checks with explicit `None` checks for both parameters:

```py
"temperature": self.temperature if temperature is None else temperature,
"topP": self.top_p if topP is None else topP,
```

This ensures:

- `None` continues to trigger the fallback to defaults
- Valid numeric values like `0` and `0.0` are preserved and correctly sent to AWS

# Impact

- Allows users to explicitly set `temperature=0` and/or `topP=0`
- Aligns behavior with common expectations for numeric model parameters
- Backwards-compatible for all non-zero values