### PR TITLE
fix(aws): Ensure OpenAI tool format for ChatBedrockConverse bind_tools

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -1208,20 +1208,17 @@ class ChatBedrockConverse(BaseChatModel):
         if system_tools:
             kwargs["disable_streaming"] = True
 
-        # If we have system tools, we need to use toolConfig format
-        # Otherwise, use the old format for backward compatibility
-        if system_tools:
-            # Format custom tools using existing logic
-            formatted_custom_tools: List[Any] = []
-            for tool in custom_tools:
-                if _is_cache_point(tool):
-                    formatted_custom_tools.append(tool)
-                else:
-                    try:
-                        formatted_custom_tools.append(convert_to_openai_tool(tool))
-                    except Exception:
-                        formatted_custom_tools.append(_format_tools([tool])[0])
+        formatted_custom_tools: List[Any] = []
+        for tool in custom_tools:
+            if _is_cache_point(tool):
+                formatted_custom_tools.append(tool)
+            else:
+                try:
+                    formatted_custom_tools.append(convert_to_openai_tool(tool))
+                except Exception:
+                    formatted_custom_tools.append(_format_tools([tool])[0])
 
+        if system_tools:
             # Merge system and custom tools
             all_tools = formatted_custom_tools + system_tools
 
@@ -1258,7 +1255,6 @@ class ChatBedrockConverse(BaseChatModel):
 
             return self.bind(toolConfig=tool_config, **kwargs)
         else:
-            # No system tools - use old format for backward compatibility
             # Format tool_choice if provided
             formatted_tool_choice = None
             if tool_choice:
@@ -1289,7 +1285,9 @@ class ChatBedrockConverse(BaseChatModel):
                 formatted_tool_choice = _format_tool_choice("any")
 
             return self.bind(
-                tools=custom_tools, tool_choice=formatted_tool_choice, **kwargs
+                tools=formatted_custom_tools,
+                tool_choice=formatted_tool_choice,
+                **kwargs,
             )
 
     def with_structured_output(


### PR DESCRIPTION
Fixes #853

Updates ChatBedrockConverse to address a regression present in langchain-aws>=1.2.1. 

#784 included a change to `bind_tools()` removing formatting of base/custom tools from `StructuredTool` to OpenAI (dictionary) format when no Nova 2.0 system tools were present, which broke compatibility with `create_agent` and the older LangGraph `create_react_agent`.

