### PR TITLE
fix(tools): make NovaSystemTool extend BaseTool for create_agent compatibility

### DIFF
--- a/libs/aws/langchain_aws/tools/nova_tools.py
+++ b/libs/aws/langchain_aws/tools/nova_tools.py
@@ -113,41 +113,58 @@ Timeout Recommendations:
     - **Web grounding**: Default timeout is usually sufficient
 """
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional, Type
+
+from langchain_core.callbacks import CallbackManagerForToolRun
+from langchain_core.tools import BaseTool
+from pydantic import BaseModel, Field
 
 
-class NovaSystemTool:
+class _EmptyInput(BaseModel):
+    """Empty input schema for Nova system tools (executed server-side)."""
+
+
+class NovaSystemTool(BaseTool):
     """Base class for Nova system tools.
 
     System tools are built-in tools provided by Nova models that execute
     server-side. Unlike custom tools, system tools don't require client-side
     implementation.
 
-    Args:
-        name: The name of the system tool (e.g., "nova_grounding")
+    This class extends ``BaseTool`` so that Nova system tools work seamlessly
+    with LangGraph's ``create_react_agent`` / ``ToolNode``, in addition to
+    ``ChatBedrockConverse.bind_tools``.
 
     Attributes:
-        name: The system tool name
-        type: Always "system_tool" to distinguish from custom tools
+        type: Always ``"system_tool"`` to distinguish from custom tools.
     """
 
-    def __init__(self, name: str) -> None:
-        """Initialize a Nova system tool.
+    type: str = Field(default="system_tool", exclude=True)
 
-        Args:
-            name: The name of the system tool
-        """
-        self.name = name
-        self.type = "system_tool"
+    args_schema: Type[BaseModel] = _EmptyInput
 
     def to_bedrock_format(self) -> Dict[str, Any]:
         """Convert to Bedrock systemTool format.
 
         Returns:
             Dictionary in the format expected by the Bedrock Converse API:
-            {"systemTool": {"name": "<tool_name>"}}
+            ``{"systemTool": {"name": "<tool_name>"}}``
         """
         return {"systemTool": {"name": self.name}}
+
+    def _run(
+        self,
+        run_manager: Optional[CallbackManagerForToolRun] = None,
+        **kwargs: Any,
+    ) -> str:
+        # System tools are executed server-side by the Bedrock Converse API.
+        # This method is only called if ToolNode invokes the tool locally,
+        # which should not happen during normal operation.
+        return (
+            f"[{self.name}] This is a Nova system tool that executes "
+            "server-side via the Bedrock Converse API. "
+            "No local execution is needed."
+        )
 
 
 class NovaGroundingTool(NovaSystemTool):
@@ -156,6 +173,9 @@ class NovaGroundingTool(NovaSystemTool):
     The nova_grounding tool enables the model to search the web for current
     information. The model autonomously decides when to invoke the tool and
     processes the results.
+
+    Compatible with both ``ChatBedrockConverse.bind_tools`` and LangGraph's
+    ``create_react_agent``.
 
     Note:
         Requires bedrock:InvokeTool IAM permission.
@@ -169,9 +189,11 @@ class NovaGroundingTool(NovaSystemTool):
         response = model_with_search.invoke("What's the latest news?")
     """
 
-    def __init__(self) -> None:
-        """Initialize the Nova grounding tool."""
-        super().__init__("nova_grounding")
+    name: str = "nova_grounding"
+    description: str = (
+        "Search the web for current information using Amazon Nova's "
+        "built-in grounding capability. Executes server-side."
+    )
 
 
 class NovaCodeInterpreterTool(NovaSystemTool):
@@ -180,6 +202,9 @@ class NovaCodeInterpreterTool(NovaSystemTool):
     The nova_code_interpreter tool enables the model to execute Python code
     in a sandboxed environment. Useful for calculations, data analysis, and
     other computational tasks.
+
+    Compatible with both ``ChatBedrockConverse.bind_tools`` and LangGraph's
+    ``create_react_agent``.
 
     Note:
         Requires bedrock:InvokeTool IAM permission.
@@ -196,6 +221,8 @@ class NovaCodeInterpreterTool(NovaSystemTool):
         )
     """
 
-    def __init__(self) -> None:
-        """Initialize the Nova code interpreter tool."""
-        super().__init__("nova_code_interpreter")
+    name: str = "nova_code_interpreter"
+    description: str = (
+        "Execute Python code in a sandboxed environment using Amazon Nova's "
+        "built-in code interpreter. Executes server-side."
+    )

--- a/libs/aws/tests/unit_tests/tools/test_nova_tools.py
+++ b/libs/aws/tests/unit_tests/tools/test_nova_tools.py
@@ -1,3 +1,5 @@
+from langchain_core.tools import BaseTool
+
 from langchain_aws.tools.nova_tools import (
     NovaCodeInterpreterTool,
     NovaGroundingTool,
@@ -10,13 +12,13 @@ class TestNovaSystemTool:
 
     def test_initialization(self) -> None:
         """Test NovaSystemTool initialization."""
-        tool = NovaSystemTool("test_tool")
+        tool = NovaSystemTool(name="test_tool", description="A test tool")
         assert tool.name == "test_tool"
         assert tool.type == "system_tool"
 
     def test_to_bedrock_format(self) -> None:
         """Test to_bedrock_format returns correct structure."""
-        tool = NovaSystemTool("test_tool")
+        tool = NovaSystemTool(name="test_tool", description="A test tool")
         result = tool.to_bedrock_format()
 
         assert isinstance(result, dict)
@@ -26,9 +28,21 @@ class TestNovaSystemTool:
 
     def test_to_bedrock_format_structure(self) -> None:
         """Test to_bedrock_format returns exact expected structure."""
-        tool = NovaSystemTool("my_tool")
+        tool = NovaSystemTool(name="my_tool", description="My tool")
         expected = {"systemTool": {"name": "my_tool"}}
         assert tool.to_bedrock_format() == expected
+
+    def test_is_base_tool(self) -> None:
+        """Test that NovaSystemTool is a BaseTool instance."""
+        tool = NovaSystemTool(name="test_tool", description="A test tool")
+        assert isinstance(tool, BaseTool)
+
+    def test_run_returns_message(self) -> None:
+        """Test that _run returns a server-side execution message."""
+        tool = NovaSystemTool(name="test_tool", description="A test tool")
+        result = tool._run()
+        assert "server-side" in result
+        assert "test_tool" in result
 
 
 class TestNovaGroundingTool:
@@ -45,6 +59,11 @@ class TestNovaGroundingTool:
         tool = NovaGroundingTool()
         assert isinstance(tool, NovaSystemTool)
 
+    def test_is_base_tool(self) -> None:
+        """Test that NovaGroundingTool is a BaseTool (create_agent compat)."""
+        tool = NovaGroundingTool()
+        assert isinstance(tool, BaseTool)
+
     def test_to_bedrock_format(self) -> None:
         """Test NovaGroundingTool formats correctly."""
         tool = NovaGroundingTool()
@@ -52,6 +71,12 @@ class TestNovaGroundingTool:
 
         expected = {"systemTool": {"name": "nova_grounding"}}
         assert result == expected
+
+    def test_has_description(self) -> None:
+        """Test that NovaGroundingTool has a non-empty description."""
+        tool = NovaGroundingTool()
+        assert tool.description
+        assert "grounding" in tool.description.lower()
 
 
 class TestNovaCodeInterpreterTool:
@@ -68,6 +93,11 @@ class TestNovaCodeInterpreterTool:
         tool = NovaCodeInterpreterTool()
         assert isinstance(tool, NovaSystemTool)
 
+    def test_is_base_tool(self) -> None:
+        """Test that NovaCodeInterpreterTool is a BaseTool (create_agent compat)."""
+        tool = NovaCodeInterpreterTool()
+        assert isinstance(tool, BaseTool)
+
     def test_to_bedrock_format(self) -> None:
         """Test NovaCodeInterpreterTool formats correctly."""
         tool = NovaCodeInterpreterTool()
@@ -75,3 +105,9 @@ class TestNovaCodeInterpreterTool:
 
         expected = {"systemTool": {"name": "nova_code_interpreter"}}
         assert result == expected
+
+    def test_has_description(self) -> None:
+        """Test that NovaCodeInterpreterTool has a non-empty description."""
+        tool = NovaCodeInterpreterTool()
+        assert tool.description
+        assert "code" in tool.description.lower()


### PR DESCRIPTION
## Problem

`NovaGroundingTool` and `NovaCodeInterpreterTool` cannot be used with LangGraph's `create_react_agent` because `ToolNode` requires tools that are `BaseTool` instances, callables, or strings:

```python
from langchain_aws.tools import NovaGroundingTool
from langgraph.prebuilt import create_react_agent

agent = create_react_agent(model=model, tools=[NovaGroundingTool()])
# ValueError: The first argument must be a string or a callable
# with a __name__ for tool decorator.
```

The error occurs in `ToolNode.__init__` → `create_tool()` because `NovaSystemTool` is a plain Python class, not a `BaseTool`.

## Fix

Make `NovaSystemTool` extend `langchain_core.tools.BaseTool`:

- **`name`** and **`description`** are now Pydantic fields (as BaseTool requires)
- **`_run()`** returns a helpful message explaining the tool executes server-side (safe fallback — these tools are never executed locally during normal operation)
- **`type`** attribute remains `"system_tool"` for backward compatibility with `bind_tools()` detection
- **`to_bedrock_format()`** unchanged
- **`args_schema`** set to empty schema (no client-side args needed)

### Backward Compatibility

All existing code paths are preserved:
- `isinstance(tool, NovaSystemTool)` still works in `ChatBedrockConverse.bind_tools()`
- `NovaGroundingTool()` / `NovaCodeInterpreterTool()` require no constructor changes (defaults provided)
- `to_bedrock_format()` output unchanged

## Tests

Updated `test_nova_tools.py`:
- Added `test_is_base_tool` for all three classes
- Added `test_run_returns_message` for base class
- Added `test_has_description` for concrete tools
- Updated `NovaSystemTool` construction to use keyword args (Pydantic model)

All 15 nova tool tests + 11 converse nova tests pass.

Closes #921