### PR TITLE
feat(aws): Update ChatBedrockConverse to support `create_agent` `response_format`

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -1133,13 +1133,7 @@ class ChatBedrockConverse(BaseChatModel):
         # Remove disable_streaming from kwargs as it's not a valid API parameter
         filtered_kwargs = {k: v for k, v in kwargs.items() if k != "disable_streaming"}
         additional_fields = filtered_kwargs.pop("additional_model_request_fields", None)
-
-        response_format = filtered_kwargs.pop("response_format", None)
-        if response_format and "output_config" not in filtered_kwargs:
-            filtered_kwargs["output_config"] = _response_format_to_output_config(
-                response_format
-            )
-
+        _apply_response_format(filtered_kwargs)
         cache_control = filtered_kwargs.pop("cache_control", None)
         params = self._converse_params(
             stop=stop,
@@ -1201,13 +1195,7 @@ class ChatBedrockConverse(BaseChatModel):
         # Remove disable_streaming from kwargs as it's not a valid API parameter
         filtered_kwargs = {k: v for k, v in kwargs.items() if k != "disable_streaming"}
         additional_fields = filtered_kwargs.pop("additional_model_request_fields", None)
-
-        response_format = filtered_kwargs.pop("response_format", None)
-        if response_format and "output_config" not in filtered_kwargs:
-            filtered_kwargs["output_config"] = _response_format_to_output_config(
-                response_format
-            )
-
+        _apply_response_format(filtered_kwargs)
         cache_control = filtered_kwargs.pop("cache_control", None)
         params = self._converse_params(
             stop=stop,
@@ -2550,6 +2538,12 @@ def _bedrock_to_lc(content: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
                 f"'reasoning_content' keys. Received:\n\n{block}"
             )
     return lc_content
+
+
+def _apply_response_format(kwargs: Dict[str, Any]) -> None:
+    response_format = kwargs.pop("response_format", None)
+    if response_format and "output_config" not in kwargs:
+        kwargs["output_config"] = _response_format_to_output_config(response_format)
 
 
 def _response_format_to_output_config(

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -4621,6 +4621,114 @@ def test_response_format_without_response_format() -> None:
     assert "outputConfig" not in call_kwargs
 
 
+def _mock_stream_response() -> dict:
+    return {
+        "stream": [
+            {"messageStart": {"role": "assistant"}},
+            {
+                "contentBlockDelta": {
+                    "delta": {"text": '{"name": "test"}'},
+                    "contentBlockIndex": 0,
+                }
+            },
+            {"messageStop": {"stopReason": "end_turn"}},
+            {
+                "metadata": {
+                    "usage": {
+                        "inputTokens": 10,
+                        "outputTokens": 5,
+                        "totalTokens": 15,
+                    }
+                }
+            },
+        ]
+    }
+
+
+def test_response_format_stream_translates_to_output_config() -> None:
+    """response_format kwarg is translated to outputConfig in streaming path."""
+    mocked_client = mock.MagicMock()
+    mocked_client.converse_stream.return_value = _mock_stream_response()
+
+    llm = ChatBedrockConverse(
+        client=mocked_client,
+        model="us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        region_name="us-west-2",
+    )
+
+    list(
+        llm.stream(
+            [HumanMessage(content="Hi")],
+            response_format={
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "TestOutput",
+                    "schema": {
+                        "type": "object",
+                        "properties": {"name": {"type": "string"}},
+                        "required": ["name"],
+                    },
+                },
+            },
+        )
+    )
+
+    call_kwargs = mocked_client.converse_stream.call_args[1]
+    assert "responseFormat" not in call_kwargs
+    assert "response_format" not in call_kwargs
+    oc = call_kwargs["outputConfig"]
+    tf = oc["textFormat"]
+    assert tf["type"] == "json_schema"
+    js = tf["structure"]["jsonSchema"]
+    assert js["name"] == "TestOutput"
+    parsed_schema = json.loads(js["schema"])
+    assert parsed_schema["additionalProperties"] is False
+
+
+def test_response_format_stream_does_not_override_output_config() -> None:
+    """Explicit outputConfig takes precedence over response_format in streaming."""
+    mocked_client = mock.MagicMock()
+    mocked_client.converse_stream.return_value = _mock_stream_response()
+
+    llm = ChatBedrockConverse(
+        client=mocked_client,
+        model="us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        region_name="us-west-2",
+    )
+
+    explicit_config = {"textFormat": {"type": "text"}}
+    list(
+        llm.stream(
+            [HumanMessage(content="Hi")],
+            output_config=explicit_config,
+            response_format={
+                "type": "json_schema",
+                "json_schema": {"name": "X", "schema": {"type": "object"}},
+            },
+        )
+    )
+
+    call_kwargs = mocked_client.converse_stream.call_args[1]
+    assert call_kwargs["outputConfig"] == explicit_config
+
+
+def test_response_format_stream_without_response_format() -> None:
+    """No outputConfig generated when response_format is absent in streaming."""
+    mocked_client = mock.MagicMock()
+    mocked_client.converse_stream.return_value = _mock_stream_response()
+
+    llm = ChatBedrockConverse(
+        client=mocked_client,
+        model="us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        region_name="us-west-2",
+    )
+
+    list(llm.stream([HumanMessage(content="Hi")]))
+
+    call_kwargs = mocked_client.converse_stream.call_args[1]
+    assert "outputConfig" not in call_kwargs
+
+
 def test_apply_cache_points_system_and_messages() -> None:
     system = [{"text": "You are helpful."}]
     messages = [


### PR DESCRIPTION
Fixes: #933 / https://github.com/langchain-ai/langchain-aws/issues/571#issuecomment-4064856804

Updates ChatBedrockConverse to be able to handle `response_format` JSON schema input passed by `create_agent`. The schema will be converted to the format expected by [`output_config`](https://reference.langchain.com/python/langchain-aws/chat_models/bedrock_converse/ChatBedrockConverse/output_config) before being passed to Converse API.