### PR TITLE
chore: add explicit workflow permissions

### DIFF
--- a/.github/workflows/_compile_integration_test.yml
+++ b/.github/workflows/_compile_integration_test.yml
@@ -8,15 +8,15 @@ on:
         type: string
         description: "From which folder this pipeline executes"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      actions: write
     strategy:
       matrix:
         python-version:

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -8,6 +8,9 @@ on:
         type: string
         description: "From which folder this pipeline executes"
 
+permissions:
+  contents: read
+
 env:
   WORKDIR: ${{ inputs.working-directory == '' && '.' || inputs.working-directory }}
 
@@ -18,9 +21,6 @@ jobs:
   build:
     name: "make lint #${{ matrix.python-version }}"
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      actions: write
     strategy:
       matrix:
         # Only lint on the min and max supported Python versions.

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -8,15 +8,15 @@ on:
         type: string
         description: "From which folder this pipeline executes"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      actions: write
     strategy:
       matrix:
         python-version:

--- a/.github/workflows/_test_release.yml
+++ b/.github/workflows/_test_release.yml
@@ -13,6 +13,11 @@ on:
         default: false
         description: "Release from a non-master branch (danger!)"
 
+permissions:
+  contents: read
+  actions: write
+  id-token: write
+
 env:
   PYTHON_VERSION: "3.13"
 

--- a/.github/workflows/check_diffs.yml
+++ b/.github/workflows/check_diffs.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -39,9 +42,6 @@ jobs:
     name: cd ${{ matrix.working-directory }}
     needs: [build]
     if: ${{ needs.build.outputs.dirs-to-lint != '[]' }}
-    permissions:
-      contents: read
-      actions: write
     strategy:
       matrix:
         working-directory: ${{ fromJson(needs.build.outputs.dirs-to-lint) }}
@@ -54,9 +54,6 @@ jobs:
     name: cd ${{ matrix.working-directory }}
     needs: [build]
     if: ${{ needs.build.outputs.dirs-to-test != '[]' }}
-    permissions:
-      contents: read
-      actions: write
     strategy:
       matrix:
         working-directory: ${{ fromJson(needs.build.outputs.dirs-to-test) }}
@@ -69,9 +66,6 @@ jobs:
     name: cd ${{ matrix.working-directory }}
     needs: [build]
     if: ${{ needs.build.outputs.dirs-to-test != '[]' }}
-    permissions:
-      contents: read
-      actions: write
     strategy:
       matrix:
         working-directory: ${{ fromJson(needs.build.outputs.dirs-to-test) }}

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -28,6 +28,11 @@ on:
 env:
   PYTHON_VERSION: "3.13"
 
+permissions:
+  contents: read
+  actions: write
+  id-token: write
+
 jobs:
   build:
     defaults:


### PR DESCRIPTION
Add workflow-level permissions following the principle of least privilege. Remove unnecessary `actions: write` from lint, test, and compile workflows that don't use artifacts.