### PR TITLE
fix(langgraph-checkpoint-aws): Fix thread ID matching in ValkeySaver delete_thread

### DIFF
--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/valkey/async_saver.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/valkey/async_saver.py
@@ -566,7 +566,7 @@ class AsyncValkeySaver(BaseValkeySaver):
         """
         try:
             # Find all checkpoint namespaces for this thread
-            pattern = f"thread:{thread_id}:*"
+            pattern = f"thread:{{{thread_id}}}:*"
             thread_keys = await self.client.keys(pattern)
 
             if not thread_keys:

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/valkey/saver.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/valkey/saver.py
@@ -524,7 +524,7 @@ class ValkeySaver(BaseValkeySaver):
         """
         try:
             # Find all checkpoint namespaces for this thread
-            pattern = f"thread:{thread_id}:*"
+            pattern = f"thread:{{{thread_id}}}:*"
             thread_keys = self.client.keys(pattern)
 
             if not thread_keys:

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/checkpoint/valkey/test_valkey_checkpoint_saver.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/checkpoint/valkey/test_valkey_checkpoint_saver.py
@@ -376,13 +376,16 @@ class TestValkeySaverUnit:
         config = {"configurable": {"thread_id": "test-thread", "checkpoint_ns": "ns1"}}
         saver.put(config, checkpoint, {"step": 1}, {"key": 1})
 
+        # Verify data was stored
+        thread_key = saver._make_thread_key("test-thread", "ns1")
+        checkpoint_key = saver._make_checkpoint_key("test-thread", "ns1", "test-id")
+        assert fake_valkey_client.exists(thread_key)
+        assert fake_valkey_client.exists(checkpoint_key)
+
         # Test thread deletion
         saver.delete_thread("test-thread")
 
         # Verify data was deleted
-        thread_key = saver._make_thread_key("test-thread", "ns1")
-        checkpoint_key = saver._make_checkpoint_key("test-thread", "ns1", "test-id")
-
         assert not fake_valkey_client.exists(thread_key)
         assert not fake_valkey_client.exists(checkpoint_key)
 


### PR DESCRIPTION
Related: #873 and #874

As is, ValkeySaver's `_make_thread_key` method explicitly wraps `thread_id` in curly braces for Valkey hash slot routing ([code ref](https://github.com/langchain-ai/langchain-aws/blob/e5fd18387ab28e00748ca177ee3244223e84fe51/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/valkey/base.py#L74)):                                                                                                                                   
```python                                                                                                                                                                                                                             
# base.py — key stored as "thread:{test-thread}:ns1"                                                                                                                                                                        
return f"thread:{{{thread_id}}}:{checkpoint_ns}"                                                                                                                                                                            
```

However, `delete_thread` searches for keys without the braces properly escaped in the f-string ([code ref](https://github.com/langchain-ai/langchain-aws/blob/e5fd18387ab28e00748ca177ee3244223e84fe51/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/valkey/saver.py#L527)):

```python
pattern = f"thread:{thread_id}:*"
```

So delete_thread silently deletes nothing.

Fixing this for both ValkeySaver's and AsyncValkeySaver's `delete_thread` methods.

