### PR TITLE
fix(aws): convert string tool_use input to dict in _lc_content_to_bedrock

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -54,11 +54,11 @@ from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResu
 from langchain_core.runnables import Runnable, RunnableMap, RunnablePassthrough
 from langchain_core.tools import BaseTool
 from langchain_core.utils import get_pydantic_field_names, secret_from_env
-from langchain_core.utils.json import parse_partial_json
 from langchain_core.utils.function_calling import (
     convert_to_openai_function,
     convert_to_openai_tool,
 )
+from langchain_core.utils.json import parse_partial_json
 from langchain_core.utils.pydantic import TypeBaseModel, is_basemodel_subclass
 from langchain_core.utils.utils import _build_model_kwargs
 from pydantic import BaseModel, ConfigDict, Field, SecretStr, model_validator

--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
@@ -624,8 +624,7 @@ def test_streaming_tool_use_round_trip() -> None:
     assert isinstance(tool_call["args"], dict)
     assert isinstance(full.content, list)
     tool_block = next(
-        b for b in full.content
-        if isinstance(b, dict) and b.get("type") == "tool_use"
+        b for b in full.content if isinstance(b, dict) and b.get("type") == "tool_use"
     )
     assert isinstance(tool_block["input"], str), (
         "After streaming accumulation, content[].tool_use.input should be a "
@@ -641,9 +640,7 @@ def test_streaming_tool_use_round_trip() -> None:
         tool_call_id=tool_call["id"],
     )
 
-    response = llm_with_tools.invoke(
-        [input_message, restored_msg, tool_result]
-    )
+    response = llm_with_tools.invoke([input_message, restored_msg, tool_result])
     assert isinstance(response, AIMessage)
 
 

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -9,6 +9,7 @@ import pytest
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import (
     AIMessage,
+    AIMessageChunk,
     BaseMessage,
     HumanMessage,
     SystemMessage,
@@ -3633,7 +3634,7 @@ def test_content_block_start_tool_call_chunk_args_type() -> None:
         }
     }
     chunk = _parse_stream_event(event)
-    assert chunk is not None
+    assert isinstance(chunk, AIMessageChunk)
     assert len(chunk.tool_call_chunks) == 1
     args = chunk.tool_call_chunks[0]["args"]
     assert args is None or isinstance(args, str)
@@ -3652,7 +3653,7 @@ def test_content_block_delta_tool_call_chunk_args_type() -> None:
         }
     }
     chunk = _parse_stream_event(event)
-    assert chunk is not None
+    assert isinstance(chunk, AIMessageChunk)
     assert len(chunk.tool_call_chunks) == 1
     args = chunk.tool_call_chunks[0]["args"]
     assert isinstance(args, str)
@@ -3701,13 +3702,10 @@ def test_streaming_tool_use_round_trip() -> None:
         if chunk is not None:
             full = chunk if full is None else full + chunk
 
-    assert full is not None
-
+    assert isinstance(full, AIMessageChunk)
     assert isinstance(full.content, list)
     tool_block = next(
-        b
-        for b in full.content
-        if isinstance(b, dict) and b.get("type") == "tool_use"
+        b for b in full.content if isinstance(b, dict) and b.get("type") == "tool_use"
     )
     assert isinstance(tool_block["input"], str)
     assert len(full.tool_call_chunks) > 0


### PR DESCRIPTION
Fixes #827.                                                                                                                                                                                                                    
                                                                  
When streaming tool-use responses, Bedrock's Converse API sends tool input as incremental JSON string fragments across `contentBlockDelta` events. LangChain accumulates these into a JSON string on `content[].tool_use.input`. If this message is sent back to Bedrock, `_lc_content_to_bedrock` passes the string directly to the Bedrock API, which expects a dict, causing a `ValidationException`.

PR #843 attempted to fix this by parsing input inside `_bedrock_to_lc`, but this broke streaming: `tool_call_chunks[].args` must be string, and parsing to dict at that level violated this requirement, resulting in Pydantic validation failures and chunk merging type mismatches.

This fix in this PR instead parses string input to dict in `_lc_content_to_bedrock`, leaving the initial Bedrock->LC streaming accumulation and chunk merging untouched.