### PR TITLE
fix(aws): unwrap `non_standard` content blocks

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -2074,6 +2074,13 @@ def _lc_content_to_bedrock(
                         }
                     }
                 )
+        elif block["type"] == "non_standard" and "value" in block:
+            # langchain-core's content_blocks property wraps provider-specific
+            # blocks (e.g. cachePoint, guardContent) that lack a recognized
+            # "type" key as {"type": "non_standard", "value": <original>}.
+            # Unwrap to restore the original block — it was valid in .content before
+            # content_blocks wrapped it.
+            bedrock_content.append(block["value"])
         else:
             raise ValueError(f"Unsupported content block type:\n{block}")
     # drop empty text blocks

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -1703,6 +1703,42 @@ def test__lc_content_to_bedrock_mixed_types_with_empty_content() -> None:
     assert bedrock_content == expected
 
 
+def test__lc_content_to_bedrock_non_standard_unwrap() -> None:
+    """Test that `non_standard` blocks are unwrapped to their original value.
+
+    When content passes through `langchain-core`'s `content_blocks`
+    normalization, blocks like `cachePoint` get wrapped as `non_standard`.
+    `_lc_content_to_bedrock` should unwrap them back to the original block.
+    """
+    content: List[Union[str, Dict[str, Any]]] = [
+        {"type": "text", "text": "System prompt"},
+        {"type": "non_standard", "value": {"cachePoint": {"type": "default"}}},
+    ]
+
+    bedrock_content = _lc_content_to_bedrock(content)
+
+    assert bedrock_content == [
+        {"text": "System prompt"},
+        {"cachePoint": {"type": "default"}},
+    ]
+
+
+def test__lc_content_to_bedrock_non_standard_unwrap_guard_content() -> None:
+    """Test that `non_standard` blocks with `guardContent` are unwrapped."""
+    content: List[Union[str, Dict[str, Any]]] = [
+        {
+            "type": "non_standard",
+            "value": {"guardContent": {"text": {"text": "guard"}}},
+        },
+    ]
+
+    bedrock_content = _lc_content_to_bedrock(content)
+
+    assert bedrock_content == [
+        {"guardContent": {"text": {"text": "guard"}}},
+    ]
+
+
 def test__get_provider() -> None:
     llm = ChatBedrockConverse(
         model="anthropic.claude-3-sonnet-20240229-v1:0", region_name="us-west-2"


### PR DESCRIPTION
Discovered in https://github.com/langchain-ai/deepagents/issues/917

---

- Unwraps `non_standard` content blocks in `_lc_content_to_bedrock` so provider-specific blocks survive round-tripping through `content_blocks`.