### PR TITLE
fix(aws): downgrade forced tool_choice to auto when thinking is enabled

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -1297,10 +1297,7 @@ class ChatBedrockConverse(BaseChatModel):
                 f"{self.supports_tool_choice_values}."
             )
         else:
-            msg = (
-                f"Model {base_model} does not currently support "
-                f"tool_choice."
-            )
+            msg = f"Model {base_model} does not currently support tool_choice."
 
         raise ValueError(
             f"{msg} Please see "

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -170,9 +170,7 @@ def test_anthropic_thinking_bind_tools_tool_choice(thinking_model: str) -> None:
 
     with _warnings.catch_warnings(record=True) as w:
         _warnings.simplefilter("always")
-        chat_model_with_tools = chat_model.bind_tools(
-            [GetWeather], tool_choice="any"
-        )
+        chat_model_with_tools = chat_model.bind_tools([GetWeather], tool_choice="any")
         assert len(w) == 1
         assert "Downgrading to tool_choice='auto'" in str(w[0].message)
     assert cast(RunnableBinding, chat_model_with_tools).kwargs["tool_choice"] == {


### PR DESCRIPTION
Closes #925

## Summary

When thinking is enabled on Claude models via Bedrock Converse, forced `tool_choice` values (`any`, `tool`, specific tool name) cause a `ValidationException`. This PR downgrades forced tool choices to `auto` when thinking is enabled, emitting a warning instead of raising `ValueError`.

This issue commonly appears when using `create_agent` with Claude Sonnet models via Bedrock and structured outputs.

Fixes Bedrock + Anthropic thinking compatibility with forced `tool_choice`.

## Why

`create_agent` fails when using thinking-enabled Claude models on Bedrock.

When extended thinking is enabled via `additional_model_request_fields={"thinking": {"type": "enabled"}}`, the Bedrock Converse API only supports `tool_choice="auto"`. `create_agent` internally calls:

```python
bind_tools(tool_choice="any")
```

Because `ChatBedrockConverse.bind_tools` raised a `ValueError` for unsupported `tool_choice`, it became impossible to use thinking-enabled Claude models together with `create_agent`.

## What

- Added `_is_thinking_enabled` to detect when extended thinking is active
- Added `_resolve_tool_choice` helper to validate tool choice
- When thinking is enabled and a forced tool choice is requested:
  - downgrade to `tool_choice="auto"`
  - emit `warnings.warn()` instead of raising `ValueError`
- Refactored `bind_tools` to reuse `_resolve_tool_choice`
- Added tests verifying downgrade behavior

## Behavior change

Previously:

```
thinking enabled + forced tool_choice → ValueError
```

Now:

```
thinking enabled + forced tool_choice → tool_choice downgraded to "auto" → warning emitted
```

## Areas for careful review

- The downgrade-to-auto behavior is a deliberate trade-off: the model may choose not to call tools when `auto` is used, whereas `any` would have forced a tool call. This is the only option that works with thinking enabled on the Converse API.
- `_resolve_tool_choice` still raises `ValueError` when thinking is NOT enabled and the tool_choice is unsupported — only the thinking + forced tool_choice combination gets the soft downgrade.

## Tests

Updated `test_anthropic_thinking_bind_tools_tool_choice` to verify that:

- `any`
- specific tool name
- dict-style `tool_choice`

all downgrade to `"auto"` when thinking is enabled.

## How to verify

```python
uv run --env-file=.env python -c "
from pydantic import BaseModel
from langchain_aws import ChatBedrockConverse
from langchain.agents import create_agent
from langchain_core.messages import HumanMessage

class Output(BaseModel):
    joke: str

model = ChatBedrockConverse(
    model='us.anthropic.claude-sonnet-4-5-20250929-v1:0',
    region_name='us-east-1',
    additional_model_request_fields={
        'thinking': {
            'type': 'enabled',
            'budget_tokens': 1024
        }
    }
)

agent = create_agent(
    model=model,
    tools=[],
    response_format=Output
)

result = agent.invoke({
    'messages': [HumanMessage(content='Tell me a short joke')]
})

print(result['structured_response'])
"
```

---

> **Note:** This contribution was developed with assistance from an AI coding agent.

