### PR TITLE
fix(bedrock): downgrade forced tool_choice to auto when thinking is enabled

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -1238,6 +1238,77 @@ class ChatBedrockConverse(BaseChatModel):
 
     # TODO: Add async support once there are async bedrock.converse methods.
 
+    def _is_thinking_enabled(self) -> bool:
+        """Check if extended thinking is enabled via additional_model_request_fields."""
+        thinking_params = (self.additional_model_request_fields or {}).get(
+            "thinking", {}
+        )
+        return thinking_params.get("type") == "enabled"
+
+    def _resolve_tool_choice(
+        self,
+        tool_choice: Optional[Union[dict, str]],
+    ) -> Optional[Dict[str, Dict[str, str]]]:
+        """Validate and resolve tool_choice against model capabilities.
+
+        When thinking is enabled and the requested tool_choice is not
+        supported, downgrades to ``auto`` with a warning instead of
+        raising, so that callers like LangGraph ``create_agent`` work
+        transparently.
+
+        Args:
+            tool_choice: Requested tool_choice value.
+
+        Returns:
+            Formatted tool_choice dict, or ``None`` if not provided.
+
+        Raises:
+            ValueError: If tool_choice is unsupported and thinking is
+                not enabled (no safe downgrade possible).
+        """
+        if not tool_choice:
+            if "deepseek.v3" in self._get_base_model():
+                return _format_tool_choice("any")
+            return None
+
+        formatted = _format_tool_choice(tool_choice)
+        tool_choice_type = list(formatted.keys())[0]
+        supported = list(self.supports_tool_choice_values or [])
+
+        if tool_choice_type in supported:
+            return formatted
+
+        # Thinking-enabled models: downgrade to auto instead of failing.
+        if self._is_thinking_enabled() and "auto" in supported:
+            warnings.warn(
+                f"tool_choice={tool_choice!r} is not supported when thinking "
+                f"is enabled. Downgrading to tool_choice='auto'. The model "
+                f"will decide whether to call tools."
+            )
+            return _format_tool_choice("auto")
+
+        # No safe downgrade — raise.
+        base_model = self._get_base_model()
+        if self.supports_tool_choice_values:
+            msg = (
+                f"Model {base_model} does not currently support "
+                f"tool_choice of type {tool_choice_type}. "
+                f"The following tool_choice types are supported: "
+                f"{self.supports_tool_choice_values}."
+            )
+        else:
+            msg = (
+                f"Model {base_model} does not currently support "
+                f"tool_choice."
+            )
+
+        raise ValueError(
+            f"{msg} Please see "
+            "https://docs.aws.amazon.com/bedrock/latest/APIReference/"
+            "API_runtime_ToolChoice.html for the latest documentation "
+            "on models that support tool choice."
+        )
+
     def bind_tools(
         self,
         tools: Sequence[
@@ -1287,6 +1358,8 @@ class ChatBedrockConverse(BaseChatModel):
                         formatted["toolSpec"]["strict"] = strict  # type: ignore[assignment]
                     formatted_custom_tools.append(formatted)
 
+        resolved_tool_choice = self._resolve_tool_choice(tool_choice)
+
         if system_tools:
             # Merge system and custom tools
             all_tools = formatted_custom_tools + system_tools
@@ -1294,68 +1367,14 @@ class ChatBedrockConverse(BaseChatModel):
             # Build toolConfig directly to avoid re-formatting
             tool_config: Dict[str, Any] = {"tools": all_tools}
 
-            if tool_choice:
-                tool_choice_formatted = _format_tool_choice(tool_choice)
-                tool_choice_type = list(tool_choice_formatted.keys())[0]
-                if tool_choice_type not in list(self.supports_tool_choice_values or []):
-                    base_model = self._get_base_model()
-                    if self.supports_tool_choice_values:
-                        supported = (
-                            f"Model {base_model} does not currently support "
-                            f"tool_choice of type {tool_choice_type}. "
-                            f"The following tool_choice types are supported: "
-                            f"{self.supports_tool_choice_values}."
-                        )
-                    else:
-                        supported = (
-                            f"Model {base_model} does not currently support "
-                            f"tool_choice."
-                        )
-
-                    raise ValueError(
-                        f"{supported} Please see "
-                        "https://docs.aws.amazon.com/bedrock/latest/APIReference/"
-                        "API_runtime_ToolChoice.html for the latest documentation "
-                        "on models that support tool choice."
-                    )
-                tool_config["toolChoice"] = tool_choice_formatted
-            elif "deepseek.v3" in self._get_base_model():
-                tool_config["toolChoice"] = _format_tool_choice("any")
+            if resolved_tool_choice:
+                tool_config["toolChoice"] = resolved_tool_choice
 
             return self.bind(toolConfig=tool_config, **kwargs)
         else:
-            # Format tool_choice if provided
-            formatted_tool_choice = None
-            if tool_choice:
-                formatted_tool_choice = _format_tool_choice(tool_choice)
-                tool_choice_type = list(formatted_tool_choice.keys())[0]
-                if tool_choice_type not in list(self.supports_tool_choice_values or []):
-                    base_model = self._get_base_model()
-                    if self.supports_tool_choice_values:
-                        supported = (
-                            f"Model {base_model} does not currently support "
-                            f"tool_choice of type {tool_choice_type}. "
-                            f"The following tool_choice types are supported: "
-                            f"{self.supports_tool_choice_values}."
-                        )
-                    else:
-                        supported = (
-                            f"Model {base_model} does not currently support "
-                            f"tool_choice."
-                        )
-
-                    raise ValueError(
-                        f"{supported} Please see "
-                        "https://docs.aws.amazon.com/bedrock/latest/APIReference/"
-                        "API_runtime_ToolChoice.html for the latest documentation "
-                        "on models that support tool choice."
-                    )
-            elif "deepseek.v3" in self._get_base_model():
-                formatted_tool_choice = _format_tool_choice("any")
-
             return self.bind(
                 tools=formatted_custom_tools,
-                tool_choice=formatted_tool_choice,
+                tool_choice=resolved_tool_choice,
                 **kwargs,
             )
 

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -160,18 +160,44 @@ def test_anthropic_thinking_bind_tools_tool_choice(thinking_model: str) -> None:
             "thinking": {"type": "enabled", "budget_tokens": 1024},
         },
     )
+    # auto is directly supported
     chat_model_with_tools = chat_model.bind_tools([GetWeather], tool_choice="auto")
     assert cast(RunnableBinding, chat_model_with_tools).kwargs["tool_choice"] == {
         "auto": {}
     }
-    with pytest.raises(ValueError):
-        chat_model.bind_tools([GetWeather], tool_choice="any")
-    with pytest.raises(ValueError):
-        chat_model.bind_tools([GetWeather], tool_choice="GetWeather")
-    with pytest.raises(ValueError):
-        chat_model.bind_tools(
+    # any/tool are downgraded to auto with a warning when thinking is enabled
+    import warnings as _warnings
+
+    with _warnings.catch_warnings(record=True) as w:
+        _warnings.simplefilter("always")
+        chat_model_with_tools = chat_model.bind_tools(
+            [GetWeather], tool_choice="any"
+        )
+        assert len(w) == 1
+        assert "Downgrading to tool_choice='auto'" in str(w[0].message)
+    assert cast(RunnableBinding, chat_model_with_tools).kwargs["tool_choice"] == {
+        "auto": {}
+    }
+    with _warnings.catch_warnings(record=True) as w:
+        _warnings.simplefilter("always")
+        chat_model_with_tools = chat_model.bind_tools(
+            [GetWeather], tool_choice="GetWeather"
+        )
+        assert len(w) == 1
+        assert "Downgrading to tool_choice='auto'" in str(w[0].message)
+    assert cast(RunnableBinding, chat_model_with_tools).kwargs["tool_choice"] == {
+        "auto": {}
+    }
+    with _warnings.catch_warnings(record=True) as w:
+        _warnings.simplefilter("always")
+        chat_model_with_tools = chat_model.bind_tools(
             [GetWeather], tool_choice={"tool": {"name": "GetWeather"}}
         )
+        assert len(w) == 1
+        assert "Downgrading to tool_choice='auto'" in str(w[0].message)
+    assert cast(RunnableBinding, chat_model_with_tools).kwargs["tool_choice"] == {
+        "auto": {}
+    }
 
 
 def test_amazon_bind_tools_tool_choice() -> None:


### PR DESCRIPTION
Closes #925

## Summary

When thinking is enabled on Claude models via Bedrock Converse, forced `tool_choice` values (`any`, `tool`, specific tool name) cause a `ValidationException`. This PR downgrades forced tool choices to `auto` when thinking is enabled, emitting a warning instead of raising `ValueError`.

This issue commonly appears when using `create_agent` with Claude Sonnet models via Bedrock and structured outputs.

Fixes Bedrock + Anthropic thinking compatibility with forced `tool_choice`.

## Why

`create_agent` fails when using thinking-enabled Claude models on Bedrock.

When extended thinking is enabled via `additional_model_request_fields={"thinking": {"type": "enabled"}}`, the Bedrock Converse API only supports `tool_choice="auto"`. `create_agent` internally calls:

```python
bind_tools(tool_choice="any")
```

Because `ChatBedrockConverse.bind_tools` raised a `ValueError` for unsupported `tool_choice`, it became impossible to use thinking-enabled Claude models together with `create_agent`.

## What

- Added `_is_thinking_enabled` to detect when extended thinking is active
- Added `_resolve_tool_choice` helper to validate tool choice
- When thinking is enabled and a forced tool choice is requested:
  - downgrade to `tool_choice="auto"`
  - emit `warnings.warn()` instead of raising `ValueError`
- Refactored `bind_tools` to reuse `_resolve_tool_choice`
- Added tests verifying downgrade behavior

## Behavior change

Previously:

```
thinking enabled + forced tool_choice → ValueError
```

Now:

```
thinking enabled + forced tool_choice → tool_choice downgraded to "auto" → warning emitted
```

## Areas for careful review

- The downgrade-to-auto behavior is a deliberate trade-off: the model may choose not to call tools when `auto` is used, whereas `any` would have forced a tool call. This is the only option that works with thinking enabled on the Converse API.
- `_resolve_tool_choice` still raises `ValueError` when thinking is NOT enabled and the tool_choice is unsupported — only the thinking + forced tool_choice combination gets the soft downgrade.

## Tests

Updated `test_anthropic_thinking_bind_tools_tool_choice` to verify that:

- `any`
- specific tool name
- dict-style `tool_choice`

all downgrade to `"auto"` when thinking is enabled.

## How to verify

```python
uv run --env-file=.env python -c "
from pydantic import BaseModel
from langchain_aws import ChatBedrockConverse
from langchain.agents import create_agent
from langchain_core.messages import HumanMessage

class Output(BaseModel):
    joke: str

model = ChatBedrockConverse(
    model='us.anthropic.claude-sonnet-4-5-20250929-v1:0',
    region_name='us-east-1',
    additional_model_request_fields={
        'thinking': {
            'type': 'enabled',
            'budget_tokens': 1024
        }
    }
)

agent = create_agent(
    model=model,
    tools=[],
    response_format=Output
)

result = agent.invoke({
    'messages': [HumanMessage(content='Tell me a short joke')]
})

print(result['structured_response'])
"
```

---

> **Note:** This contribution was developed with assistance from an AI coding agent.

