### PR TITLE
feat(aws): impute file name for `document` content blocks

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -4,6 +4,7 @@ import functools
 import json
 import logging
 import re
+import uuid
 import warnings
 from operator import itemgetter
 from typing import (
@@ -2171,6 +2172,7 @@ def _format_data_content_block(block: dict) -> dict:
                     "'mime_type': 'application/pdf', 'base64': '...', "
                     "'name': 'my-pdf'}"
                 )
+                formatted_block["document"]["name"] = uuid.uuid4().hex[:12]
         else:
             error_message = "File data only supported through in-line base64 format."
             raise ValueError(error_message)

--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
@@ -44,6 +44,10 @@ class TestBedrockStandard(ChatModelIntegrationTests):
     def supports_image_inputs(self) -> bool:
         return True
 
+    @property
+    def supports_pdf_tool_message(self) -> bool:
+        return True
+
 
 class TestBedrockMistralStandard(ChatModelIntegrationTests):
     @property


### PR DESCRIPTION
LangChain standard format for file types is
```python
{
    "type": "file",
    "mime_type": "application/pdf",
    "base64": "...",
}
```
Converse requires a `"name"` field. We [document](https://docs.langchain.com/oss/python/langchain/messages#multimodal) that these should be placed in the `"extras"` field of the content block. The problem with this is anything constructing this block-- such as a `read_file` tool-- needs to know if it's dealing with a Bedrock model (or OpenAI model, which similarly requires a `"filename"` field). So here we just impute a placeholder value.

Note: we use a random string for the name, because Converse errors if two files have the same name in the same thread: https://smith.langchain.com/public/f2ac108a-ffd3-448b-a9f0-ba6e2c173a97/r