### PR TITLE
feat(aws): add Qwen ChatML prompt conversion support

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -296,6 +296,47 @@ def convert_messages_to_prompt_writer(messages: List[BaseMessage]) -> str:
     )
 
 
+def _convert_one_message_to_text_qwen(message: BaseMessage) -> str:
+    """Convert a single message to ChatML format for Qwen models.
+
+    Args:
+        message: The message to convert.
+
+    Returns:
+        The message formatted in ChatML syntax.
+
+    Raises:
+        ValueError: If the message type is not supported.
+    """
+    if isinstance(message, SystemMessage):
+        message_text = f"<|im_start|>system\n{message.content}<|im_end|>"
+    elif isinstance(message, ChatMessage):
+        message_text = f"<|im_start|>{message.role}\n{message.content}<|im_end|>"
+    elif isinstance(message, HumanMessage):
+        message_text = f"<|im_start|>user\n{message.content}<|im_end|>"
+    elif isinstance(message, AIMessage):
+        message_text = f"<|im_start|>assistant\n{message.content}<|im_end|>"
+    else:
+        raise ValueError(f"Got unknown type {message}")
+
+    return message_text
+
+
+def convert_messages_to_prompt_qwen(messages: List[BaseMessage]) -> str:
+    """Convert a list of messages to a ChatML prompt for Qwen models.
+
+    Args:
+        messages: List of messages to convert.
+
+    Returns:
+        The formatted ChatML prompt string.
+    """
+    return "\n".join(
+        [_convert_one_message_to_text_qwen(message) for message in messages]
+        + ["<|im_start|>assistant\n"]
+    )
+
+
 def _convert_one_message_to_text_openai(message: BaseMessage) -> str:
     if isinstance(message, SystemMessage):
         message_text = f"<|start|>system<|message|>{message.content}<|end|>"
@@ -757,6 +798,8 @@ class ChatPromptAdapter:
             prompt = convert_messages_to_prompt_writer(messages=messages)
         elif provider == "openai":
             prompt = convert_messages_to_prompt_openai(messages=messages)
+        elif provider == "qwen":
+            prompt = convert_messages_to_prompt_qwen(messages=messages)
         else:
             raise NotImplementedError(
                 f"Provider {provider} model does not support chat."

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
@@ -19,9 +19,11 @@ from pydantic import BaseModel, Field
 from langchain_aws import ChatBedrock
 from langchain_aws.chat_models.bedrock import (
     ChatPromptAdapter,
+    _convert_one_message_to_text_qwen,
     _format_anthropic_messages,
     _merge_messages,
     convert_messages_to_prompt_anthropic,
+    convert_messages_to_prompt_qwen,
 )
 from langchain_aws.function_calling import convert_to_anthropic_tool
 
@@ -1342,6 +1344,12 @@ def test__format_anthropic_messages_preserves_content_order() -> None:
             "deepseek",
             "<|begin_of_sentence|>",
         ),
+        (
+            "qwen.qwen3-32b-v1:0",
+            "qwen.qwen3-32b-v1:0",
+            "qwen",
+            "<|im_start|>",
+        ),
     ],
 )
 def test_chat_prompt_adapter_with_model_detection(
@@ -2264,3 +2272,58 @@ def test_stream_cache_control_kwarg_applied() -> None:
         "type": "ephemeral",
         "ttl": "5m",
     }
+
+
+def test_convert_one_message_to_text_qwen_system() -> None:
+    """Test that SystemMessage is converted to ChatML system format."""
+    message = SystemMessage(content="You are a helpful assistant")
+    result = _convert_one_message_to_text_qwen(message)
+    assert result == "<|im_start|>system\nYou are a helpful assistant<|im_end|>"
+
+
+def test_convert_one_message_to_text_qwen_human() -> None:
+    """Test that HumanMessage is converted to ChatML user format."""
+    message = HumanMessage(content="Hello")
+    result = _convert_one_message_to_text_qwen(message)
+    assert result == "<|im_start|>user\nHello<|im_end|>"
+
+
+def test_convert_one_message_to_text_qwen_ai() -> None:
+    """Test that AIMessage is converted to ChatML assistant format."""
+    message = AIMessage(content="Hi there")
+    result = _convert_one_message_to_text_qwen(message)
+    assert result == "<|im_start|>assistant\nHi there<|im_end|>"
+
+
+def test_convert_one_message_to_text_qwen_unknown_type() -> None:
+    """Test that unknown message types raise ValueError."""
+    message = ToolMessage(content="result", tool_call_id="123")
+    with pytest.raises(ValueError, match="Got unknown type"):
+        _convert_one_message_to_text_qwen(message)
+
+
+def test_convert_messages_to_prompt_qwen() -> None:
+    """Test multi-turn conversation is formatted in ChatML with suffix."""
+    messages = [
+        SystemMessage(content="You are a helpful assistant"),
+        HumanMessage(content="What is 1+1?"),
+        AIMessage(content="2"),
+        HumanMessage(content="And 2+2?"),
+    ]
+    result = convert_messages_to_prompt_qwen(messages)
+    expected = (
+        "<|im_start|>system\nYou are a helpful assistant<|im_end|>\n"
+        "<|im_start|>user\nWhat is 1+1?<|im_end|>\n"
+        "<|im_start|>assistant\n2<|im_end|>\n"
+        "<|im_start|>user\nAnd 2+2?<|im_end|>\n"
+        "<|im_start|>assistant\n"
+    )
+    assert result == expected
+
+
+def test_convert_messages_to_prompt_qwen_single_message() -> None:
+    """Test single user message produces valid ChatML prompt."""
+    messages = [HumanMessage(content="Hello")]
+    result = convert_messages_to_prompt_qwen(messages)
+    expected = "<|im_start|>user\nHello<|im_end|>\n<|im_start|>assistant\n"
+    assert result == expected


### PR DESCRIPTION
## Why

`ChatBedrock` with `provider="qwen"` raises `NotImplementedError` in `ChatPromptAdapter.convert_messages_to_prompt` because there's no prompt conversion for Qwen models. The LLM layer (`llms/bedrock.py`) already handles Qwen for input/output, but the chat model layer was missing. This was reported in #780.

## What

Adds ChatML prompt formatting (`<|im_start|>role\ncontent<|im_end|>`) for Qwen models in the `ChatBedrock` invoke_model path, following the [[official Qwen chat template spec](https://qwen.readthedocs.io/en/latest/getting_started/concepts.html#chat-template)](https://qwen.readthedocs.io/en/latest/getting_started/concepts.html#chat-template).

### Changes

- `_convert_one_message_to_text_qwen`: maps `SystemMessage`, `HumanMessage`, `AIMessage`, `ChatMessage` to ChatML tokens
- `convert_messages_to_prompt_qwen`: assembles the full prompt with `<|im_start|>assistant\n` suffix
- Wires `provider="qwen"` into `ChatPromptAdapter.convert_messages_to_prompt`

### Tests

- Individual message type conversion (system, human, ai)
- Unknown message type raises `ValueError`
- Multi-turn conversation formatting
- Single message formatting
- Parametrized model detection test with `qwen.qwen3-32b-v1:0`

### Areas requiring careful review

- The ChatML format matches Qwen's official docs, but Bedrock's Qwen integration may have nuances worth verifying with an integration test if credentials are available.

> This contribution was developed with AI agent assistance (Kiro).

Closes #780