### PR TITLE
fix(aws): Migrate chat models to `_resolve_model_profile` hook

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -52,7 +52,6 @@ from langchain_core.utils.function_calling import convert_to_openai_tool
 from langchain_core.utils.pydantic import TypeBaseModel, is_basemodel_subclass
 from langchain_core.utils.utils import _build_model_kwargs
 from pydantic import BaseModel, ConfigDict, Field, model_validator
-from typing_extensions import Self
 
 from langchain_aws.chat_models._compat import _convert_from_v1_to_anthropic
 from langchain_aws.chat_models.bedrock_converse import ChatBedrockConverse

--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -953,9 +953,6 @@ class BedrockBase(BaseLanguageModel, ABC):
                 # Format: arn:aws:bedrock:region::foundation-model/provider.model-name
                 self.base_model_id = model_arn.split("/")[-1]
 
-        if hasattr(self, "profile") and not self.profile:
-            self.profile = self._resolve_model_profile()
-
         return self
 
     @property


### PR DESCRIPTION
Follow-up to: https://github.com/langchain-ai/langchain-aws/pull/959#pullrequestreview-4025283276

With [this PR](https://github.com/langchain-ai/langchain/pull/36129) included in `langchain-core` v1.2.21, the following update has been made for model profiles:
> Add BaseChatModel._resolve_model_profile() hook that returns None by default. Partners can override this single method instead of redefining the full _set_model_profile validator — the base validator calls it automatically

Specifically, the old `_set_model_profile` validator defined by partner chat models has been implemented directly in `BaseChatModel`, in favor of the a new `_resolve_model_profile()` hook for partners to override. 

This change breaks our current model profile resolution, but only for AIPs. This is because `_set_model_profile` now runs before `validate_environment` in the BaseChatModel's validator chain, meaning that `_base_chat_model` will be run before the GetInferenceProfile API call to retrieve the AIP's modelArn, so the raw AIP ARN string will be passed for profile lookup instead (and subsequently return nothing).

To fix this, this PR:
- Replaces the `_set_model_profile` implementation in `ChatBedrock`/`ChatBedrockConverse` with the new `_resolve_model_profile` override. 
- Additionally, for Converse, re-resolves `profile` at the end of `validate_environment` for the AIP case where `base_model_id` isn't available on the first pass.

