### PR TITLE
chore(aws): relax numpy pip requirements

### DIFF
--- a/libs/aws/pyproject.toml
+++ b/libs/aws/pyproject.toml
@@ -15,8 +15,7 @@ dependencies = [
     "langchain-core>=1.2.5",
     "boto3>=1.42.5",
     "pydantic>=2.10.6,<3",
-    "numpy>=2.2,<3; python_version>='3.12'",
-    "numpy>=1.0.0,<3; python_version<'3.12'",
+    "numpy>=1.0.0,<3",
 ]
 
 [project.urls]

--- a/libs/aws/uv.lock
+++ b/libs/aws/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.13' and platform_python_implementation == 'PyPy'",
@@ -675,8 +675,7 @@ requires-dist = [
     { name = "bedrock-agentcore", marker = "python_full_version >= '3.10' and extra == 'tools'", specifier = ">=1.2.0" },
     { name = "boto3", specifier = ">=1.42.5" },
     { name = "langchain-core", specifier = ">=1.2.5" },
-    { name = "numpy", marker = "python_full_version < '3.12'", specifier = ">=1.0.0,<3" },
-    { name = "numpy", marker = "python_full_version >= '3.12'", specifier = ">=2.2,<3" },
+    { name = "numpy", specifier = ">=1.0.0,<3" },
     { name = "playwright", marker = "extra == 'tools'", specifier = ">=1.53.0" },
     { name = "pydantic", specifier = ">=2.10.6,<3" },
 ]


### PR DESCRIPTION
The package works fine in any version of numpy (>1,<3). Restricting to >2.2 for py3.12 and above means folks still using numpy v1 will face conflict with this package for no technical reason ( :( still using numpy v1, but i suspect I am not alone)

Note that without this specifier, package resolution is still bounded by numpy supported versions as declared in numpy's `requires_python` tags. As such, this change should:

1. not change any dependency resolution for projects which already (or can use) numpy v2
2. not unduly pull in numpy v2 in python versions which cant support it
3. enable folks to use this package when using py3.12/numpy@v1

Should this package actually come to use or rely on numpy@v2 functionality, then makes sense to bump this. But for now seems this may as well loosen, if possible to be more permissive.

```
$ uv venv --python 3.13 --clear && uv pip install . && (uv pip freeze | grep numpy)
Using CPython 3.13.8
numpy==2.4.2
$ uv venv --python 3.12 --clear && uv pip install . && (uv pip freeze | grep numpy)
Using CPython 3.12.10
numpy==2.4.2
$ uv venv --python 3.11 --clear && uv pip install . && (uv pip freeze | grep numpy)
Using CPython 3.11.14 interpreter at: /usr/bin/python3.11
numpy==2.4.2
$ uv venv --python 3.10 --clear && uv pip install . && (uv pip freeze | grep numpy)
Using CPython 3.10.18
numpy==2.2.6
```

so we use v2 unless specifically requestes

```
uv venv --python 3.12 --clear && uv pip install . numpy==1.26.4
numpy==1.26.4
```

Followed https://docs.langchain.com/oss/python/contributing/code#submitting-your-pr, but don't have a related issue. I can open one if there is interest in this change. Thanks so much for the project!