### PR TITLE
ci: add automated model profile refresh workflow

### DIFF
--- a/.github/workflows/refresh_model_profiles.yml
+++ b/.github/workflows/refresh_model_profiles.yml
@@ -1,0 +1,28 @@
+# Refreshes model profile data by pulling the latest metadata from models.dev
+# via the `langchain-profiles` CLI (hosted in langchain-ai/langchain).
+#
+# Creates a pull request with any changes. Runs daily and can be triggered
+# manually from the Actions UI.
+
+name: "🔄 Refresh Model Profiles"
+
+on:
+  schedule:
+    - cron: "0 8 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  refresh-profiles:
+    uses: langchain-ai/langchain/.github/workflows/_refresh_model_profiles.yml@master
+    with:
+      providers: >-
+        [
+          {"provider":"anthropic", "data_dir":"libs/aws/langchain_aws/data"}
+        ]
+    secrets:
+      MODEL_PROFILE_BOT_APP_ID: ${{ secrets.MODEL_PROFILE_BOT_APP_ID }}
+      MODEL_PROFILE_BOT_PRIVATE_KEY: ${{ secrets.MODEL_PROFILE_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
Add automated daily model profile refresh for Bedrock's `anthropic` provider. Calls the reusable `_refresh_model_profiles.yml` workflow from the main `langchain` monorepo, which handles CLI setup, profile generation, and PR creation.

## Changes
- Add `refresh_model_profiles.yml` workflow with daily cron (08:00 UTC) and manual `workflow_dispatch`, calling `langchain-ai/langchain/.github/workflows/_refresh_model_profiles.yml@master` with the `anthropic` provider entry pointing to `libs/aws/langchain_aws/data`
