### PR TITLE
fix(aws): Set model profile correctly for application inference ARNs

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -948,7 +948,7 @@ class ChatBedrock(BaseChatModel, BedrockBase):
     def _set_model_profile(self) -> Self:
         """Set model profile if not overridden."""
         if self.profile is None:
-            model_id = re.sub(r"^[A-Za-z]{2}\.", "", self.model_id)
+            model_id = self.base_model_id if self.base_model_id else self.model_id
             self.profile = _get_default_model_profile(model_id)
         return self
 

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -1004,7 +1004,7 @@ class ChatBedrockConverse(BaseChatModel):
     def _set_model_profile(self) -> Self:
         """Set model profile if not overridden."""
         if self.profile is None:
-            model_id = re.sub(r"^[A-Za-z]{2}\.", "", self.model_id)
+            model_id = self._get_base_model()
             self.profile = _get_default_model_profile(model_id)
         return self
 

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
@@ -844,6 +844,34 @@ def test_beta_use_converse_api_with_inference_profile_as_nova_model(
     assert chat.beta_use_converse_api is True
 
 
+@mock.patch("langchain_aws.chat_models.bedrock.create_aws_client")
+def test_profile_with_application_inference_profile(mock_create_aws_client):
+    """Test _set_model_profile resolves profile correctly for AIP ARNs."""
+    mock_bedrock_client = mock.MagicMock()
+    mock_bedrock_client.get_inference_profile.return_value = {
+        "models": [
+            {
+                "modelArn": (
+                    "arn:aws:bedrock:us-west-2::foundation-model/"
+                    "anthropic.claude-sonnet-4-5-20250929-v1:0"
+                )
+            }
+        ]
+    }
+    mock_create_aws_client.return_value = mock_bedrock_client
+
+    aip_model_id = "arn:aws:bedrock:us-west-2:123456789012:application-inference-profile/my-profile"  # noqa: E501
+    chat = ChatBedrock(
+        model=aip_model_id,
+        region="us-west-2",
+        bedrock_client=mock_bedrock_client,
+    )  # type: ignore[call-arg]
+
+    # Profile should be resolved from the base model, not the ARN
+    assert chat.profile
+    assert chat.profile["reasoning_output"]
+
+
 @pytest.mark.parametrize(
     "model_id, provider, expected_provider, expectation, region_name",
     [

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -2293,6 +2293,45 @@ def test_get_base_model_with_application_inference_profile(
 
 
 @mock.patch("langchain_aws.chat_models.bedrock_converse.create_aws_client")
+def test_profile_with_application_inference_profile(
+    mock_create_client: mock.Mock,
+) -> None:
+    """Test _set_model_profile resolves profile correctly for AIP ARNs."""
+    mock_bedrock_client = mock.Mock()
+    mock_runtime_client = mock.Mock()
+
+    mock_bedrock_client.get_inference_profile.return_value = {
+        "models": [
+            {
+                "modelArn": (
+                    "arn:aws:bedrock:us-east-1::foundation-model/"
+                    "anthropic.claude-sonnet-4-5-20250929-v1:0"
+                )
+            }
+        ]
+    }
+
+    def side_effect(service_name: str, **kwargs: Any) -> mock.Mock:
+        if service_name == "bedrock":
+            return mock_bedrock_client
+        elif service_name == "bedrock-runtime":
+            return mock_runtime_client
+        return mock.Mock()
+
+    mock_create_client.side_effect = side_effect
+
+    chat_model = ChatBedrockConverse(
+        model="arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/test-profile",
+        region_name="us-west-2",
+        provider="anthropic",
+    )
+
+    # Profile should be resolved from the base model, not the ARN
+    assert chat_model.profile
+    assert chat_model.profile["reasoning_output"]
+
+
+@mock.patch("langchain_aws.chat_models.bedrock_converse.create_aws_client")
 def test_get_base_model_without_application_inference_profile(
     mock_create_client: mock.Mock,
 ) -> None:


### PR DESCRIPTION
Fixes #953

Updates the `_set_model_profile` validators in `ChatBedrock` and `ChatBedrockConverse` to pull model ID via `_get_base_model()`, which returns the correct model for Bedrock application inference profiles.