### PR TITLE
fix(utils): handle "adaptive" thinking type in thinking_in_params

### DIFF
--- a/libs/aws/langchain_aws/utils.py
+++ b/libs/aws/langchain_aws/utils.py
@@ -238,7 +238,7 @@ def create_aws_client(
 
 def thinking_in_params(params: dict) -> bool:
     """Check if the thinking parameter is enabled in the request."""
-    return params.get("thinking", {}).get("type") == "enabled"
+    return params.get("thinking", {}).get("type") in ("enabled", "adaptive")
 
 
 def trim_message_whitespace(messages: List[Any]) -> List[Any]:

--- a/libs/aws/tests/unit_tests/test_utils.py
+++ b/libs/aws/tests/unit_tests/test_utils.py
@@ -11,6 +11,7 @@ from pydantic import SecretStr
 from langchain_aws.utils import (
     count_tokens_api_supported_for_model,
     create_aws_client,
+    thinking_in_params,
     trim_message_whitespace,
 )
 
@@ -580,3 +581,20 @@ def test_api_key_overrides_existing_env_var(
     session_mock.assert_not_called()
     client_mock.assert_called_once_with(service_name="bedrock-runtime")
     assert client == client_instance
+
+
+class TestThinkingInParams:
+    def test_enabled_type(self) -> None:
+        assert thinking_in_params({"thinking": {"type": "enabled", "budget_tokens": 1024}})
+
+    def test_adaptive_type(self) -> None:
+        assert thinking_in_params({"thinking": {"type": "adaptive", "budget_tokens": 1024}})
+
+    def test_disabled_type(self) -> None:
+        assert not thinking_in_params({"thinking": {"type": "disabled"}})
+
+    def test_missing_thinking_key(self) -> None:
+        assert not thinking_in_params({})
+
+    def test_missing_type_key(self) -> None:
+        assert not thinking_in_params({"thinking": {}})


### PR DESCRIPTION
## Problem

`thinking_in_params()` only checks for `thinking.type == "enabled"`, but Claude claude-sonnet-4.6 introduced `thinking.type: "adaptive"` which also activates extended thinking. This causes all thinking-dependent code paths to silently ignore adaptive thinking configurations:

- **Tool choice restrictions**: `bind_tools` with `tool_choice` should raise when thinking is active, but doesn't with adaptive type
- **Content block formatting**: Thinking blocks in responses are not properly handled
- **Output token validation**: The `max_tokens` / budget constraints are bypassed

## Fix

Changed the equality check to a membership test:

```python
# Before
return params.get("thinking", {}).get("type") == "enabled"

# After
return params.get("thinking", {}).get("type") in ("enabled", "adaptive")
```

## Tests

Added `TestThinkingInParams` class with 5 test cases covering:
- `type: "enabled"` → `True`
- `type: "adaptive"` → `True`
- `type: "disabled"` → `False`
- Missing `thinking` key → `False`
- Missing `type` key → `False`

Closes #922