### PR TITLE
feat(aws): Add API key parameter to Bedrock chat models

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -799,7 +799,7 @@ class ChatBedrockConverse(BaseChatModel):
                 endpoint_url=self.endpoint_url,
                 config=self.config,
                 service_name="bedrock-runtime",
-                bedrock_api_key=self.bedrock_api_key,
+                api_key=self.bedrock_api_key,
             )
 
         # Create bedrock client for control plane API call
@@ -823,7 +823,7 @@ class ChatBedrockConverse(BaseChatModel):
                 endpoint_url=self.endpoint_url,
                 config=self.config,
                 service_name="bedrock",
-                bedrock_api_key=self.bedrock_api_key,
+                api_key=self.bedrock_api_key,
             )
 
         if self.default_headers is not None:

--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -905,7 +905,7 @@ class BedrockBase(BaseLanguageModel, ABC):
                 endpoint_url=self.endpoint_url,
                 config=self.config,
                 service_name="bedrock-runtime",
-                bedrock_api_key=self.bedrock_api_key,
+                api_key=self.bedrock_api_key,
             )
 
         # Create bedrock client for control plane API call
@@ -933,7 +933,7 @@ class BedrockBase(BaseLanguageModel, ABC):
                 endpoint_url=self.endpoint_url,
                 config=self.config or bedrock_client_cfg.get("config"),
                 service_name="bedrock",
-                bedrock_api_key=self.bedrock_api_key,
+                api_key=self.bedrock_api_key,
             )
 
         if (

--- a/libs/aws/langchain_aws/utils.py
+++ b/libs/aws/langchain_aws/utils.py
@@ -1,6 +1,6 @@
+import logging
 import os
 import re
-import warnings
 from abc import abstractmethod
 from typing import Any, Dict, Generic, Iterator, List, Literal, Optional, TypeVar, Union
 
@@ -8,6 +8,8 @@ from botocore.exceptions import BotoCoreError, UnknownServiceError
 from langchain_core.messages import AIMessage
 from packaging import version
 from pydantic import SecretStr
+
+logger = logging.getLogger(__name__)
 
 MESSAGE_ROLES = Literal["system", "user", "assistant"]
 MESSAGE_FORMAT = Dict[Literal["role", "content"], Union[MESSAGE_ROLES, str]]
@@ -136,7 +138,7 @@ def create_aws_client(
     aws_session_token: Optional[SecretStr] = None,
     endpoint_url: Optional[str] = None,
     config: Any = None,
-    bedrock_api_key: Optional[SecretStr] = None,
+    api_key: Optional[SecretStr] = None,
 ) -> Any:
     """Helper function to validate AWS credentials and create an AWS client.
 
@@ -149,7 +151,7 @@ def create_aws_client(
         aws_session_token: AWS session token.
         endpoint_url: The complete URL to use for the constructed client.
         config: Advanced client configuration options.
-        bedrock_api_key: Bedrock API key for bearer token authentication.
+        api_key: Bedrock API key for bearer token authentication.
             If provided, sets AWS_BEARER_TOKEN_BEDROCK env variable.
     Returns:
         boto3.client: An AWS service client instance.
@@ -169,19 +171,17 @@ def create_aws_client(
             or aws_secret_access_key
             or aws_session_token
         )
-        has_api_key = bool(bedrock_api_key and bedrock_api_key.get_secret_value())
+        has_api_key = bool(api_key and api_key.get_secret_value())
 
         if has_api_key and has_aws_credentials:
-            warnings.warn(
-                "Both bedrock_api_key and AWS credentials were provided. "
-                "Using bedrock_api_key for authentication; AWS credentials "
-                "will be ignored.",
-                UserWarning,
-                stacklevel=2,
+            logger.warning(
+                "Both api_key and AWS credentials were provided. "
+                "Using api_key for authentication; AWS credentials "
+                "will be ignored."
             )
 
         if has_api_key:
-            os.environ["AWS_BEARER_TOKEN_BEDROCK"] = bedrock_api_key.get_secret_value()  # type: ignore[union-attr]
+            os.environ["AWS_BEARER_TOKEN_BEDROCK"] = api_key.get_secret_value()  # type: ignore[union-attr]
 
         client_params = {
             "service_name": service_name,

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
@@ -1536,19 +1536,23 @@ def test_bedrock_client_inherits_from_runtime_client(
 
     mock_create_client.side_effect = side_effect
 
-    ChatBedrock(model="us.meta.llama3-3-70b-instruct-v1:0", client=mock_runtime_client)
+    with mock.patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("AWS_BEARER_TOKEN_BEDROCK", None)
+        ChatBedrock(
+            model="us.meta.llama3-3-70b-instruct-v1:0", client=mock_runtime_client
+        )
 
-    mock_create_client.assert_called_with(
-        region_name="us-west-2",
-        credentials_profile_name=None,
-        aws_access_key_id=None,
-        aws_secret_access_key=None,
-        aws_session_token=None,
-        endpoint_url=None,
-        config=mock_client_config,
-        service_name="bedrock",
-        bedrock_api_key=None,
-    )
+        mock_create_client.assert_called_with(
+            region_name="us-west-2",
+            credentials_profile_name=None,
+            aws_access_key_id=None,
+            aws_secret_access_key=None,
+            aws_session_token=None,
+            endpoint_url=None,
+            config=mock_client_config,
+            service_name="bedrock",
+            api_key=None,
+        )
 
 
 @patch("langchain_aws.llms.bedrock.create_aws_client")
@@ -1574,24 +1578,26 @@ def test_bedrock_client_uses_explicit_values_over_runtime_client(
 
     mock_create_client.side_effect = side_effect
 
-    ChatBedrock(
-        model="us.meta.llama3-3-70b-instruct-v1:0",
-        client=mock_runtime_client,
-        region="us-east-1",
-        config=explicit_config,
-    )
+    with mock.patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("AWS_BEARER_TOKEN_BEDROCK", None)
+        ChatBedrock(
+            model="us.meta.llama3-3-70b-instruct-v1:0",
+            client=mock_runtime_client,
+            region="us-east-1",
+            config=explicit_config,
+        )
 
-    mock_create_client.assert_called_with(
-        region_name="us-east-1",
-        credentials_profile_name=None,
-        aws_access_key_id=None,
-        aws_secret_access_key=None,
-        aws_session_token=None,
-        endpoint_url=None,
-        config=explicit_config,
-        service_name="bedrock",
-        bedrock_api_key=None,
-    )
+        mock_create_client.assert_called_with(
+            region_name="us-east-1",
+            credentials_profile_name=None,
+            aws_access_key_id=None,
+            aws_secret_access_key=None,
+            aws_session_token=None,
+            endpoint_url=None,
+            config=explicit_config,
+            service_name="bedrock",
+            api_key=None,
+        )
 
 
 def test_get_num_tokens_from_messages_with_base_messages():

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -2338,21 +2338,23 @@ def test_bedrock_client_inherits_from_runtime_client(
 
     mock_create_client.side_effect = side_effect
 
-    ChatBedrockConverse(
-        model="us.meta.llama3-3-70b-instruct-v1:0", client=mock_runtime_client
-    )
+    with mock.patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("AWS_BEARER_TOKEN_BEDROCK", None)
+        ChatBedrockConverse(
+            model="us.meta.llama3-3-70b-instruct-v1:0", client=mock_runtime_client
+        )
 
-    mock_create_client.assert_called_with(
-        region_name="us-west-2",
-        credentials_profile_name=None,
-        aws_access_key_id=None,
-        aws_secret_access_key=None,
-        aws_session_token=None,
-        endpoint_url=None,
-        config=None,
-        service_name="bedrock",
-        bedrock_api_key=None,
-    )
+        mock_create_client.assert_called_with(
+            region_name="us-west-2",
+            credentials_profile_name=None,
+            aws_access_key_id=None,
+            aws_secret_access_key=None,
+            aws_session_token=None,
+            endpoint_url=None,
+            config=None,
+            service_name="bedrock",
+            api_key=None,
+        )
 
 
 @mock.patch("langchain_aws.chat_models.bedrock_converse.create_aws_client")
@@ -2376,23 +2378,25 @@ def test_bedrock_client_uses_explicit_values_over_runtime_client(
 
     mock_create_client.side_effect = side_effect
 
-    ChatBedrockConverse(
-        model="us.meta.llama3-3-70b-instruct-v1:0",
-        client=mock_runtime_client,
-        region_name="us-east-1",
-    )
+    with mock.patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("AWS_BEARER_TOKEN_BEDROCK", None)
+        ChatBedrockConverse(
+            model="us.meta.llama3-3-70b-instruct-v1:0",
+            client=mock_runtime_client,
+            region_name="us-east-1",
+        )
 
-    mock_create_client.assert_called_with(
-        region_name="us-east-1",
-        credentials_profile_name=None,
-        aws_access_key_id=None,
-        aws_secret_access_key=None,
-        aws_session_token=None,
-        endpoint_url=None,
-        config=None,
-        service_name="bedrock",
-        bedrock_api_key=None,
-    )
+        mock_create_client.assert_called_with(
+            region_name="us-east-1",
+            credentials_profile_name=None,
+            aws_access_key_id=None,
+            aws_secret_access_key=None,
+            aws_session_token=None,
+            endpoint_url=None,
+            config=None,
+            service_name="bedrock",
+            api_key=None,
+        )
 
 
 def test__has_tool_use_or_result_blocks() -> None:


### PR DESCRIPTION
Related: #841 

This PR adds a new `bedrock_api_key`(or just `api_key`) parameter to ChatBedrock and ChatBedrockConverse, allowing for [Bedrock API keys](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html) to be passed explicitly during model instantiation. This parameter follows the equivalent `api_key` implementations in [ChatAnthropic](https://github.com/langchain-ai/langchain/blob/72571185a8f51e353a2fe9143855f310c4d31e08/libs/partners/anthropic/langchain_anthropic/chat_models.py#L804) and [ChatOpenAI](https://reference.langchain.com/python/integrations/langchain_openai/ChatOpenAI/#langchain_openai.ChatOpenAI.openai_api_key). 

Usage example:

```python
API_KEY = "your_api_key_here"

llm = ChatBedrockConverse(
    model="global.anthropic.claude-sonnet-4-5-20250929-v1:0",
    region_name="us-west-2",
    bedrock_api_key=API_KEY
)
```

A few notes:
- If `bedrock_api_key` is not specified, it will pick up the value of the `AWS_BEARER_TOKEN_BEDROCK` environmental variable, if present. (This is the existing default behavior.)
- If `bedrock_api_key` is specified AND `AWS_BEARER_TOKEN_BEDROCK` exist, the env variable will be overwritten with the value of `bedrock_api_key`.
- If both `bedrock_api_key` and AWS credentials are passed during model instantiation, the API key will take precedence.