### PR TITLE
fix(aws): Refactor BedrockLLM `stop_reason` and `stop_sequence` handling

### DIFF
--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -169,11 +169,23 @@ def _stream_response_to_generation_chunk(
                 content_block["type"] = "thinking"
                 return AIMessageChunk(content=[content_block])
         elif msg_type == "message_delta":
+            provider = self._get_provider()
+
+            # Get the correct key (e.g., 'stopSequences' for Amazon)
+            # Default to "stop_sequence" if the provider is unknown
+            stop_key = provider_stop_sequence_key_name_map.get(provider, "stop_sequence")
+    
+            delta = stream_response.get("delta", {})
+            
             return AIMessageChunk(
                 content="",
                 response_metadata={
-                    "stop_reason": stream_response["delta"].get("stop_reason"),
-                    "stop_sequence": stream_response["delta"].get("stop_sequence"),
+                    "stop_reason": delta.get("stop_reason"),
+                    # CRITICAL: Use .get(stop_key) to return None if Guardrails 
+                    # stripped the field from the response.
+                    "stop_sequence": delta.get(stop_key),
+                    #"stop_reason": stream_response["delta"].get("stop_reason"),
+                    #"stop_sequence": stream_response["delta"].get("stop_sequence"),
                 },
             )
         else:


### PR DESCRIPTION
langchain_aws/llms/bedrock.py "stop_sequence" hardcoded for msg_type == "message_delta" - breaks with bedrock guardrails with langchain agents #214

When a Bedrock Guardrail triggers, Amazon Bedrock stops the model's generation and injects specific metadata into the response stream. In the message_delta event, this shows up as a specific stop_reason.

Here is exactly how the value is populated and why the previous code failed.

1. The Raw Payload from AWS When a Guardrail blocks a response (e.g., for PII or restricted topics), the underlying Boto3/Bedrock event stream sends a JSON object that looks like this:

JSON
{
  "delta": {
    "stop_reason": "guardrail_intervened",
    "stopSequences": null 
  }
}