### PR TITLE
fix(aws): strip extra fields from text blocks in `tool_result` content

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -536,6 +536,24 @@ def _format_anthropic_messages(
                                     processed_list.append(
                                         {"type": "image", "source": source}
                                     )
+                                elif (
+                                    isinstance(list_item, dict)
+                                    and list_item.get("type") == "text"
+                                ):
+                                    # Strip extra fields that are not accepted
+                                    # by the Bedrock API.
+                                    formatted_item: Dict[str, Any] = {
+                                        k: v
+                                        for k, v in list_item.items()
+                                        if k
+                                        in (
+                                            "type",
+                                            "text",
+                                            "cache_control",
+                                            "citations",
+                                        )
+                                    }
+                                    processed_list.append(formatted_item)
                                 else:
                                     # Keep other items as is
                                     processed_list.append(list_item)

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
@@ -969,6 +969,34 @@ def test__format_anthropic_messages_with_image_conversion_in_tool() -> None:
     assert expected == actual
 
 
+def test__format_anthropic_messages_strips_extra_fields_from_tool_result_text() -> None:
+    """Test that extra fields are stripped from text content block inside
+    tool_result content."""
+    messages = [
+        ToolMessage(  # type: ignore[misc]
+            content=[
+                {
+                    "type": "text",
+                    "text": "tool output",
+                    "id": "lc_12345",
+                }
+            ],
+            tool_call_id="test_tool_call_123",
+        ),
+        HumanMessage("What happened?"),  # type: ignore[misc]
+    ]
+
+    _, actual = _format_anthropic_messages(messages)
+    tool_result = actual[0]["content"][0]
+    assert tool_result["type"] == "tool_result"
+    assert tool_result["tool_use_id"] == "test_tool_call_123"
+
+    # The text block inside the tool_result should only have "type" and "text"
+    text_block = tool_result["content"][0]
+    assert text_block == {"type": "text", "text": "tool output"}
+    assert "id" not in text_block
+
+
 def test__convert_messages_to_prompt_anthropic_message_is_none() -> None:
     messages = None
     assert convert_messages_to_prompt_anthropic(messages) == ""


### PR DESCRIPTION
- Text content blocks from `langchain-mcp-adapters` include an `id` field (auto-generated by `create_text_block()` in langchain-core). When these blocks appear inside `tool_result` content in `ChatBedrock`, they pass through to the Bedrock API unfiltered, causing validation errors since `id` is not an expected field on text content blocks in the request payload.
- Filter text blocks inside `tool_result` content to only allowed keys
- `ChatBedrockConverse` is not affected — `_lc_content_to_bedrock` already reconstructs text blocks with only `{"text": block["text"]}`.