### PR TITLE
fix: add optional sanitization for Bedrock tool_call serialization bug

### DIFF
--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/agentcore/saver.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/agentcore/saver.py
@@ -100,7 +100,7 @@ class AgentCoreMemorySaver(BaseCheckpointSaver[str]):
             return result
         sanitized = sanitize_checkpoint(result.checkpoint)
         if sanitized is not result.checkpoint:
-            return result._replace(checkpoint=sanitized)
+            return result._replace(checkpoint=cast(Checkpoint, sanitized))
         return result
 
     def get_tuple(

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/agentcore/saver.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/agentcore/saver.py
@@ -40,6 +40,7 @@ from langgraph_checkpoint_aws.agentcore.models import (
     WriteItem,
     WritesEvent,
 )
+from langgraph_checkpoint_aws.sanitization import sanitize_checkpoint
 
 RunnableConfigDict: TypeAlias = dict[str, Any]
 
@@ -53,6 +54,9 @@ class AgentCoreMemorySaver(BaseCheckpointSaver[str]):
     Args:
         memory_id: the ID of the memory resource created in AgentCore Memory
         serde: serialization protocol to be used. Defaults to JSONPlusSerializer
+        sanitize_tool_calls: if True, sanitize tool_call args on checkpoint load.
+            Fixes Bedrock Converse API serialization bug where tool_call args are
+            stored as JSON strings instead of dicts. Default: True
         limit: maximum number of events to parse from ListEvents.
         max_results: maximum number of results to retrieve from AgentCore Memory.
         max_retries: maximum number of retry attempts for retryable errors.
@@ -65,6 +69,7 @@ class AgentCoreMemorySaver(BaseCheckpointSaver[str]):
         memory_id: str,
         *,
         serde: SerializerProtocol | None = None,
+        sanitize_tool_calls: bool = True,
         limit: int | None = None,
         max_results: int | None = 100,
         max_retries: int = DEFAULT_MAX_RETRIES,
@@ -75,6 +80,7 @@ class AgentCoreMemorySaver(BaseCheckpointSaver[str]):
         super().__init__(serde=serde)
 
         self.memory_id = memory_id
+        self._sanitize_tool_calls = sanitize_tool_calls
         self.limit = limit
         self.max_results = max_results
         self.serializer = EventSerializer(self.serde)
@@ -87,6 +93,15 @@ class AgentCoreMemorySaver(BaseCheckpointSaver[str]):
             **boto3_kwargs,
         )
         self.processor = EventProcessor()
+
+    def _maybe_sanitize(self, result: CheckpointTuple) -> CheckpointTuple:
+        """Apply checkpoint sanitization if enabled."""
+        if not self._sanitize_tool_calls:
+            return result
+        sanitized = sanitize_checkpoint(result.checkpoint)
+        if sanitized is not result.checkpoint:
+            return result._replace(checkpoint=sanitized)
+        return result
 
     def get_tuple(
         self,
@@ -132,9 +147,10 @@ class AgentCoreMemorySaver(BaseCheckpointSaver[str]):
 
         # Build and return checkpoint tuple
         writes = writes_by_checkpoint.get(checkpoint_event.checkpoint_id, [])
-        return self.processor.build_checkpoint_tuple(
+        result = self.processor.build_checkpoint_tuple(
             checkpoint_event, writes, channel_data, checkpoint_config
         )
+        return self._maybe_sanitize(result)
 
     def list(
         self,
@@ -183,9 +199,10 @@ class AgentCoreMemorySaver(BaseCheckpointSaver[str]):
 
             writes = writes_by_checkpoint.get(checkpoint_id, [])
 
-            yield self.processor.build_checkpoint_tuple(
+            result = self.processor.build_checkpoint_tuple(
                 checkpoint_event, writes, channel_data, checkpoint_config
             )
+            yield self._maybe_sanitize(result)
 
             count += 1
 

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/sanitization.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/sanitization.py
@@ -162,7 +162,10 @@ def sanitize_message(msg: BaseMessage) -> BaseMessage:
 
     sanitized_tool_calls: list[dict[str, Any]] | None = None
     if msg.tool_calls:
-        sanitized_tool_calls = _sanitize_tool_calls(msg.tool_calls)
+        # Cast ToolCall (TypedDict) list to dict list for sanitization
+        sanitized_tool_calls = _sanitize_tool_calls(
+            cast(list[dict[str, Any]], msg.tool_calls)
+        )
         if sanitized_tool_calls != msg.tool_calls:
             needs_sanitization = True
 

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/sanitization.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/sanitization.py
@@ -1,0 +1,233 @@
+"""Checkpoint sanitization utilities for Bedrock tool_call serialization.
+
+When using AWS Bedrock Converse API, checkpoints containing tool_use blocks
+may have their input/args fields serialized as JSON strings instead of dicts.
+This module provides sanitization functions to fix this on checkpoint load.
+"""
+
+import json
+import logging
+from typing import Any
+
+from langchain_core.messages import AIMessage, BaseMessage
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_tool_args(args: Any) -> Any:
+    """Safely deserialize tool args that may be JSON strings.
+
+    Bedrock Converse API sometimes returns nested objects as JSON strings
+    instead of proper dicts. This function handles both cases.
+
+    Args:
+        args: Tool arguments (can be dict, string, or other)
+
+    Returns:
+        Parsed arguments as dict if possible, original value otherwise
+    """
+    if args is None:
+        return {}
+
+    if isinstance(args, dict):
+        return {
+            k: _parse_tool_args(v) if isinstance(v, str) and v.startswith("{") else v
+            for k, v in args.items()
+        }
+
+    if isinstance(args, str):
+        try:
+            parsed = json.loads(args)
+            if isinstance(parsed, dict):
+                return parsed
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+    return args
+
+
+def _sanitize_tool_calls(tool_calls: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Ensure all tool call args are dicts, not strings.
+
+    Args:
+        tool_calls: List of tool call dicts with 'name', 'args', 'id' keys
+
+    Returns:
+        Sanitized list with args properly deserialized
+    """
+    if not tool_calls:
+        return tool_calls
+
+    sanitized = []
+    for tc in tool_calls:
+        tc_copy = tc.copy()
+        if "args" in tc_copy:
+            original_args = tc_copy["args"]
+            tc_copy["args"] = _parse_tool_args(original_args)
+
+            if tc_copy["args"] != original_args and isinstance(original_args, str):
+                logger.debug(
+                    "Sanitized tool_call args for %s: string -> dict",
+                    tc_copy.get("name", "unknown"),
+                )
+
+        sanitized.append(tc_copy)
+
+    return sanitized
+
+
+def _sanitize_content_blocks(content: Any) -> Any:
+    """Sanitize content blocks in message content.
+
+    AIMessage content can be a list with blocks like:
+    [
+        {"type": "text", "text": "Let me..."},
+        {"type": "tool_use", "name": "...", "id": "...", "input": {...}}
+    ]
+
+    The 'input' field of tool_use blocks must be a dict, not a string.
+    """
+    if not isinstance(content, list):
+        return content
+
+    sanitized = []
+    modified = False
+
+    for block in content:
+        if not isinstance(block, dict):
+            sanitized.append(block)
+            continue
+
+        if block.get("type") == "tool_use" and "input" in block:
+            original_input = block["input"]
+            sanitized_input = _parse_tool_args(original_input)
+
+            if sanitized_input != original_input and isinstance(original_input, str):
+                logger.debug(
+                    "Sanitized tool_use.input for %s: string -> dict",
+                    block.get("name", "unknown"),
+                )
+                block_copy = block.copy()
+                block_copy["input"] = sanitized_input
+                sanitized.append(block_copy)
+                modified = True
+            else:
+                sanitized.append(block)
+        else:
+            sanitized.append(block)
+
+    return sanitized if modified else content
+
+
+def _sanitize_additional_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Sanitize additional_kwargs which may contain tool_calls in Bedrock format."""
+    if not kwargs or "tool_calls" not in kwargs:
+        return kwargs
+
+    kwargs_copy = kwargs.copy()
+    sanitized_calls = []
+    for tc in kwargs_copy.get("tool_calls", []):
+        tc_copy = tc.copy()
+        if "input" in tc_copy:
+            tc_copy["input"] = _parse_tool_args(tc_copy["input"])
+        if "args" in tc_copy:
+            tc_copy["args"] = _parse_tool_args(tc_copy["args"])
+        sanitized_calls.append(tc_copy)
+
+    kwargs_copy["tool_calls"] = sanitized_calls
+    return kwargs_copy
+
+
+def sanitize_message(msg: BaseMessage) -> BaseMessage:
+    """Sanitize a single message to ensure tool calls have dict args.
+
+    Handles:
+    1. msg.tool_calls - LangChain tool_calls attribute
+    2. msg.additional_kwargs.tool_calls - Bedrock format
+    3. msg.content - When content is a list with tool_use blocks
+
+    Args:
+        msg: A LangChain message
+
+    Returns:
+        Sanitized message with properly formatted tool calls
+    """
+    if not isinstance(msg, AIMessage):
+        return msg
+
+    needs_sanitization = False
+
+    sanitized_tool_calls = None
+    if msg.tool_calls:
+        sanitized_tool_calls = _sanitize_tool_calls(msg.tool_calls)
+        if sanitized_tool_calls != msg.tool_calls:
+            needs_sanitization = True
+
+    sanitized_kwargs = _sanitize_additional_kwargs(msg.additional_kwargs)
+    if sanitized_kwargs != msg.additional_kwargs:
+        needs_sanitization = True
+
+    sanitized_content = msg.content
+    if isinstance(msg.content, list):
+        sanitized_content = _sanitize_content_blocks(msg.content)
+        if sanitized_content != msg.content:
+            needs_sanitization = True
+
+    if needs_sanitization:
+        return AIMessage(
+            content=sanitized_content,
+            tool_calls=sanitized_tool_calls or msg.tool_calls,
+            additional_kwargs=sanitized_kwargs,
+            response_metadata=getattr(msg, "response_metadata", {}),
+            id=msg.id,
+        )
+
+    return msg
+
+
+def sanitize_checkpoint(checkpoint: dict | None) -> dict | None:
+    """Sanitize a checkpoint's messages to fix malformed tool_call args.
+
+    This is the main entry point for checkpoint sanitization.
+
+    Args:
+        checkpoint: Raw checkpoint dict
+
+    Returns:
+        Sanitized checkpoint with properly formatted tool calls
+    """
+    if not checkpoint:
+        return checkpoint
+
+    if "channel_values" not in checkpoint:
+        return checkpoint
+
+    channel_values = checkpoint["channel_values"]
+    if not isinstance(channel_values, dict) or "messages" not in channel_values:
+        return checkpoint
+
+    messages = channel_values["messages"]
+    if not messages:
+        return checkpoint
+
+    sanitized_messages = []
+    sanitized_count = 0
+
+    for msg in messages:
+        original = msg
+        sanitized_msg = sanitize_message(msg)
+        if sanitized_msg is not original:
+            sanitized_count += 1
+        sanitized_messages.append(sanitized_msg)
+
+    if sanitized_count == 0:
+        return checkpoint
+
+    logger.info(
+        "Sanitized %d message(s) with malformed tool_call args", sanitized_count
+    )
+
+    sanitized_checkpoint = checkpoint.copy()
+    sanitized_checkpoint["channel_values"] = channel_values.copy()
+    sanitized_checkpoint["channel_values"]["messages"] = sanitized_messages
+    return sanitized_checkpoint

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/test_sanitization.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/test_sanitization.py
@@ -229,15 +229,11 @@ class TestSanitizeCheckpoint:
         result = sanitize_checkpoint(checkpoint)
 
         # Original should be unchanged
-        orig_args = checkpoint["channel_values"][
-            "messages"
-        ][1].tool_calls[0]["args"]
+        orig_args = checkpoint["channel_values"]["messages"][1].tool_calls[0]["args"]
         assert orig_args == '{"name": "X", "price": 50}'
 
         # Result should be sanitized
-        fixed_args = result["channel_values"][
-            "messages"
-        ][1].tool_calls[0]["args"]
+        fixed_args = result["channel_values"]["messages"][1].tool_calls[0]["args"]
         assert fixed_args == {"name": "X", "price": 50}
 
     def test_preserves_other_fields(self):

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/test_sanitization.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/test_sanitization.py
@@ -1,0 +1,318 @@
+"""Tests for checkpoint sanitization utilities."""
+
+import json
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+from langgraph_checkpoint_aws.sanitization import (
+    _parse_tool_args,
+    _sanitize_content_blocks,
+    _sanitize_tool_calls,
+    sanitize_checkpoint,
+    sanitize_message,
+)
+
+
+class TestParseToolArgs:
+    """Test _parse_tool_args function."""
+
+    def test_dict_passthrough(self):
+        args = {"name": "test", "price": 50}
+        assert _parse_tool_args(args) == args
+
+    def test_string_to_dict(self):
+        args = '{"name": "test", "price": 50}'
+        result = _parse_tool_args(args)
+        assert result == {"name": "test", "price": 50}
+        assert isinstance(result, dict)
+
+    def test_none_to_empty_dict(self):
+        assert _parse_tool_args(None) == {}
+
+    def test_invalid_json_string(self):
+        assert _parse_tool_args("not json") == "not json"
+
+    def test_nested_string_in_dict(self):
+        args = {"name": "test", "nested": '{"key": "value"}'}
+        result = _parse_tool_args(args)
+        assert result["nested"] == {"key": "value"}
+
+
+class TestSanitizeToolCalls:
+    """Test _sanitize_tool_calls function."""
+
+    def test_empty_list(self):
+        assert _sanitize_tool_calls([]) == []
+
+    def test_dict_args_unchanged(self):
+        tool_calls = [
+            {"name": "create_product", "id": "call_123", "args": {"name": "X", "price": 50}}
+        ]
+        result = _sanitize_tool_calls(tool_calls)
+        assert result == tool_calls
+
+    def test_string_args_converted(self):
+        tool_calls = [
+            {
+                "name": "create_product",
+                "id": "call_123",
+                "args": '{"name": "X", "price": 50}',
+            }
+        ]
+        result = _sanitize_tool_calls(tool_calls)
+        assert result[0]["args"] == {"name": "X", "price": 50}
+        assert isinstance(result[0]["args"], dict)
+
+    def test_multiple_tool_calls(self):
+        tool_calls = [
+            {"name": "tool1", "id": "1", "args": '{"a": 1}'},
+            {"name": "tool2", "id": "2", "args": {"b": 2}},
+            {"name": "tool3", "id": "3", "args": '{"c": 3}'},
+        ]
+        result = _sanitize_tool_calls(tool_calls)
+        assert result[0]["args"] == {"a": 1}
+        assert result[1]["args"] == {"b": 2}
+        assert result[2]["args"] == {"c": 3}
+
+
+class TestSanitizeContentBlocks:
+    """Test _sanitize_content_blocks function."""
+
+    def test_string_content_unchanged(self):
+        assert _sanitize_content_blocks("Hello, world!") == "Hello, world!"
+
+    def test_text_block_unchanged(self):
+        content = [{"type": "text", "text": "Hello"}]
+        assert _sanitize_content_blocks(content) == content
+
+    def test_tool_use_dict_input_unchanged(self):
+        content = [
+            {
+                "type": "tool_use",
+                "name": "create_product",
+                "id": "call_123",
+                "input": {"name": "X", "price": 50},
+            }
+        ]
+        assert _sanitize_content_blocks(content) == content
+
+    def test_tool_use_string_input_converted(self):
+        content = [
+            {
+                "type": "tool_use",
+                "name": "create_product",
+                "id": "call_123",
+                "input": '{"name": "X", "price": 50}',
+            }
+        ]
+        result = _sanitize_content_blocks(content)
+        assert result[0]["input"] == {"name": "X", "price": 50}
+        assert isinstance(result[0]["input"], dict)
+
+    def test_mixed_blocks(self):
+        content = [
+            {"type": "text", "text": "I'll create that product."},
+            {
+                "type": "tool_use",
+                "name": "create_product",
+                "id": "call_123",
+                "input": '{"name": "X"}',
+            },
+        ]
+        result = _sanitize_content_blocks(content)
+        assert result[0] == {"type": "text", "text": "I'll create that product."}
+        assert result[1]["input"] == {"name": "X"}
+
+
+class TestSanitizeMessage:
+    """Test sanitize_message function."""
+
+    def test_human_message_unchanged(self):
+        msg = HumanMessage(content="Hello")
+        assert sanitize_message(msg) is msg
+
+    def test_ai_message_no_tools_unchanged(self):
+        msg = AIMessage(content="Hello back!")
+        result = sanitize_message(msg)
+        assert result.content == "Hello back!"
+
+    def test_ai_message_tool_calls_sanitized(self):
+        msg = AIMessage(
+            content="I'll create that.",
+            tool_calls=[
+                {
+                    "name": "create_product",
+                    "id": "call_123",
+                    "args": '{"name": "X", "price": 50}',
+                }
+            ],
+        )
+        result = sanitize_message(msg)
+        assert result.tool_calls[0]["args"] == {"name": "X", "price": 50}
+
+    def test_ai_message_content_blocks_sanitized(self):
+        msg = AIMessage(
+            content=[
+                {"type": "text", "text": "Creating..."},
+                {
+                    "type": "tool_use",
+                    "name": "create_product",
+                    "id": "call_123",
+                    "input": '{"name": "X"}',
+                },
+            ]
+        )
+        result = sanitize_message(msg)
+        assert result.content[1]["input"] == {"name": "X"}
+
+
+class TestSanitizeCheckpoint:
+    """Test sanitize_checkpoint function."""
+
+    def test_none_checkpoint(self):
+        assert sanitize_checkpoint(None) is None
+
+    def test_empty_checkpoint(self):
+        assert sanitize_checkpoint({}) == {}
+
+    def test_no_channel_values(self):
+        checkpoint = {"v": 1, "id": "123"}
+        assert sanitize_checkpoint(checkpoint) == checkpoint
+
+    def test_no_messages(self):
+        checkpoint = {"channel_values": {"other": "data"}}
+        assert sanitize_checkpoint(checkpoint) == checkpoint
+
+    def test_messages_sanitized(self):
+        checkpoint = {
+            "v": 1,
+            "id": "123",
+            "channel_values": {
+                "messages": [
+                    HumanMessage(content="Create product X"),
+                    AIMessage(
+                        content="Creating...",
+                        tool_calls=[
+                            {
+                                "name": "create_product",
+                                "id": "call_123",
+                                "args": '{"name": "X", "price": 50}',
+                            }
+                        ],
+                    ),
+                ]
+            },
+        }
+        result = sanitize_checkpoint(checkpoint)
+
+        # Original should be unchanged
+        assert (
+            checkpoint["channel_values"]["messages"][1].tool_calls[0]["args"]
+            == '{"name": "X", "price": 50}'
+        )
+
+        # Result should be sanitized
+        assert result["channel_values"]["messages"][1].tool_calls[0]["args"] == {
+            "name": "X",
+            "price": 50,
+        }
+
+    def test_preserves_other_fields(self):
+        checkpoint = {
+            "v": 1,
+            "id": "checkpoint_123",
+            "ts": "2026-01-08T10:00:00Z",
+            "channel_values": {
+                "messages": [HumanMessage(content="Hello")],
+                "other_channel": {"data": "value"},
+            },
+            "channel_versions": {"messages": 1},
+            "versions_seen": {},
+        }
+        result = sanitize_checkpoint(checkpoint)
+
+        assert result["v"] == 1
+        assert result["id"] == "checkpoint_123"
+        assert result["ts"] == "2026-01-08T10:00:00Z"
+        assert result["channel_values"]["other_channel"] == {"data": "value"}
+        assert result["channel_versions"] == {"messages": 1}
+
+
+class TestIntegration:
+    """Integration tests simulating real-world Bedrock HITL scenarios."""
+
+    def test_bedrock_hitl_checkpoint_roundtrip(self):
+        """Simulate full HITL checkpoint flow with Bedrock serialization bug."""
+        buggy_checkpoint = {
+            "v": 1,
+            "id": "cp_123",
+            "channel_values": {
+                "messages": [
+                    HumanMessage(content="Create a product called Latte"),
+                    AIMessage(
+                        content=[
+                            {"type": "text", "text": "I'll create that product."},
+                            {
+                                "type": "tool_use",
+                                "name": "Foodics___create_product",
+                                "id": "toolu_abc",
+                                "input": '{"name": "Latte", "price": 25, "category_id": "cat_123"}',
+                            },
+                        ],
+                        tool_calls=[
+                            {
+                                "name": "Foodics___create_product",
+                                "id": "toolu_abc",
+                                "args": '{"name": "Latte", "price": 25, "category_id": "cat_123"}',
+                            }
+                        ],
+                    ),
+                ]
+            },
+        }
+
+        fixed_checkpoint = sanitize_checkpoint(buggy_checkpoint)
+
+        ai_msg = fixed_checkpoint["channel_values"]["messages"][1]
+
+        assert isinstance(ai_msg.content[1]["input"], dict)
+        assert ai_msg.content[1]["input"]["name"] == "Latte"
+
+        assert isinstance(ai_msg.tool_calls[0]["args"], dict)
+        assert ai_msg.tool_calls[0]["args"]["name"] == "Latte"
+
+    def test_already_correct_checkpoint_unchanged(self):
+        """Checkpoints that are already correct should not be modified."""
+        correct_checkpoint = {
+            "v": 1,
+            "id": "cp_123",
+            "channel_values": {
+                "messages": [
+                    HumanMessage(content="Create a product"),
+                    AIMessage(
+                        content=[
+                            {"type": "text", "text": "Creating..."},
+                            {
+                                "type": "tool_use",
+                                "name": "create_product",
+                                "id": "toolu_abc",
+                                "input": {"name": "X", "price": 50},
+                            },
+                        ],
+                        tool_calls=[
+                            {
+                                "name": "create_product",
+                                "id": "toolu_abc",
+                                "args": {"name": "X", "price": 50},
+                            }
+                        ],
+                    ),
+                ]
+            },
+        }
+
+        result = sanitize_checkpoint(correct_checkpoint)
+
+        # Should return the same object (no changes needed)
+        assert result is correct_checkpoint


### PR DESCRIPTION
## Summary

- Adds optional checkpoint sanitization to `AgentCoreMemorySaver` that fixes Bedrock Converse API tool_call serialization bug
- When checkpoints containing `tool_use` blocks are saved, the `input`/`args` fields may be serialized as JSON strings instead of dicts, causing `ValidationException` on resume
- New `sanitize_tool_calls` parameter (default `True`) sanitizes tool_call args on checkpoint load

## Problem

When using `AgentCoreMemorySaver` with AWS Bedrock Converse API, checkpoints containing `tool_use` blocks may have their `input` field serialized as a JSON string instead of a dict. When these checkpoints are loaded and the conversation is resumed, Bedrock rejects the request with:

```
ValidationException: 1 validation error detected: Value '{"name":"test"}' at
'messages.2.member.content.1.member.toolUse.input' failed to satisfy constraint:
Member must be a map (JSON object)
```

### Reproduction

1. Create an agent with `AgentCoreMemorySaver` and Bedrock LLM (`ChatBedrockConverse`)
2. Invoke agent with a request that triggers a tool call
3. Use HITL (`interrupt()`) to pause execution — checkpoint saved automatically
4. Resume with `Command(resume=...)` — **fails** with `ValidationException`

## Solution

Defense-in-depth fix that sanitizes checkpoints on load:

1. **New module `sanitization.py`** — standalone sanitization functions that:
   - Parse JSON string tool args back to dicts (`_parse_tool_args`)
   - Sanitize `tool_calls[].args`, `content[].input`, and `additional_kwargs` formats
   - Handle both LangChain and Bedrock tool call formats
2. **Modified `AgentCoreMemorySaver`**:
   - Added `sanitize_tool_calls: bool = True` parameter
   - `get_tuple()` and `list()` apply sanitization before returning
   - `aget_tuple()` covered via delegation to `get_tuple()`

## Changes

- `langgraph_checkpoint_aws/sanitization.py` — new sanitization module
- `langgraph_checkpoint_aws/agentcore/saver.py` — added sanitization support
- `tests/unit_tests/test_sanitization.py` — 22 unit tests including integration scenario

## Testing

- [x] Unit tests for all sanitization functions
- [x] Integration test simulating real Bedrock HITL checkpoint roundtrip with the bug
- [x] Test that already-correct checkpoints pass through unchanged (no performance impact)
- [x] Test that sanitization is non-destructive (original checkpoint not modified)

## Related

- Bedrock Converse API tool_use serialization (root cause is in Bedrock's serialization layer)
- LangGraph HITL with nested agents