### PR TITLE
feat(langgraph-checkpoint-aws): add DeferredCheckpointSaver wrapper (#806)

### DIFF
--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/__init__.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/__init__.py
@@ -15,6 +15,9 @@ from langgraph_checkpoint_aws.agentcore.store import (
 from langgraph_checkpoint_aws.checkpoint.dynamodb import (
     DynamoDBSaver,
 )
+from langgraph_checkpoint_aws.deferred_saver import (
+    DeferredCheckpointSaver,
+)
 from langgraph_checkpoint_aws.store.dynamodb import (
     DynamoDBStore,
 )
@@ -89,6 +92,7 @@ SDK_USER_AGENT = f"LangGraphCheckpointAWS#{__version__}"
 # Expose the saver class at the package level
 __all__ = [
     "AgentCoreMemorySaver",
+    "DeferredCheckpointSaver",
     "AgentCoreMemoryStore",
     "AgentCoreValkeySaver",
     "AsyncValkeySaver",

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/deferred_saver.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/deferred_saver.py
@@ -1,0 +1,628 @@
+"""Deferred checkpoint saver that defers persistence until explicit flush.
+
+Wraps any ``BaseCheckpointSaver`` and defers ``put()`` / ``put_writes()``
+calls in memory, reducing API calls from dozens per workflow to a single
+batch on flush.  Designed for use cases (chatbots, single-turn agents) that
+only need the final conversation state persisted for session continuity.
+
+.. warning::
+    Mid-workflow crash recovery is **not** available when using this wrapper.
+    Buffered data is only persisted when ``flush()`` / ``aflush()`` is called
+    or a ``flush_on_exit()`` / ``aflush_on_exit()`` context manager exits.
+
+Example::
+
+    saver = AgentCoreMemorySaver(memory_id, region_name="us-east-1")
+    deferred = DeferredCheckpointSaver(saver)
+    graph = create_react_agent(model, tools=tools, checkpointer=deferred)
+
+    with deferred.flush_on_exit():
+        response = graph.invoke({"messages": [user_input]}, config)
+"""
+
+from __future__ import annotations
+
+import contextlib
+import threading
+from collections.abc import AsyncIterator, Iterator, Sequence
+from typing import Any, NamedTuple
+
+from langchain_core.runnables import RunnableConfig
+from langgraph.checkpoint.base import (
+    BaseCheckpointSaver,
+    ChannelVersions,
+    Checkpoint,
+    CheckpointMetadata,
+    CheckpointTuple,
+    V,
+)
+
+# ---------------------------------------------------------------------------
+# Internal buffer entry types
+# ---------------------------------------------------------------------------
+# NamedTuple was chosen over the alternatives for these internal types:
+#
+#   - Plain tuple: works but positional-only access (entry[0]) hurts
+#     readability in the flush/match logic.
+#   - TypedDict: mutable dict at runtime with hash-table overhead and no
+#     immutability guarantee — wrong fit for a lock-protected buffer where
+#     entries must not be modified after creation.
+#   - dataclass (mutable): allows accidental mutation of buffered state,
+#     which would introduce subtle concurrency bugs.
+#   - dataclass (frozen=True, slots=True): immutable and memory-efficient,
+#     but cannot be unpacked with ``a, b, c = entry`` and has slightly
+#     higher object-creation cost than a tuple.
+#
+# NamedTuple gives us named fields (``entry.config``), immutability,
+# zero overhead vs plain tuples, and tuple-compatible unpacking — the
+# best balance for simple internal containers guarded by a lock.
+
+
+class _PendingCheckpoint(NamedTuple):
+    """Captured arguments to ``BaseCheckpointSaver.put()``.
+
+    Stored in the buffer so they can be replayed on flush.
+    """
+
+    config: RunnableConfig
+    checkpoint: Checkpoint
+    metadata: CheckpointMetadata
+    new_versions: ChannelVersions
+
+
+class _PendingWrite(NamedTuple):
+    """Captured arguments to ``BaseCheckpointSaver.put_writes()``.
+
+    Stored in the buffer so they can be replayed on flush.
+    """
+
+    config: RunnableConfig
+    writes: list[tuple[str, Any]]
+    task_id: str
+    task_path: str
+
+
+class DeferredCheckpointSaver(BaseCheckpointSaver):
+    """Checkpoint saver wrapper that buffers writes and flushes on demand.
+
+    Intercepts every ``put()`` and ``put_writes()`` call from the LangGraph
+    runtime, keeping only the latest checkpoint in memory and accumulating
+    all writes.  Nothing is persisted until the user explicitly calls
+    ``flush()`` / ``aflush()`` or uses the ``flush_on_exit()`` /
+    ``aflush_on_exit()`` context managers.
+
+    This reduces API overhead from *O(nodes)* calls per invocation down to a
+    single batch, at the cost of mid-workflow fault tolerance.
+
+    Args:
+        saver: The underlying checkpoint saver to delegate persistence to.
+
+    Raises:
+        ValueError: If *saver* is itself a ``DeferredCheckpointSaver``
+            (nesting is not supported).
+
+    Example::
+
+        deferred = DeferredCheckpointSaver(my_saver)
+        graph = workflow.compile(checkpointer=buffered)
+
+        with buffered.flush_on_exit():
+            graph.invoke(input, config)
+    """
+
+    def __init__(self, saver: BaseCheckpointSaver) -> None:
+        if isinstance(saver, DeferredCheckpointSaver):
+            msg = (
+                "Nesting DeferredCheckpointSaver is not supported. "
+                "Pass the underlying saver directly."
+            )
+            raise ValueError(msg)
+        super().__init__()
+        self._saver = saver
+        self._lock = threading.Lock()
+        self._pending_checkpoint: _PendingCheckpoint | None = None
+        self._pending_writes: list[_PendingWrite] = []
+        self._last_config: RunnableConfig | None = None
+
+    # ------------------------------------------------------------------
+    # Read-only properties
+    # ------------------------------------------------------------------
+
+    @property
+    def saver(self) -> BaseCheckpointSaver:
+        """The wrapped checkpoint saver."""
+        return self._saver
+
+    @property
+    def has_buffered_checkpoint(self) -> bool:
+        """Whether a checkpoint is currently buffered."""
+        with self._lock:
+            return self._pending_checkpoint is not None
+
+    @property
+    def has_buffered_writes(self) -> bool:
+        """Whether any writes are currently buffered."""
+        with self._lock:
+            return len(self._pending_writes) > 0
+
+    @property
+    def is_empty(self) -> bool:
+        """Whether the buffer contains no pending data."""
+        with self._lock:
+            return self._pending_checkpoint is None and len(self._pending_writes) == 0
+
+    # ------------------------------------------------------------------
+    # BaseCheckpointSaver interface — buffered writes
+    # ------------------------------------------------------------------
+
+    def put(
+        self,
+        config: RunnableConfig,
+        checkpoint: Checkpoint,
+        metadata: CheckpointMetadata,
+        new_versions: ChannelVersions,
+    ) -> RunnableConfig:
+        """Buffer a checkpoint instead of persisting immediately.
+
+        Each call overwrites the previously buffered checkpoint — only the
+        latest one is kept.  This is the core optimization: for a 6-node
+        workflow LangGraph calls ``put()`` 6 times, but we only persist once.
+
+        Args:
+            config: The runnable config associated with this checkpoint.
+            checkpoint: The checkpoint data to buffer.
+            metadata: Metadata associated with the checkpoint.
+            new_versions: Channel version information.
+
+        Returns:
+            A config pointing to the buffered checkpoint.
+        """
+        thread_id = config["configurable"]["thread_id"]
+        checkpoint_ns = config["configurable"].get("checkpoint_ns", "")
+        result_config: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "checkpoint_ns": checkpoint_ns,
+                "checkpoint_id": checkpoint["id"],
+            }
+        }
+        with self._lock:
+            self._pending_checkpoint = _PendingCheckpoint(
+                config=config,
+                checkpoint=checkpoint,
+                metadata=metadata,
+                new_versions=new_versions,
+            )
+            self._last_config = result_config
+        return result_config
+
+    async def aput(
+        self,
+        config: RunnableConfig,
+        checkpoint: Checkpoint,
+        metadata: CheckpointMetadata,
+        new_versions: ChannelVersions,
+    ) -> RunnableConfig:
+        """Async version of :meth:`put`. Delegates to the sync implementation.
+
+        Args:
+            config: The runnable config associated with this checkpoint.
+            checkpoint: The checkpoint data to buffer.
+            metadata: Metadata associated with the checkpoint.
+            new_versions: Channel version information.
+
+        Returns:
+            A config pointing to the buffered checkpoint.
+        """
+        return self.put(config, checkpoint, metadata, new_versions)
+
+    def put_writes(
+        self,
+        config: RunnableConfig,
+        writes: Sequence[tuple[str, Any]],
+        task_id: str,
+        task_path: str = "",
+    ) -> None:
+        """Buffer writes instead of persisting immediately.
+
+        All writes accumulate in the buffer until flushed.
+
+        Args:
+            config: The runnable config for this write batch.
+            writes: Sequence of ``(channel, value)`` pairs.
+            task_id: Identifier of the task that produced these writes.
+            task_path: Path of the task within the graph.
+        """
+        with self._lock:
+            self._pending_writes.append(
+                _PendingWrite(
+                    config=config,
+                    writes=list(writes),
+                    task_id=task_id,
+                    task_path=task_path,
+                )
+            )
+
+    async def aput_writes(
+        self,
+        config: RunnableConfig,
+        writes: Sequence[tuple[str, Any]],
+        task_id: str,
+        task_path: str = "",
+    ) -> None:
+        """Async version of :meth:`put_writes`. Delegates to sync implementation.
+
+        Args:
+            config: The runnable config for this write batch.
+            writes: Sequence of ``(channel, value)`` pairs.
+            task_id: Identifier of the task that produced these writes.
+            task_path: Path of the task within the graph.
+        """
+        self.put_writes(config, writes, task_id, task_path)
+
+    # ------------------------------------------------------------------
+    # BaseCheckpointSaver interface — reads (buffer-first)
+    # ------------------------------------------------------------------
+
+    def _get_buffered_tuple(self, config: RunnableConfig) -> CheckpointTuple | None:
+        """Return a ``CheckpointTuple`` from the buffer if it matches *config*.
+
+        Must be called while ``self._lock`` is held.
+
+        Args:
+            config: The config to match against the buffered checkpoint.
+
+        Returns:
+            A ``CheckpointTuple`` built from buffered data, or ``None`` if
+            the buffer doesn't match.
+        """
+        if self._pending_checkpoint is None:
+            return None
+
+        buf_config = self._pending_checkpoint.config
+        buf_checkpoint = self._pending_checkpoint.checkpoint
+        buf_metadata = self._pending_checkpoint.metadata
+
+        # Extract identifiers from the request
+        req_thread = config["configurable"].get("thread_id")
+        req_ns = config["configurable"].get("checkpoint_ns", "")
+        req_ckpt_id = config["configurable"].get("checkpoint_id")
+
+        # Extract identifiers from the buffer
+        buf_thread = buf_config["configurable"].get("thread_id")
+        buf_ns = buf_config["configurable"].get("checkpoint_ns", "")
+        buf_ckpt_id = buf_checkpoint["id"]
+
+        # Match thread_id and checkpoint_ns
+        if req_thread != buf_thread or req_ns != buf_ns:
+            return None
+
+        # If a specific checkpoint_id was requested, it must match
+        if req_ckpt_id is not None and req_ckpt_id != buf_ckpt_id:
+            return None
+
+        # Collect matching pending writes
+        pending_writes: list[tuple[str, str, Any]] = []
+        for entry in self._pending_writes:
+            w_thread = entry.config["configurable"].get("thread_id")
+            w_ns = entry.config["configurable"].get("checkpoint_ns", "")
+            w_ckpt_id = entry.config["configurable"].get("checkpoint_id")
+            if w_thread == buf_thread and w_ns == buf_ns and w_ckpt_id == buf_ckpt_id:
+                for channel, value in entry.writes:
+                    pending_writes.append((entry.task_id, channel, value))
+
+        # Build parent config if available
+        parent_config: RunnableConfig | None = None
+        parent_id = (
+            buf_metadata.get("parents", {}).get(buf_ns) if buf_metadata else None
+        )
+        if parent_id is None and buf_metadata:
+            parent_id = buf_config["configurable"].get("checkpoint_id")
+        if parent_id:
+            parent_config = {
+                "configurable": {
+                    "thread_id": buf_thread,
+                    "checkpoint_ns": buf_ns,
+                    "checkpoint_id": parent_id,
+                }
+            }
+
+        result_config: RunnableConfig = {
+            "configurable": {
+                "thread_id": buf_thread,
+                "checkpoint_ns": buf_ns,
+                "checkpoint_id": buf_ckpt_id,
+            }
+        }
+
+        return CheckpointTuple(
+            config=result_config,
+            checkpoint=buf_checkpoint,
+            metadata=buf_metadata,
+            parent_config=parent_config,
+            pending_writes=pending_writes if pending_writes else None,
+        )
+
+    def get_tuple(self, config: RunnableConfig) -> CheckpointTuple | None:
+        """Return the checkpoint tuple, checking the buffer first.
+
+        If the requested ``thread_id`` + ``checkpoint_ns`` match the buffered
+        checkpoint, the result is returned from memory with zero API calls.
+        Otherwise the call is delegated to the underlying saver.
+
+        Args:
+            config: The runnable config identifying the checkpoint.
+
+        Returns:
+            The matching ``CheckpointTuple``, or ``None``.
+        """
+        with self._lock:
+            buffered = self._get_buffered_tuple(config)
+            if buffered is not None:
+                return buffered
+        return self._saver.get_tuple(config)
+
+    async def aget_tuple(self, config: RunnableConfig) -> CheckpointTuple | None:
+        """Async version of :meth:`get_tuple`.
+
+        Args:
+            config: The runnable config identifying the checkpoint.
+
+        Returns:
+            The matching ``CheckpointTuple``, or ``None``.
+        """
+        with self._lock:
+            buffered = self._get_buffered_tuple(config)
+            if buffered is not None:
+                return buffered
+        return await self._saver.aget_tuple(config)
+
+    def list(
+        self,
+        config: RunnableConfig | None,
+        *,
+        filter: dict[str, Any] | None = None,
+        before: RunnableConfig | None = None,
+        limit: int | None = None,
+    ) -> Iterator[CheckpointTuple]:
+        """List checkpoints from the underlying saver.
+
+        Buffered data is **not** included — only persisted checkpoints appear.
+
+        Args:
+            config: Optional config to scope the listing.
+            filter: Optional filter criteria.
+            before: Only return checkpoints before this config.
+            limit: Maximum number of results.
+
+        Yields:
+            ``CheckpointTuple`` instances from the underlying saver.
+        """
+        yield from self._saver.list(config, filter=filter, before=before, limit=limit)
+
+    async def alist(
+        self,
+        config: RunnableConfig | None,
+        *,
+        filter: dict[str, Any] | None = None,
+        before: RunnableConfig | None = None,
+        limit: int | None = None,
+    ) -> AsyncIterator[CheckpointTuple]:
+        """Async version of :meth:`list`.
+
+        Args:
+            config: Optional config to scope the listing.
+            filter: Optional filter criteria.
+            before: Only return checkpoints before this config.
+            limit: Maximum number of results.
+
+        Yields:
+            ``CheckpointTuple`` instances from the underlying saver.
+        """
+        async for item in self._saver.alist(
+            config, filter=filter, before=before, limit=limit
+        ):
+            yield item
+
+    def get_next_version(self, current: V | None, channel: None) -> V:
+        """Delegate version generation to the underlying saver.
+
+        Args:
+            current: The current version identifier.
+            channel: Deprecated, kept for backwards compatibility.
+
+        Returns:
+            The next version identifier.
+        """
+        return self._saver.get_next_version(current, channel)
+
+    # ------------------------------------------------------------------
+    # Flush mechanics
+    # ------------------------------------------------------------------
+
+    def flush(self) -> RunnableConfig | None:
+        """Persist all buffered data to the underlying saver.
+
+        Flushes the buffered checkpoint first, then all accumulated writes.
+        The lock is never held during network I/O.
+
+        On checkpoint flush failure the checkpoint is restored to the buffer
+        and the exception is re-raised.  On write flush failure, successfully
+        flushed writes are removed; remaining writes stay in the buffer.
+
+        Returns:
+            The config returned by the underlying saver's ``put()``, or
+            ``None`` if no checkpoint was buffered.
+
+        Raises:
+            Exception: Any exception raised by the underlying saver during
+                persistence is propagated after restoring unflushed data.
+        """
+        result_config: RunnableConfig | None = None
+
+        # --- Flush checkpoint ---
+        # We clear _pending_checkpoint before I/O to prevent a concurrent
+        # flush() from double-persisting the same checkpoint.  If the I/O
+        # fails, we restore it — but only when no new put() has written a
+        # newer checkpoint while we were blocked on the network call.
+        # Without this guard, a stale checkpoint would overwrite the fresh
+        # one, silently dropping data.
+        with self._lock:
+            pending_cp = self._pending_checkpoint
+            self._pending_checkpoint = None
+
+        if pending_cp is not None:
+            try:
+                result_config = self._saver.put(
+                    pending_cp.config,
+                    pending_cp.checkpoint,
+                    pending_cp.metadata,
+                    pending_cp.new_versions,
+                )
+            except Exception:
+                with self._lock:
+                    if self._pending_checkpoint is None:
+                        self._pending_checkpoint = pending_cp
+                raise
+
+        # --- Flush writes one at a time ---
+        # Unlike the checkpoint, writes use a peek-then-pop pattern: we
+        # read _pending_writes[0] but leave it in the list during I/O.
+        # On success we pop it; on failure it stays at index 0 so the
+        # next flush() retries it.  No restore logic is needed because
+        # the failed entry was never removed.  New put_writes() calls
+        # append to the tail, so they never interfere with the drain.
+        while True:
+            with self._lock:
+                if not self._pending_writes:
+                    break
+                write_entry = self._pending_writes[0]
+
+            try:
+                self._saver.put_writes(
+                    write_entry.config,
+                    write_entry.writes,
+                    write_entry.task_id,
+                    write_entry.task_path,
+                )
+            except Exception:
+                raise
+
+            with self._lock:
+                if self._pending_writes and self._pending_writes[0] is write_entry:
+                    self._pending_writes.pop(0)
+
+        return result_config
+
+    async def aflush(self) -> RunnableConfig | None:
+        """Async version of :meth:`flush`.
+
+        Returns:
+            The config returned by the underlying saver's ``aput()``, or
+            ``None`` if no checkpoint was buffered.
+
+        Raises:
+            Exception: Any exception raised by the underlying saver during
+                persistence is propagated after restoring unflushed data.
+        """
+        result_config: RunnableConfig | None = None
+
+        # --- Flush checkpoint ---
+        # Same race-condition-safe pattern as flush(). See comments there.
+        with self._lock:
+            pending_cp = self._pending_checkpoint
+            self._pending_checkpoint = None
+
+        if pending_cp is not None:
+            try:
+                result_config = await self._saver.aput(
+                    pending_cp.config,
+                    pending_cp.checkpoint,
+                    pending_cp.metadata,
+                    pending_cp.new_versions,
+                )
+            except Exception:
+                with self._lock:
+                    if self._pending_checkpoint is None:
+                        self._pending_checkpoint = pending_cp
+                raise
+
+        # --- Flush writes one at a time ---
+        # Same peek-then-pop pattern as flush(). See comments there.
+        while True:
+            with self._lock:
+                if not self._pending_writes:
+                    break
+                write_entry = self._pending_writes[0]
+
+            try:
+                await self._saver.aput_writes(
+                    write_entry.config,
+                    write_entry.writes,
+                    write_entry.task_id,
+                    write_entry.task_path,
+                )
+            except Exception:
+                raise
+
+            with self._lock:
+                if self._pending_writes and self._pending_writes[0] is write_entry:
+                    self._pending_writes.pop(0)
+
+        return result_config
+
+    # ------------------------------------------------------------------
+    # Context managers
+    # ------------------------------------------------------------------
+
+    @contextlib.contextmanager
+    def flush_on_exit(self) -> Iterator[DeferredCheckpointSaver]:
+        """Context manager that flushes buffered data on exit.
+
+        Flushes in the ``finally`` block so data is persisted even when the
+        graph raises an exception.
+
+        Yields:
+            This ``DeferredCheckpointSaver`` instance.
+
+        Example::
+
+            with deferred.flush_on_exit():
+                graph.invoke(input, config)
+        """
+        try:
+            yield self
+        finally:
+            self.flush()
+
+    @contextlib.asynccontextmanager
+    async def aflush_on_exit(self) -> AsyncIterator[DeferredCheckpointSaver]:
+        """Async context manager that flushes buffered data on exit.
+
+        Yields:
+            This ``DeferredCheckpointSaver`` instance.
+
+        Example::
+
+            async with deferred.aflush_on_exit():
+                await graph.ainvoke(input, config)
+        """
+        try:
+            yield self
+        finally:
+            await self.aflush()
+
+    # ------------------------------------------------------------------
+    # Buffer management
+    # ------------------------------------------------------------------
+
+    def clear(self) -> None:
+        """Discard all buffered data without persisting.
+
+        This is useful when you want to abandon an in-progress workflow
+        without saving any intermediate state.
+        """
+        with self._lock:
+            self._pending_checkpoint = None
+            self._pending_writes.clear()
+            self._last_config = None

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/deferred_saver.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/deferred_saver.py
@@ -1,25 +1,3 @@
-"""Deferred checkpoint saver that defers persistence until explicit flush.
-
-Wraps any ``BaseCheckpointSaver`` and defers ``put()`` / ``put_writes()``
-calls in memory, reducing API calls from dozens per workflow to a single
-batch on flush.  Designed for use cases (chatbots, single-turn agents) that
-only need the final conversation state persisted for session continuity.
-
-.. warning::
-    Mid-workflow crash recovery is **not** available when using this wrapper.
-    Buffered data is only persisted when ``flush()`` / ``aflush()`` is called
-    or a ``flush_on_exit()`` / ``aflush_on_exit()`` context manager exits.
-
-Example::
-
-    saver = AgentCoreMemorySaver(memory_id, region_name="us-east-1")
-    deferred = DeferredCheckpointSaver(saver)
-    graph = create_react_agent(model, tools=tools, checkpointer=deferred)
-
-    with deferred.flush_on_exit():
-        response = graph.invoke({"messages": [user_input]}, config)
-"""
-
 from __future__ import annotations
 
 import contextlib
@@ -36,26 +14,6 @@ from langgraph.checkpoint.base import (
     CheckpointTuple,
     V,
 )
-
-# ---------------------------------------------------------------------------
-# Internal buffer entry types
-# ---------------------------------------------------------------------------
-# NamedTuple was chosen over the alternatives for these internal types:
-#
-#   - Plain tuple: works but positional-only access (entry[0]) hurts
-#     readability in the flush/match logic.
-#   - TypedDict: mutable dict at runtime with hash-table overhead and no
-#     immutability guarantee — wrong fit for a lock-protected buffer where
-#     entries must not be modified after creation.
-#   - dataclass (mutable): allows accidental mutation of buffered state,
-#     which would introduce subtle concurrency bugs.
-#   - dataclass (frozen=True, slots=True): immutable and memory-efficient,
-#     but cannot be unpacked with ``a, b, c = entry`` and has slightly
-#     higher object-creation cost than a tuple.
-#
-# NamedTuple gives us named fields (``entry.config``), immutability,
-# zero overhead vs plain tuples, and tuple-compatible unpacking — the
-# best balance for simple internal containers guarded by a lock.
 
 
 class _PendingCheckpoint(NamedTuple):
@@ -104,9 +62,9 @@ class DeferredCheckpointSaver(BaseCheckpointSaver):
     Example::
 
         deferred = DeferredCheckpointSaver(my_saver)
-        graph = workflow.compile(checkpointer=buffered)
+        graph = workflow.compile(checkpointer=deferred)
 
-        with buffered.flush_on_exit():
+        with deferred.flush_on_exit():
             graph.invoke(input, config)
     """
 
@@ -123,10 +81,6 @@ class DeferredCheckpointSaver(BaseCheckpointSaver):
         self._pending_checkpoint: _PendingCheckpoint | None = None
         self._pending_writes: list[_PendingWrite] = []
         self._last_config: RunnableConfig | None = None
-
-    # ------------------------------------------------------------------
-    # Read-only properties
-    # ------------------------------------------------------------------
 
     @property
     def saver(self) -> BaseCheckpointSaver:
@@ -150,10 +104,6 @@ class DeferredCheckpointSaver(BaseCheckpointSaver):
         """Whether the buffer contains no pending data."""
         with self._lock:
             return self._pending_checkpoint is None and len(self._pending_writes) == 0
-
-    # ------------------------------------------------------------------
-    # BaseCheckpointSaver interface — buffered writes
-    # ------------------------------------------------------------------
 
     def put(
         self,
@@ -181,6 +131,7 @@ class DeferredCheckpointSaver(BaseCheckpointSaver):
         checkpoint_ns = config["configurable"].get("checkpoint_ns", "")
         result_config: RunnableConfig = {
             "configurable": {
+                **config["configurable"],
                 "thread_id": thread_id,
                 "checkpoint_ns": checkpoint_ns,
                 "checkpoint_id": checkpoint["id"],
@@ -260,10 +211,6 @@ class DeferredCheckpointSaver(BaseCheckpointSaver):
         """
         self.put_writes(config, writes, task_id, task_path)
 
-    # ------------------------------------------------------------------
-    # BaseCheckpointSaver interface — reads (buffer-first)
-    # ------------------------------------------------------------------
-
     def _get_buffered_tuple(self, config: RunnableConfig) -> CheckpointTuple | None:
         """Return a ``CheckpointTuple`` from the buffer if it matches *config*.
 
@@ -321,6 +268,7 @@ class DeferredCheckpointSaver(BaseCheckpointSaver):
         if parent_id:
             parent_config = {
                 "configurable": {
+                    **buf_config["configurable"],
                     "thread_id": buf_thread,
                     "checkpoint_ns": buf_ns,
                     "checkpoint_id": parent_id,
@@ -329,6 +277,7 @@ class DeferredCheckpointSaver(BaseCheckpointSaver):
 
         result_config: RunnableConfig = {
             "configurable": {
+                **buf_config["configurable"],
                 "thread_id": buf_thread,
                 "checkpoint_ns": buf_ns,
                 "checkpoint_id": buf_ckpt_id,
@@ -436,10 +385,6 @@ class DeferredCheckpointSaver(BaseCheckpointSaver):
         """
         return self._saver.get_next_version(current, channel)
 
-    # ------------------------------------------------------------------
-    # Flush mechanics
-    # ------------------------------------------------------------------
-
     def flush(self) -> RunnableConfig | None:
         """Persist all buffered data to the underlying saver.
 
@@ -498,15 +443,12 @@ class DeferredCheckpointSaver(BaseCheckpointSaver):
                     break
                 write_entry = self._pending_writes[0]
 
-            try:
-                self._saver.put_writes(
-                    write_entry.config,
-                    write_entry.writes,
-                    write_entry.task_id,
-                    write_entry.task_path,
-                )
-            except Exception:
-                raise
+            self._saver.put_writes(
+                write_entry.config,
+                write_entry.writes,
+                write_entry.task_id,
+                write_entry.task_path,
+            )
 
             with self._lock:
                 if self._pending_writes and self._pending_writes[0] is write_entry:
@@ -555,25 +497,18 @@ class DeferredCheckpointSaver(BaseCheckpointSaver):
                     break
                 write_entry = self._pending_writes[0]
 
-            try:
-                await self._saver.aput_writes(
-                    write_entry.config,
-                    write_entry.writes,
-                    write_entry.task_id,
-                    write_entry.task_path,
-                )
-            except Exception:
-                raise
+            await self._saver.aput_writes(
+                write_entry.config,
+                write_entry.writes,
+                write_entry.task_id,
+                write_entry.task_path,
+            )
 
             with self._lock:
                 if self._pending_writes and self._pending_writes[0] is write_entry:
                     self._pending_writes.pop(0)
 
         return result_config
-
-    # ------------------------------------------------------------------
-    # Context managers
-    # ------------------------------------------------------------------
 
     @contextlib.contextmanager
     def flush_on_exit(self) -> Iterator[DeferredCheckpointSaver]:
@@ -611,10 +546,6 @@ class DeferredCheckpointSaver(BaseCheckpointSaver):
             yield self
         finally:
             await self.aflush()
-
-    # ------------------------------------------------------------------
-    # Buffer management
-    # ------------------------------------------------------------------
 
     def clear(self) -> None:
         """Discard all buffered data without persisting.

--- a/libs/langgraph-checkpoint-aws/tests/integration_tests/test_deferred_saver.py
+++ b/libs/langgraph-checkpoint-aws/tests/integration_tests/test_deferred_saver.py
@@ -33,8 +33,6 @@ DYNAMODB_TABLE = os.getenv("DYNAMODB_TABLE_NAME", "langgraph-deferred-saver-inte
 BEDROCK_SESSION_REGION = os.getenv("BEDROCK_SESSION_REGION", "us-east-1")
 
 
-
-
 _SaverAndCleanup = tuple[BaseCheckpointSaver, Callable[[str, str], None], str | None]
 
 
@@ -65,7 +63,6 @@ def _make_checkpoint() -> Checkpoint:
     )
 
 
-
 @pytest.fixture(scope="module")
 def agentcore_memory_id() -> str:
     """Ensure the AgentCore memory exists, creating it if needed.
@@ -90,8 +87,6 @@ def dynamodb_table() -> str:
         return ensure_dynamodb_table(DYNAMODB_TABLE, AWS_REGION)
     except Exception as exc:
         pytest.skip(f"DynamoDB table unavailable: {exc}")
-
-
 
 
 def _make_agentcore(memory_id: str) -> _SaverAndCleanup:
@@ -160,7 +155,6 @@ def saver_and_cleanup(
 
     msg = f"Unknown backend: {name}"
     raise ValueError(msg)
-
 
 
 class TestDeferredCheckpointSaver:
@@ -621,7 +615,6 @@ class TestDeferredCheckpointSaver:
         finally:
             cleanup(thread_id, actor_id)
 
-
     def test_checkpoint_ns_isolation(self, saver_and_cleanup: _SaverAndCleanup) -> None:
         """Checkpoints with different namespaces on the same thread stay isolated."""
         saver, cleanup, thread_id, actor_id = self._unpack(saver_and_cleanup)
@@ -705,7 +698,6 @@ class TestDeferredCheckpointSaver:
         finally:
             cleanup(thread_id, actor_id)
 
-
     def test_pending_writes_retrievable_after_flush(
         self, saver_and_cleanup: _SaverAndCleanup
     ) -> None:
@@ -755,7 +747,6 @@ class TestDeferredCheckpointSaver:
             assert "messages" in channels
         finally:
             cleanup(thread_id, actor_id)
-
 
     def test_multiple_task_ids_flushed(
         self, saver_and_cleanup: _SaverAndCleanup
@@ -972,7 +963,6 @@ class TestDeferredCheckpointSaver:
             assert len(post_flush) >= 1
         finally:
             cleanup(thread_id, actor_id)
-
 
     def test_writes_only_flush_no_checkpoint(
         self, saver_and_cleanup: _SaverAndCleanup

--- a/libs/langgraph-checkpoint-aws/tests/integration_tests/test_deferred_saver.py
+++ b/libs/langgraph-checkpoint-aws/tests/integration_tests/test_deferred_saver.py
@@ -1,13 +1,3 @@
-"""Integration tests for DeferredCheckpointSaver.
-
-Tests the wrapper against all available backend savers:
-- AgentCoreMemorySaver (creates memory if AGENTCORE_MEMORY_ID not set)
-- DynamoDBSaver (creates table if not exists)
-- BedrockSessionSaver (requires BEDROCK_SESSION_REGION env var)
-
-Resources are created automatically when possible and cleaned up after.
-"""
-
 from __future__ import annotations
 
 import datetime
@@ -36,18 +26,14 @@ from tests.integration_tests.utils import (
 
 logger = logging.getLogger(__name__)
 
-# ---------------------------------------------------------------------------
-# Configuration
-# ---------------------------------------------------------------------------
+
 AWS_REGION = os.getenv("AWS_REGION", "us-east-1")
 AGENTCORE_MEMORY_ID = os.getenv("AGENTCORE_MEMORY_ID", "langgraph_deferred_saver_integ")
 DYNAMODB_TABLE = os.getenv("DYNAMODB_TABLE_NAME", "langgraph-deferred-saver-integ")
 BEDROCK_SESSION_REGION = os.getenv("BEDROCK_SESSION_REGION", "us-east-1")
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
+
 
 _SaverAndCleanup = tuple[BaseCheckpointSaver, Callable[[str, str], None], str | None]
 
@@ -79,10 +65,6 @@ def _make_checkpoint() -> Checkpoint:
     )
 
 
-# ---------------------------------------------------------------------------
-# Resource setup — AgentCore memory
-# ---------------------------------------------------------------------------
-
 
 @pytest.fixture(scope="module")
 def agentcore_memory_id() -> str:
@@ -95,11 +77,6 @@ def agentcore_memory_id() -> str:
         return ensure_agentcore_memory(AGENTCORE_MEMORY_ID, AWS_REGION)
     except Exception as exc:
         pytest.skip(f"AgentCore memory unavailable: {exc}")
-
-
-# ---------------------------------------------------------------------------
-# Resource setup — DynamoDB table
-# ---------------------------------------------------------------------------
 
 
 @pytest.fixture(scope="module")
@@ -115,9 +92,6 @@ def dynamodb_table() -> str:
         pytest.skip(f"DynamoDB table unavailable: {exc}")
 
 
-# ---------------------------------------------------------------------------
-# Backend saver factories
-# ---------------------------------------------------------------------------
 
 
 def _make_agentcore(memory_id: str) -> _SaverAndCleanup:
@@ -187,10 +161,6 @@ def saver_and_cleanup(
     msg = f"Unknown backend: {name}"
     raise ValueError(msg)
 
-
-# ---------------------------------------------------------------------------
-# Tests — run once per backend saver
-# ---------------------------------------------------------------------------
 
 
 class TestDeferredCheckpointSaver:
@@ -651,9 +621,6 @@ class TestDeferredCheckpointSaver:
         finally:
             cleanup(thread_id, actor_id)
 
-    # ------------------------------------------------------------------
-    # Checkpoint namespace isolation
-    # ------------------------------------------------------------------
 
     def test_checkpoint_ns_isolation(self, saver_and_cleanup: _SaverAndCleanup) -> None:
         """Checkpoints with different namespaces on the same thread stay isolated."""
@@ -738,9 +705,6 @@ class TestDeferredCheckpointSaver:
         finally:
             cleanup(thread_id, actor_id)
 
-    # ------------------------------------------------------------------
-    # Pending writes retrievable after flush
-    # ------------------------------------------------------------------
 
     def test_pending_writes_retrievable_after_flush(
         self, saver_and_cleanup: _SaverAndCleanup
@@ -792,9 +756,6 @@ class TestDeferredCheckpointSaver:
         finally:
             cleanup(thread_id, actor_id)
 
-    # ------------------------------------------------------------------
-    # Multiple task_ids flushed correctly
-    # ------------------------------------------------------------------
 
     def test_multiple_task_ids_flushed(
         self, saver_and_cleanup: _SaverAndCleanup
@@ -860,10 +821,6 @@ class TestDeferredCheckpointSaver:
             assert len(flushed_task_ids) >= 1
         finally:
             cleanup(thread_id, actor_id)
-
-    # ------------------------------------------------------------------
-    # Async paths against real backends
-    # ------------------------------------------------------------------
 
     @pytest.mark.asyncio
     async def test_async_flush_persists_to_backend(
@@ -1016,9 +973,6 @@ class TestDeferredCheckpointSaver:
         finally:
             cleanup(thread_id, actor_id)
 
-    # ------------------------------------------------------------------
-    # Writes-only flush (no checkpoint)
-    # ------------------------------------------------------------------
 
     def test_writes_only_flush_no_checkpoint(
         self, saver_and_cleanup: _SaverAndCleanup

--- a/libs/langgraph-checkpoint-aws/tests/integration_tests/test_deferred_saver.py
+++ b/libs/langgraph-checkpoint-aws/tests/integration_tests/test_deferred_saver.py
@@ -1,0 +1,1076 @@
+"""Integration tests for DeferredCheckpointSaver.
+
+Tests the wrapper against all available backend savers:
+- AgentCoreMemorySaver (creates memory if AGENTCORE_MEMORY_ID not set)
+- DynamoDBSaver (creates table if not exists)
+- BedrockSessionSaver (requires BEDROCK_SESSION_REGION env var)
+
+Resources are created automatically when possible and cleaned up after.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+import os
+import random
+import string
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+from langchain_core.runnables import RunnableConfig
+from langgraph.checkpoint.base import (
+    BaseCheckpointSaver,
+    Checkpoint,
+    CheckpointMetadata,
+    uuid6,
+)
+
+from langgraph_checkpoint_aws.deferred_saver import DeferredCheckpointSaver
+from tests.integration_tests.utils import (
+    create_bedrock_session,
+    ensure_agentcore_memory,
+    ensure_dynamodb_table,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+AWS_REGION = os.getenv("AWS_REGION", "us-east-1")
+AGENTCORE_MEMORY_ID = os.getenv("AGENTCORE_MEMORY_ID", "langgraph_deferred_saver_integ")
+DYNAMODB_TABLE = os.getenv("DYNAMODB_TABLE_NAME", "langgraph-deferred-saver-integ")
+BEDROCK_SESSION_REGION = os.getenv("BEDROCK_SESSION_REGION", "us-east-1")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SaverAndCleanup = tuple[BaseCheckpointSaver, Callable[[str, str], None], str | None]
+
+
+def _generate_id(prefix: str = "test") -> str:
+    chars = string.ascii_letters + string.digits
+    return prefix + "".join(random.choices(chars, k=6))
+
+
+def _has_async_support(saver: BaseCheckpointSaver) -> bool:
+    """Check if the saver implements async methods (not just the base stubs)."""
+    try:
+        # Base class raises NotImplementedError; if the method is not
+        # overridden the saver is sync-only.
+        return type(saver).aput is not BaseCheckpointSaver.aput
+    except AttributeError:
+        return False
+
+
+def _make_checkpoint() -> Checkpoint:
+    return Checkpoint(
+        v=1,
+        id=str(uuid6(clock_seq=-2)),
+        ts=datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        channel_values={"messages": ["test message"]},
+        channel_versions={"messages": "v1"},
+        versions_seen={"node1": {"messages": "v1"}},
+        updated_channels=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Resource setup — AgentCore memory
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def agentcore_memory_id() -> str:
+    """Ensure the AgentCore memory exists, creating it if needed.
+
+    Skips gracefully when the memory ID is invalid or unreachable so
+    that other backends (DynamoDB, Bedrock Session) are not blocked.
+    """
+    try:
+        return ensure_agentcore_memory(AGENTCORE_MEMORY_ID, AWS_REGION)
+    except Exception as exc:
+        pytest.skip(f"AgentCore memory unavailable: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Resource setup — DynamoDB table
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def dynamodb_table() -> str:
+    """Ensure the DynamoDB table exists, creating it if needed.
+
+    Skips gracefully when the table cannot be created or reached so
+    that other backends are not blocked.
+    """
+    try:
+        return ensure_dynamodb_table(DYNAMODB_TABLE, AWS_REGION)
+    except Exception as exc:
+        pytest.skip(f"DynamoDB table unavailable: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Backend saver factories
+# ---------------------------------------------------------------------------
+
+
+def _make_agentcore(memory_id: str) -> _SaverAndCleanup:
+    from langgraph_checkpoint_aws.agentcore.saver import AgentCoreMemorySaver
+
+    saver = AgentCoreMemorySaver(memory_id=memory_id, region_name=AWS_REGION)
+
+    def cleanup(thread_id: str, actor_id: str) -> None:
+        try:
+            saver.delete_thread(thread_id, actor_id)
+        except Exception:
+            pass
+
+    return saver, cleanup, None
+
+
+def _make_dynamodb(table_name: str) -> _SaverAndCleanup:
+    from langgraph_checkpoint_aws.checkpoint.dynamodb import DynamoDBSaver
+
+    saver = DynamoDBSaver(table_name=table_name, region_name=AWS_REGION)
+
+    def cleanup(thread_id: str, _actor_id: str) -> None:
+        try:
+            saver.delete_thread(thread_id)
+        except Exception:
+            pass
+
+    return saver, cleanup, None
+
+
+def _make_bedrock_session() -> _SaverAndCleanup:
+    saver, session_id, session_cleanup = create_bedrock_session(BEDROCK_SESSION_REGION)
+
+    def cleanup(thread_id: str, _actor_id: str) -> None:
+        session_cleanup()
+
+    return saver, cleanup, session_id
+
+
+@pytest.fixture(
+    params=["agentcore", "dynamodb", "bedrock_session"],
+)
+def saver_and_cleanup(
+    request: Any,
+) -> _SaverAndCleanup:
+    """Parametrized fixture — creates one backend per test invocation.
+
+    Each backend lazily resolves its own resource fixture via
+    ``request.getfixturevalue`` so that a failure in one backend
+    (e.g. AgentCore memory unavailable) only skips tests for that
+    backend — other backends proceed normally.
+    """
+    name = request.param
+
+    if name == "agentcore":
+        memory_id = request.getfixturevalue("agentcore_memory_id")
+        return _make_agentcore(memory_id)
+    if name == "dynamodb":
+        table = request.getfixturevalue("dynamodb_table")
+        return _make_dynamodb(table)
+    if name == "bedrock_session":
+        try:
+            return _make_bedrock_session()
+        except Exception as exc:
+            pytest.skip(f"Bedrock session unavailable: {exc}")
+
+    msg = f"Unknown backend: {name}"
+    raise ValueError(msg)
+
+
+# ---------------------------------------------------------------------------
+# Tests — run once per backend saver
+# ---------------------------------------------------------------------------
+
+
+class TestDeferredCheckpointSaver:
+    """Integration tests for DeferredCheckpointSaver across all backends."""
+
+    @staticmethod
+    def _unpack(
+        saver_and_cleanup: _SaverAndCleanup,
+    ) -> tuple[BaseCheckpointSaver, Callable, str, str]:
+        """Unpack fixture and generate IDs.
+
+        Uses the backend-provided thread_id override when present
+        (e.g. Bedrock Session requires a UUID session ID).
+        """
+        saver, cleanup, thread_id_override = saver_and_cleanup
+        thread_id = thread_id_override or _generate_id("thread")
+        actor_id = _generate_id("actor")
+        return saver, cleanup, thread_id, actor_id
+
+    def test_nothing_persisted_before_flush(
+        self, saver_and_cleanup: _SaverAndCleanup
+    ) -> None:
+        """Buffer holds data; underlying saver has nothing until flush."""
+        saver, cleanup, thread_id, actor_id = self._unpack(saver_and_cleanup)
+        deferred = DeferredCheckpointSaver(saver)
+
+        config: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "actor_id": actor_id,
+                "checkpoint_ns": "",
+            }
+        }
+
+        try:
+            deferred.put(
+                config,
+                _make_checkpoint(),
+                {"source": "input", "step": 1},
+                {},
+            )
+            assert not deferred.is_empty
+
+            persisted = list(saver.list(config))
+            assert len(persisted) == 0
+        finally:
+            deferred.clear()
+            cleanup(thread_id, actor_id)
+
+    def test_flush_persists_to_underlying_saver(
+        self, saver_and_cleanup: _SaverAndCleanup
+    ) -> None:
+        """After flush(), the checkpoint is retrievable from the backend."""
+        saver, cleanup, thread_id, actor_id = self._unpack(saver_and_cleanup)
+        deferred = DeferredCheckpointSaver(saver)
+
+        config: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "actor_id": actor_id,
+                "checkpoint_ns": "",
+            }
+        }
+        checkpoint = _make_checkpoint()
+
+        try:
+            deferred.put(
+                config,
+                checkpoint,
+                {"source": "input", "step": 1},
+                {},
+            )
+            deferred.flush()
+
+            assert deferred.is_empty
+
+            persisted = list(saver.list(config))
+            assert len(persisted) >= 1
+
+            saved_config: RunnableConfig = {
+                "configurable": {
+                    "thread_id": thread_id,
+                    "actor_id": actor_id,
+                    "checkpoint_ns": "",
+                    "checkpoint_id": checkpoint["id"],
+                }
+            }
+            result = saver.get_tuple(saved_config)
+            assert result is not None
+            assert result.checkpoint["id"] == checkpoint["id"]
+        finally:
+            cleanup(thread_id, actor_id)
+
+    def test_flush_on_exit_context_manager(
+        self, saver_and_cleanup: _SaverAndCleanup
+    ) -> None:
+        """flush_on_exit() auto-persists when the block exits."""
+        saver, cleanup, thread_id, actor_id = self._unpack(saver_and_cleanup)
+        deferred = DeferredCheckpointSaver(saver)
+
+        config: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "actor_id": actor_id,
+                "checkpoint_ns": "",
+            }
+        }
+
+        try:
+            with deferred.flush_on_exit():
+                deferred.put(
+                    config,
+                    _make_checkpoint(),
+                    {"source": "input", "step": 1},
+                    {},
+                )
+
+            assert deferred.is_empty
+            assert len(list(saver.list(config))) >= 1
+        finally:
+            cleanup(thread_id, actor_id)
+
+    def test_get_tuple_returns_buffered_data(
+        self, saver_and_cleanup: _SaverAndCleanup
+    ) -> None:
+        """get_tuple() serves from the buffer before flush."""
+        saver, cleanup, thread_id, actor_id = self._unpack(saver_and_cleanup)
+        deferred = DeferredCheckpointSaver(saver)
+
+        config: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "actor_id": actor_id,
+                "checkpoint_ns": "",
+            }
+        }
+        checkpoint = _make_checkpoint()
+
+        try:
+            deferred.put(
+                config,
+                checkpoint,
+                {"source": "input", "step": 1},
+                {},
+            )
+
+            result = deferred.get_tuple(config)
+            assert result is not None
+            assert result.checkpoint["id"] == checkpoint["id"]
+        finally:
+            deferred.clear()
+            cleanup(thread_id, actor_id)
+
+    def test_put_overwrites_keeps_only_latest(
+        self, saver_and_cleanup: _SaverAndCleanup
+    ) -> None:
+        """Multiple put() calls — only the last checkpoint is flushed."""
+        saver, cleanup, thread_id, actor_id = self._unpack(saver_and_cleanup)
+        deferred = DeferredCheckpointSaver(saver)
+
+        config: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "actor_id": actor_id,
+                "checkpoint_ns": "",
+            }
+        }
+        metadata: CheckpointMetadata = {
+            "source": "loop",
+            "step": 0,
+        }
+        ckpt_1 = _make_checkpoint()
+        ckpt_2 = _make_checkpoint()
+        ckpt_3 = _make_checkpoint()
+
+        try:
+            deferred.put(config, ckpt_1, metadata, {})
+            deferred.put(config, ckpt_2, metadata, {})
+            deferred.put(config, ckpt_3, metadata, {})
+
+            deferred.flush()
+
+            persisted = list(saver.list(config))
+            assert len(persisted) == 1
+            assert persisted[0].checkpoint["id"] == ckpt_3["id"]
+        finally:
+            cleanup(thread_id, actor_id)
+
+    def test_clear_discards_without_persisting(
+        self, saver_and_cleanup: _SaverAndCleanup
+    ) -> None:
+        """clear() drops buffered data; nothing reaches the backend."""
+        saver, cleanup, thread_id, actor_id = self._unpack(saver_and_cleanup)
+        deferred = DeferredCheckpointSaver(saver)
+
+        config: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "actor_id": actor_id,
+                "checkpoint_ns": "",
+            }
+        }
+
+        try:
+            deferred.put(
+                config,
+                _make_checkpoint(),
+                {"source": "input", "step": 1},
+                {},
+            )
+            assert not deferred.is_empty
+
+            deferred.clear()
+            assert deferred.is_empty
+
+            assert len(list(saver.list(config))) == 0
+        finally:
+            cleanup(thread_id, actor_id)
+
+    def test_flush_persists_writes(self, saver_and_cleanup: _SaverAndCleanup) -> None:
+        """put_writes() data is flushed alongside the checkpoint."""
+        saver, cleanup, thread_id, actor_id = self._unpack(saver_and_cleanup)
+        deferred = DeferredCheckpointSaver(saver)
+        checkpoint = _make_checkpoint()
+
+        config: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "actor_id": actor_id,
+                "checkpoint_ns": "",
+            }
+        }
+        write_config: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "actor_id": actor_id,
+                "checkpoint_ns": "",
+                "checkpoint_id": checkpoint["id"],
+            }
+        }
+
+        try:
+            deferred.put(
+                config,
+                checkpoint,
+                {"source": "input", "step": 1},
+                {},
+            )
+            deferred.put_writes(write_config, [("messages", "hello")], "task-1")
+
+            assert deferred.has_buffered_writes
+            deferred.flush()
+            assert deferred.is_empty
+        finally:
+            cleanup(thread_id, actor_id)
+
+    def test_multi_session_isolation(self, saver_and_cleanup: _SaverAndCleanup) -> None:
+        """Two flush_on_exit blocks with different threads stay isolated."""
+        saver, cleanup, thread_id_1, actor_id = self._unpack(saver_and_cleanup)
+        # For Bedrock Session, thread_id is a pre-created session UUID
+        # and we can't easily create a second one here, so we reuse
+        # the same thread for both invocations (different checkpoints).
+        deferred = DeferredCheckpointSaver(saver)
+        ckpt_1 = _make_checkpoint()
+        ckpt_2 = _make_checkpoint()
+
+        config: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id_1,
+                "actor_id": actor_id,
+                "checkpoint_ns": "",
+            }
+        }
+
+        try:
+            with deferred.flush_on_exit():
+                deferred.put(
+                    config,
+                    ckpt_1,
+                    {"source": "input", "step": 1},
+                    {},
+                )
+
+            with deferred.flush_on_exit():
+                deferred.put(
+                    config,
+                    ckpt_2,
+                    {"source": "loop", "step": 2},
+                    {},
+                )
+
+            # Both checkpoints should be persisted
+            persisted = list(saver.list(config))
+            assert len(persisted) >= 2
+        finally:
+            cleanup(thread_id_1, actor_id)
+
+    def test_flush_on_exit_persists_on_exception(
+        self, saver_and_cleanup: _SaverAndCleanup
+    ) -> None:
+        """Context manager flushes even when the body raises."""
+        saver, cleanup, thread_id, actor_id = self._unpack(saver_and_cleanup)
+        deferred = DeferredCheckpointSaver(saver)
+
+        config: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "actor_id": actor_id,
+                "checkpoint_ns": "",
+            }
+        }
+
+        try:
+            with pytest.raises(ValueError, match="simulated"):
+                with deferred.flush_on_exit():
+                    deferred.put(
+                        config,
+                        _make_checkpoint(),
+                        {"source": "input", "step": 1},
+                        {},
+                    )
+                    msg = "simulated"
+                    raise ValueError(msg)
+
+            # Data should still have been flushed
+            assert deferred.is_empty
+            persisted = list(saver.list(config))
+            assert len(persisted) >= 1
+        finally:
+            cleanup(thread_id, actor_id)
+
+    def test_get_tuple_delegates_after_flush(
+        self, saver_and_cleanup: _SaverAndCleanup
+    ) -> None:
+        """After flush, get_tuple reads from the backend, not buffer."""
+        saver, cleanup, thread_id, actor_id = self._unpack(saver_and_cleanup)
+        deferred = DeferredCheckpointSaver(saver)
+        checkpoint = _make_checkpoint()
+
+        config: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "actor_id": actor_id,
+                "checkpoint_ns": "",
+            }
+        }
+
+        try:
+            deferred.put(
+                config,
+                checkpoint,
+                {"source": "input", "step": 1},
+                {},
+            )
+            deferred.flush()
+
+            assert deferred.is_empty
+
+            # This must delegate to the backend since buffer is empty
+            result = deferred.get_tuple(config)
+            assert result is not None
+            assert result.checkpoint["id"] == checkpoint["id"]
+        finally:
+            cleanup(thread_id, actor_id)
+
+    def test_list_excludes_buffered_includes_flushed(
+        self, saver_and_cleanup: _SaverAndCleanup
+    ) -> None:
+        """list() never shows buffered data, but shows flushed data."""
+        saver, cleanup, thread_id, actor_id = self._unpack(saver_and_cleanup)
+        deferred = DeferredCheckpointSaver(saver)
+
+        config: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "actor_id": actor_id,
+                "checkpoint_ns": "",
+            }
+        }
+
+        try:
+            deferred.put(
+                config,
+                _make_checkpoint(),
+                {"source": "input", "step": 1},
+                {},
+            )
+
+            # Buffered — list should return nothing
+            assert len(list(deferred.list(config))) == 0
+
+            deferred.flush()
+
+            # Flushed — list should return the checkpoint
+            assert len(list(deferred.list(config))) >= 1
+        finally:
+            cleanup(thread_id, actor_id)
+
+    def test_double_flush_is_safe(self, saver_and_cleanup: _SaverAndCleanup) -> None:
+        """Calling flush() twice is a no-op the second time."""
+        saver, cleanup, thread_id, actor_id = self._unpack(saver_and_cleanup)
+        deferred = DeferredCheckpointSaver(saver)
+
+        config: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "actor_id": actor_id,
+                "checkpoint_ns": "",
+            }
+        }
+
+        try:
+            deferred.put(
+                config,
+                _make_checkpoint(),
+                {"source": "input", "step": 1},
+                {},
+            )
+
+            result1 = deferred.flush()
+            assert result1 is not None
+
+            result2 = deferred.flush()
+            assert result2 is None
+            assert deferred.is_empty
+        finally:
+            cleanup(thread_id, actor_id)
+
+    def test_flush_returns_correct_config(
+        self, saver_and_cleanup: _SaverAndCleanup
+    ) -> None:
+        """flush() returns a config with the correct identifiers."""
+        saver, cleanup, thread_id, actor_id = self._unpack(saver_and_cleanup)
+        deferred = DeferredCheckpointSaver(saver)
+        checkpoint = _make_checkpoint()
+
+        config: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "actor_id": actor_id,
+                "checkpoint_ns": "",
+            }
+        }
+
+        try:
+            deferred.put(
+                config,
+                checkpoint,
+                {"source": "input", "step": 1},
+                {},
+            )
+
+            result = deferred.flush()
+            assert result is not None
+            cfg = result["configurable"]
+            assert cfg["thread_id"] == thread_id
+            assert cfg["checkpoint_id"] == checkpoint["id"]
+        finally:
+            cleanup(thread_id, actor_id)
+
+    # ------------------------------------------------------------------
+    # Checkpoint namespace isolation
+    # ------------------------------------------------------------------
+
+    def test_checkpoint_ns_isolation(self, saver_and_cleanup: _SaverAndCleanup) -> None:
+        """Checkpoints with different namespaces on the same thread stay isolated."""
+        saver, cleanup, thread_id, actor_id = self._unpack(saver_and_cleanup)
+        deferred = DeferredCheckpointSaver(saver)
+        ckpt_ns_a = _make_checkpoint()
+        ckpt_ns_b = _make_checkpoint()
+
+        config_ns_a: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "actor_id": actor_id,
+                "checkpoint_ns": "ns_a",
+            }
+        }
+        config_ns_b: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "actor_id": actor_id,
+                "checkpoint_ns": "ns_b",
+            }
+        }
+
+        try:
+            # Flush ns_a first, then ns_b
+            deferred.put(
+                config_ns_a,
+                ckpt_ns_a,
+                {"source": "input", "step": 1},
+                {},
+            )
+            deferred.flush()
+
+            deferred.put(
+                config_ns_b,
+                ckpt_ns_b,
+                {"source": "input", "step": 1},
+                {},
+            )
+            deferred.flush()
+
+            # Each namespace should return its own checkpoint
+            result_a = saver.get_tuple(
+                {
+                    "configurable": {
+                        "thread_id": thread_id,
+                        "actor_id": actor_id,
+                        "checkpoint_ns": "ns_a",
+                        "checkpoint_id": ckpt_ns_a["id"],
+                    }
+                }
+            )
+            result_b = saver.get_tuple(
+                {
+                    "configurable": {
+                        "thread_id": thread_id,
+                        "actor_id": actor_id,
+                        "checkpoint_ns": "ns_b",
+                        "checkpoint_id": ckpt_ns_b["id"],
+                    }
+                }
+            )
+
+            assert result_a is not None
+            assert result_a.checkpoint["id"] == ckpt_ns_a["id"]
+
+            assert result_b is not None
+            assert result_b.checkpoint["id"] == ckpt_ns_b["id"]
+
+            # Cross-check: ns_a checkpoint_id should not appear under ns_b
+            cross_result = saver.get_tuple(
+                {
+                    "configurable": {
+                        "thread_id": thread_id,
+                        "actor_id": actor_id,
+                        "checkpoint_ns": "ns_b",
+                        "checkpoint_id": ckpt_ns_a["id"],
+                    }
+                }
+            )
+            assert cross_result is None
+        finally:
+            cleanup(thread_id, actor_id)
+
+    # ------------------------------------------------------------------
+    # Pending writes retrievable after flush
+    # ------------------------------------------------------------------
+
+    def test_pending_writes_retrievable_after_flush(
+        self, saver_and_cleanup: _SaverAndCleanup
+    ) -> None:
+        """Writes flushed to the backend are returned by get_tuple().pending_writes."""
+        saver, cleanup, thread_id, actor_id = self._unpack(saver_and_cleanup)
+        deferred = DeferredCheckpointSaver(saver)
+        checkpoint = _make_checkpoint()
+
+        config: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "actor_id": actor_id,
+                "checkpoint_ns": "",
+            }
+        }
+        write_config: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "actor_id": actor_id,
+                "checkpoint_ns": "",
+                "checkpoint_id": checkpoint["id"],
+            }
+        }
+
+        try:
+            deferred.put(
+                config,
+                checkpoint,
+                {"source": "input", "step": 1},
+                {},
+            )
+            deferred.put_writes(
+                write_config,
+                [("messages", "hello")],
+                "task-1",
+            )
+            deferred.flush()
+
+            # Read back from the backend directly
+            result = saver.get_tuple(write_config)
+            assert result is not None
+            assert result.pending_writes is not None
+            assert len(result.pending_writes) >= 1
+
+            # Verify the write content is present
+            channels = [pw[1] for pw in result.pending_writes]
+            assert "messages" in channels
+        finally:
+            cleanup(thread_id, actor_id)
+
+    # ------------------------------------------------------------------
+    # Multiple task_ids flushed correctly
+    # ------------------------------------------------------------------
+
+    def test_multiple_task_ids_flushed(
+        self, saver_and_cleanup: _SaverAndCleanup
+    ) -> None:
+        """Writes from multiple task_ids all persist after flush."""
+        saver, cleanup, thread_id, actor_id = self._unpack(saver_and_cleanup)
+        deferred = DeferredCheckpointSaver(saver)
+        checkpoint = _make_checkpoint()
+
+        config: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "actor_id": actor_id,
+                "checkpoint_ns": "",
+            }
+        }
+        write_config: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "actor_id": actor_id,
+                "checkpoint_ns": "",
+                "checkpoint_id": checkpoint["id"],
+            }
+        }
+
+        try:
+            deferred.put(
+                config,
+                checkpoint,
+                {"source": "input", "step": 1},
+                {},
+            )
+            deferred.put_writes(
+                write_config,
+                [("messages", "from-task-1")],
+                "task-1",
+            )
+            deferred.put_writes(
+                write_config,
+                [("messages", "from-task-2")],
+                "task-2",
+            )
+            deferred.put_writes(
+                write_config,
+                [("tools", "from-task-3")],
+                "task-3",
+            )
+
+            assert not deferred.is_empty
+            deferred.flush()
+            assert deferred.is_empty
+
+            result = saver.get_tuple(write_config)
+            assert result is not None
+            assert result.pending_writes is not None
+
+            flushed_task_ids = {pw[0] for pw in result.pending_writes}
+            # BedrockSessionSaver only retains the last write per
+            # checkpoint, so we check that at least one task_id is
+            # present and all returned ids are from our set.
+            expected = {"task-1", "task-2", "task-3"}
+            assert flushed_task_ids.issubset(expected)
+            assert len(flushed_task_ids) >= 1
+        finally:
+            cleanup(thread_id, actor_id)
+
+    # ------------------------------------------------------------------
+    # Async paths against real backends
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_async_flush_persists_to_backend(
+        self, saver_and_cleanup: _SaverAndCleanup
+    ) -> None:
+        """aflush() persists checkpoint to the real backend."""
+        saver, cleanup, thread_id, actor_id = self._unpack(saver_and_cleanup)
+        if not _has_async_support(saver):
+            pytest.skip("Backend does not implement async methods")
+        deferred = DeferredCheckpointSaver(saver)
+        checkpoint = _make_checkpoint()
+
+        config: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "actor_id": actor_id,
+                "checkpoint_ns": "",
+            }
+        }
+
+        try:
+            await deferred.aput(
+                config,
+                checkpoint,
+                {"source": "input", "step": 1},
+                {},
+            )
+            assert deferred.has_buffered_checkpoint
+
+            result = await deferred.aflush()
+            assert deferred.is_empty
+            assert result is not None
+
+            # Verify persisted via sync read on the backend
+            saved_config: RunnableConfig = {
+                "configurable": {
+                    "thread_id": thread_id,
+                    "actor_id": actor_id,
+                    "checkpoint_ns": "",
+                    "checkpoint_id": checkpoint["id"],
+                }
+            }
+            persisted = saver.get_tuple(saved_config)
+            assert persisted is not None
+            assert persisted.checkpoint["id"] == checkpoint["id"]
+        finally:
+            cleanup(thread_id, actor_id)
+
+    @pytest.mark.asyncio
+    async def test_async_get_tuple_from_backend(
+        self, saver_and_cleanup: _SaverAndCleanup
+    ) -> None:
+        """aget_tuple() reads from the backend after aflush()."""
+        saver, cleanup, thread_id, actor_id = self._unpack(saver_and_cleanup)
+        if not _has_async_support(saver):
+            pytest.skip("Backend does not implement async methods")
+        deferred = DeferredCheckpointSaver(saver)
+        checkpoint = _make_checkpoint()
+
+        config: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "actor_id": actor_id,
+                "checkpoint_ns": "",
+            }
+        }
+
+        try:
+            await deferred.aput(
+                config,
+                checkpoint,
+                {"source": "input", "step": 1},
+                {},
+            )
+            await deferred.aflush()
+
+            result = await deferred.aget_tuple(config)
+            assert result is not None
+            assert result.checkpoint["id"] == checkpoint["id"]
+        finally:
+            cleanup(thread_id, actor_id)
+
+    @pytest.mark.asyncio
+    async def test_async_flush_on_exit_persists(
+        self, saver_and_cleanup: _SaverAndCleanup
+    ) -> None:
+        """aflush_on_exit() context manager persists on exit."""
+        saver, cleanup, thread_id, actor_id = self._unpack(saver_and_cleanup)
+        if not _has_async_support(saver):
+            pytest.skip("Backend does not implement async methods")
+        deferred = DeferredCheckpointSaver(saver)
+
+        config: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "actor_id": actor_id,
+                "checkpoint_ns": "",
+            }
+        }
+
+        try:
+            async with deferred.aflush_on_exit():
+                await deferred.aput(
+                    config,
+                    _make_checkpoint(),
+                    {"source": "input", "step": 1},
+                    {},
+                )
+
+            assert deferred.is_empty
+            assert len(list(saver.list(config))) >= 1
+        finally:
+            cleanup(thread_id, actor_id)
+
+    @pytest.mark.asyncio
+    async def test_async_list_after_flush(
+        self, saver_and_cleanup: _SaverAndCleanup
+    ) -> None:
+        """alist() returns flushed data from the backend."""
+        saver, cleanup, thread_id, actor_id = self._unpack(saver_and_cleanup)
+        if not _has_async_support(saver):
+            pytest.skip("Backend does not implement async methods")
+        deferred = DeferredCheckpointSaver(saver)
+
+        config: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "actor_id": actor_id,
+                "checkpoint_ns": "",
+            }
+        }
+
+        try:
+            deferred.put(
+                config,
+                _make_checkpoint(),
+                {"source": "input", "step": 1},
+                {},
+            )
+
+            # Before flush — alist should return nothing
+            pre_flush = [item async for item in deferred.alist(config)]
+            assert len(pre_flush) == 0
+
+            deferred.flush()
+
+            # After flush — alist should return the checkpoint
+            post_flush = [item async for item in deferred.alist(config)]
+            assert len(post_flush) >= 1
+        finally:
+            cleanup(thread_id, actor_id)
+
+    # ------------------------------------------------------------------
+    # Writes-only flush (no checkpoint)
+    # ------------------------------------------------------------------
+
+    def test_writes_only_flush_no_checkpoint(
+        self, saver_and_cleanup: _SaverAndCleanup
+    ) -> None:
+        """Flushing only writes (no buffered checkpoint) against real backend."""
+        saver, cleanup, thread_id, actor_id = self._unpack(saver_and_cleanup)
+        deferred = DeferredCheckpointSaver(saver)
+        checkpoint = _make_checkpoint()
+
+        config: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "actor_id": actor_id,
+                "checkpoint_ns": "",
+            }
+        }
+        write_config: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "actor_id": actor_id,
+                "checkpoint_ns": "",
+                "checkpoint_id": checkpoint["id"],
+            }
+        }
+
+        try:
+            # First persist the checkpoint directly so writes have a target
+            saver.put(
+                config,
+                checkpoint,
+                {"source": "input", "step": 1},
+                {},
+            )
+
+            # Now buffer only writes (no deferred.put)
+            deferred.put_writes(
+                write_config,
+                [("messages", "orphan-write")],
+                "task-1",
+            )
+            assert not deferred.has_buffered_checkpoint
+            assert deferred.has_buffered_writes
+
+            result = deferred.flush()
+            assert result is None  # No checkpoint was buffered
+            assert deferred.is_empty
+
+            # Verify the write landed
+            persisted = saver.get_tuple(write_config)
+            assert persisted is not None
+            assert persisted.pending_writes is not None
+            channels = [pw[1] for pw in persisted.pending_writes]
+            assert "messages" in channels
+        finally:
+            cleanup(thread_id, actor_id)

--- a/libs/langgraph-checkpoint-aws/tests/integration_tests/utils.py
+++ b/libs/langgraph-checkpoint-aws/tests/integration_tests/utils.py
@@ -1,0 +1,252 @@
+"""Shared utilities for integration tests.
+
+Provides common helpers for AWS resource setup and permission handling
+so individual test modules don't duplicate boilerplate.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any
+
+import boto3
+import pytest
+from botocore.exceptions import ClientError
+from langchain_core.runnables import RunnableConfig
+
+logger = logging.getLogger(__name__)
+
+
+def skip_on_aws_403(call_fn: Callable, description: str) -> Any:
+    """Execute *call_fn*; skip the test on AWS permission errors.
+
+    Args:
+        call_fn: Zero-argument callable that makes an AWS API call.
+        description: Human-readable label for the operation (used in
+            the skip message).
+
+    Returns:
+        Whatever *call_fn* returns on success.
+
+    Raises:
+        ClientError: Re-raised if the error is not a permission error.
+    """
+    try:
+        return call_fn()
+    except ClientError as e:
+        code = e.response["Error"]["Code"]
+        if code in ("AccessDenied", "AccessDeniedException", "403"):
+            pytest.skip(f"Insufficient permissions for {description}, skipping.")
+        else:
+            raise
+
+
+def ensure_dynamodb_table(
+    table_name: str,
+    region_name: str,
+) -> str:
+    """Ensure a DynamoDB table exists, creating it if needed.
+
+    The table uses a composite key (PK/SK) with PAY_PER_REQUEST billing,
+    matching the schema expected by ``DynamoDBSaver``.
+
+    Args:
+        table_name: Name of the DynamoDB table.
+        region_name: AWS region for the table.
+
+    Returns:
+        The table name (pass-through for convenience).
+    """
+    dynamodb = boto3.client("dynamodb", region_name=region_name)
+
+    try:
+        skip_on_aws_403(
+            lambda: dynamodb.describe_table(TableName=table_name),
+            f"DynamoDB DescribeTable on {table_name}",
+        )
+        logger.info("DynamoDB table '%s' already exists", table_name)
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "ResourceNotFoundException":
+            logger.info("Creating DynamoDB table '%s'...", table_name)
+            skip_on_aws_403(
+                lambda: dynamodb.create_table(
+                    TableName=table_name,
+                    KeySchema=[
+                        {"AttributeName": "PK", "KeyType": "HASH"},
+                        {"AttributeName": "SK", "KeyType": "RANGE"},
+                    ],
+                    AttributeDefinitions=[
+                        {"AttributeName": "PK", "AttributeType": "S"},
+                        {"AttributeName": "SK", "AttributeType": "S"},
+                    ],
+                    BillingMode="PAY_PER_REQUEST",
+                ),
+                "DynamoDB CreateTable",
+            )
+            waiter = dynamodb.get_waiter("table_exists")
+            skip_on_aws_403(
+                lambda: waiter.wait(TableName=table_name),
+                "DynamoDB WaitForTable",
+            )
+            logger.info("DynamoDB table '%s' created successfully", table_name)
+        else:
+            raise
+
+    return table_name
+
+
+def ensure_agentcore_memory(
+    memory_id: str,
+    region_name: str,
+) -> str:
+    """Ensure an AgentCore memory is accessible, creating one if needed.
+
+    Attempts to probe the given memory ID.  If the server rejects it
+    (validation error, not found), falls back to discovering an
+    existing ACTIVE memory or creating a new one.
+
+    Args:
+        memory_id: The memory ID to verify or create.
+        region_name: AWS region for the AgentCore service.
+
+    Returns:
+        A valid, reachable memory ID.
+    """
+    from langgraph_checkpoint_aws.agentcore.saver import (
+        AgentCoreMemorySaver,
+    )
+
+    saver = AgentCoreMemorySaver(memory_id=memory_id, region_name=region_name)
+    try:
+        config: RunnableConfig = {
+            "configurable": {
+                "thread_id": "probe0",
+                "actor_id": "probe0",
+                "checkpoint_ns": "",
+            }
+        }
+        list(saver.list(config))
+        logger.info("AgentCore memory '%s' is reachable", memory_id)
+        return memory_id
+    except Exception as e:
+        error_code = ""
+        if hasattr(e, "response"):
+            error_code = e.response.get("Error", {}).get("Code", "")
+        if error_code in (
+            "AccessDenied",
+            "AccessDeniedException",
+            "403",
+        ):
+            pytest.skip(
+                f"Insufficient permissions for AgentCore memory "
+                f"'{memory_id}', skipping."
+            )
+        if error_code in (
+            "ValidationException",
+            "ResourceNotFoundException",
+        ):
+            logger.info(
+                "Memory '%s' unavailable (%s), discovering or creating one.",
+                memory_id,
+                error_code,
+            )
+            return _discover_or_create_memory(region_name)
+        raise
+
+
+def _discover_or_create_memory(region_name: str) -> str:
+    """Find an existing AgentCore memory or create a new one.
+
+    Args:
+        region_name: AWS region for the AgentCore control plane.
+
+    Returns:
+        A valid memory ID.
+    """
+    control = skip_on_aws_403(
+        lambda: boto3.client("bedrock-agentcore-control", region_name=region_name),
+        "AgentCore control plane client",
+    )
+
+    # Try to reuse an existing ACTIVE memory
+    try:
+        resp = skip_on_aws_403(
+            lambda: control.list_memories(maxResults=5),
+            "AgentCore ListMemories",
+        )
+        for mem in resp.get("memories", []):
+            if mem.get("status") == "ACTIVE":
+                logger.info("Reusing existing AgentCore memory: %s", mem["id"])
+                return mem["id"]
+    except Exception:
+        logger.warning("Failed to list AgentCore memories, will create one.")
+
+    # No existing memory found — create one
+    try:
+        create_resp = skip_on_aws_403(
+            lambda: control.create_memory(
+                name="langraphIntegTest",
+            ),
+            "AgentCore CreateMemory",
+        )
+        new_id = create_resp["memory"]["id"]
+        logger.info("Created AgentCore memory: %s", new_id)
+
+        # Wait for ACTIVE status
+        import time
+
+        for _ in range(30):
+            status_resp = control.get_memory(memoryId=new_id)
+            if status_resp["memory"]["status"] == "ACTIVE":
+                return new_id
+            time.sleep(2)
+
+        pytest.skip(
+            f"AgentCore memory '{new_id}' did not become ACTIVE within timeout."
+        )
+    except Exception as exc:
+        pytest.skip(f"Failed to create AgentCore memory: {exc}")
+
+
+def create_bedrock_session(
+    region_name: str,
+) -> tuple[Any, str, Callable[[], None]]:
+    """Create a Bedrock session saver with a pre-created session.
+
+    ``BedrockSessionSaver`` requires a pre-created session whose UUID
+    is used as the ``thread_id``.  This helper creates the saver, a
+    session, and returns a cleanup callable.
+
+    Args:
+        region_name: AWS region for the Bedrock runtime.
+
+    Returns:
+        A tuple of ``(saver, session_id, cleanup_fn)`` where
+        *cleanup_fn* accepts no arguments and tears down the session.
+    """
+    from langgraph_checkpoint_aws.saver import BedrockSessionSaver
+
+    saver = BedrockSessionSaver(region_name=region_name)
+    client = saver.session_client.client
+
+    try:
+        session_resp = skip_on_aws_403(
+            lambda: client.create_session(),
+            "Bedrock CreateSession",
+        )
+    except ClientError:
+        pytest.skip("Failed to create Bedrock session, skipping.")
+
+    session_id = session_resp["sessionId"]
+    logger.info("Created Bedrock session: %s", session_id)
+
+    def cleanup() -> None:
+        try:
+            client.end_session(sessionIdentifier=session_id)
+            client.delete_session(sessionIdentifier=session_id)
+            logger.info("Deleted Bedrock session: %s", session_id)
+        except Exception:
+            logger.warning("Failed to delete Bedrock session: %s", session_id)
+
+    return saver, session_id, cleanup

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/conftest.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/conftest.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 import pytest
 from botocore.client import BaseClient
 from langgraph.checkpoint.base import Checkpoint, CheckpointMetadata
+from langgraph.checkpoint.memory import MemorySaver
 from langgraph.constants import TASKS
 
 from langgraph_checkpoint_aws.constants import CHECKPOINT_PREFIX, WRITES_PREFIX
@@ -270,3 +271,9 @@ def sample_checkpoint_metadata(sample_timestamp):
             "namespace2": "parent_checkpoint_2",
         },
     )
+
+
+@pytest.fixture
+def memory_saver():
+    """In-memory checkpoint saver for unit testing DeferredCheckpointSaver."""
+    return MemorySaver()

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/test_deferred_saver.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/test_deferred_saver.py
@@ -1,17 +1,4 @@
-"""Unit tests for DeferredCheckpointSaver.
-
-Covers the 10 correctness properties from the design document:
-1. After flush() succeeds, is_empty is True
-2. After flush() fails on checkpoint, has_buffered_checkpoint is still True
-3. After flush() fails on write N, writes 0..N-1 removed, N..end remain
-4. get_tuple() returns buffered data when thread_id + checkpoint_ns match
-5. get_tuple() delegates to underlying saver when buffer doesn't match
-6. list() never returns buffered data
-7. Context managers flush in finally — even on exception
-8. Concurrent put() + get_tuple() from different threads never raises
-9. DeferredCheckpointSaver(DeferredCheckpointSaver(x)) raises ValueError
-10. clear() discards all buffered data without persisting
-"""
+"""Unit tests for DeferredCheckpointSaver."""
 
 from __future__ import annotations
 
@@ -29,20 +16,18 @@ from langgraph.checkpoint.memory import MemorySaver
 
 from langgraph_checkpoint_aws.deferred_saver import DeferredCheckpointSaver
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
 
 def _make_config(
     thread_id: str = "thread-1",
     checkpoint_ns: str = "",
     checkpoint_id: str | None = None,
+    **extra: Any,
 ) -> RunnableConfig:
     cfg: RunnableConfig = {
         "configurable": {
             "thread_id": thread_id,
             "checkpoint_ns": checkpoint_ns,
+            **extra,
         }
     }
     if checkpoint_id is not None:
@@ -70,11 +55,6 @@ def _make_metadata(step: int = 0) -> CheckpointMetadata:
     )
 
 
-# ---------------------------------------------------------------------------
-# Init tests
-# ---------------------------------------------------------------------------
-
-
 class TestInit:
     """Initialization and nesting prevention."""
 
@@ -93,11 +73,6 @@ class TestInit:
         assert buffered.is_empty
         assert not buffered.has_buffered_checkpoint
         assert not buffered.has_buffered_writes
-
-
-# ---------------------------------------------------------------------------
-# Buffering tests
-# ---------------------------------------------------------------------------
 
 
 class TestBuffering:
@@ -157,11 +132,6 @@ class TestBuffering:
                 "task-1",
             )
             mock_pw.assert_not_called()
-
-
-# ---------------------------------------------------------------------------
-# get_tuple tests
-# ---------------------------------------------------------------------------
 
 
 class TestGetTuple:
@@ -259,11 +229,6 @@ class TestGetTuple:
         buffered = DeferredCheckpointSaver(memory_saver)
         result = buffered.get_tuple(_make_config())
         assert result is None
-
-
-# ---------------------------------------------------------------------------
-# Flush tests
-# ---------------------------------------------------------------------------
 
 
 class TestFlush:
@@ -379,11 +344,6 @@ class TestFlush:
         assert buffered.is_empty
 
 
-# ---------------------------------------------------------------------------
-# Context manager tests
-# ---------------------------------------------------------------------------
-
-
 class TestContextManagers:
     """flush_on_exit and aflush_on_exit."""
 
@@ -449,11 +409,6 @@ class TestContextManagers:
         assert buffered.is_empty
 
 
-# ---------------------------------------------------------------------------
-# Clear tests
-# ---------------------------------------------------------------------------
-
-
 class TestClear:
     """Property 10: clear() discards all buffered data without persisting."""
 
@@ -485,11 +440,6 @@ class TestClear:
             mock_put.assert_not_called()
 
 
-# ---------------------------------------------------------------------------
-# list() tests
-# ---------------------------------------------------------------------------
-
-
 class TestList:
     """Property 6: list() never returns buffered data."""
 
@@ -512,11 +462,6 @@ class TestList:
         assert len(results) == 1
 
 
-# ---------------------------------------------------------------------------
-# get_next_version delegation
-# ---------------------------------------------------------------------------
-
-
 class TestGetNextVersion:
     """get_next_version always delegates to the underlying saver."""
 
@@ -531,11 +476,6 @@ class TestGetNextVersion:
         v_buffered = buffered.get_next_version(None, None)
         v_saver = memory_saver.get_next_version(None, None)
         assert type(v_buffered) is type(v_saver)
-
-
-# ---------------------------------------------------------------------------
-# Config preservation
-# ---------------------------------------------------------------------------
 
 
 class TestConfigPreservation:
@@ -569,10 +509,43 @@ class TestConfigPreservation:
         assert result is not None
         assert result.config["configurable"]["checkpoint_id"] == "ckpt-1"
 
+    def test_extra_configurable_keys_preserved_in_put(
+        self, memory_saver: MemorySaver
+    ) -> None:
+        """Extra keys like actor_id must survive through put() and get_tuple()."""
+        buffered = DeferredCheckpointSaver(memory_saver)
+        config = _make_config(thread_id="t1", actor_id="actor-42", custom_key="val")
+        result = buffered.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), {})
 
-# ---------------------------------------------------------------------------
-# Parent config
-# ---------------------------------------------------------------------------
+        assert result["configurable"]["actor_id"] == "actor-42"
+        assert result["configurable"]["custom_key"] == "val"
+
+    def test_extra_configurable_keys_preserved_in_get_tuple(
+        self, memory_saver: MemorySaver
+    ) -> None:
+        """get_tuple result config preserves extra keys from the original put."""
+        buffered = DeferredCheckpointSaver(memory_saver)
+        config = _make_config(thread_id="t1", actor_id="actor-42")
+        buffered.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), {})
+
+        result = buffered.get_tuple(_make_config(thread_id="t1"))
+        assert result is not None
+        assert result.config["configurable"]["actor_id"] == "actor-42"
+
+    def test_extra_configurable_keys_preserved_in_parent_config(
+        self, memory_saver: MemorySaver
+    ) -> None:
+        """parent_config preserves extra keys from the original config."""
+        buffered = DeferredCheckpointSaver(memory_saver)
+        config = _make_config(
+            thread_id="t1", checkpoint_id="parent-ckpt", actor_id="actor-42"
+        )
+        buffered.put(config, _make_checkpoint("ckpt-2"), _make_metadata(), {})
+
+        result = buffered.get_tuple(_make_config(thread_id="t1"))
+        assert result is not None
+        assert result.parent_config is not None
+        assert result.parent_config["configurable"]["actor_id"] == "actor-42"
 
 
 class TestParentConfig:
@@ -601,11 +574,6 @@ class TestParentConfig:
         result = buffered.get_tuple(_make_config(thread_id="t1"))
         assert result is not None
         assert result.parent_config is None
-
-
-# ---------------------------------------------------------------------------
-# Thread safety
-# ---------------------------------------------------------------------------
 
 
 class TestThreadSafety:
@@ -678,11 +646,6 @@ class TestThreadSafety:
         assert buffered.has_buffered_writes
 
 
-# ---------------------------------------------------------------------------
-# Async tests
-# ---------------------------------------------------------------------------
-
-
 class TestAsync:
     """Async variants delegate correctly."""
 
@@ -753,11 +716,6 @@ class TestAsync:
         assert len(results) == 0
 
 
-# ---------------------------------------------------------------------------
-# Multi-session
-# ---------------------------------------------------------------------------
-
-
 class TestMultiSession:
     """Each flush_on_exit block handles one session independently."""
 
@@ -777,11 +735,6 @@ class TestMultiSession:
         r2 = list(buffered.list(_make_config(thread_id="session-2")))
         assert len(r1) == 1
         assert len(r2) == 1
-
-
-# ---------------------------------------------------------------------------
-# Clear with combined checkpoint + writes
-# ---------------------------------------------------------------------------
 
 
 class TestClearCombined:
@@ -828,11 +781,6 @@ class TestClearCombined:
         result = buffered.flush()
         assert result is None
         assert len(list(memory_saver.list(_make_config(thread_id="t1")))) == 0
-
-
-# ---------------------------------------------------------------------------
-# get_tuple delegation with pre-populated backend
-# ---------------------------------------------------------------------------
 
 
 class TestGetTupleDelegation:
@@ -884,11 +832,6 @@ class TestGetTupleDelegation:
         result = await buffered.aget_tuple(_make_config(thread_id="thread-B"))
         assert result is not None
         assert result.checkpoint["id"] == "ckpt-B"
-
-
-# ---------------------------------------------------------------------------
-# list() with filter, before, and limit parameters
-# ---------------------------------------------------------------------------
 
 
 class TestListParameters:
@@ -967,11 +910,6 @@ class TestListParameters:
         assert len(results) == 2
 
 
-# ---------------------------------------------------------------------------
-# Flush write-drain identity guard (gap #5)
-# ---------------------------------------------------------------------------
-
-
 class TestFlushWriteDrainIdentityGuard:
     """The pop after successful write I/O uses ``is`` identity comparison.
 
@@ -1037,11 +975,6 @@ class TestFlushWriteDrainIdentityGuard:
         assert deferred.is_empty
 
 
-# ---------------------------------------------------------------------------
-# Concurrent flush() + flush() (gap #15)
-# ---------------------------------------------------------------------------
-
-
 class TestConcurrentFlush:
     """Two threads calling flush() concurrently must not double-persist."""
 
@@ -1103,11 +1036,6 @@ class TestConcurrentFlush:
         assert put_writes_call_count == 1
 
 
-# ---------------------------------------------------------------------------
-# Async flush — write failure keeps remaining (gap #6)
-# ---------------------------------------------------------------------------
-
-
 class TestAsyncFlushWriteFailure:
     """aflush() partial write failure must keep remaining writes in buffer."""
 
@@ -1145,11 +1073,6 @@ class TestAsyncFlushWriteFailure:
         # First write succeeded and was removed; second failed and remains
         # along with the third.
         assert buffered.has_buffered_writes
-
-
-# ---------------------------------------------------------------------------
-# Async flush — checkpoint failure race guard (gap #7)
-# ---------------------------------------------------------------------------
 
 
 class TestAsyncFlushCheckpointRace:

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/test_deferred_saver.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/test_deferred_saver.py
@@ -1,0 +1,1184 @@
+"""Unit tests for DeferredCheckpointSaver.
+
+Covers the 10 correctness properties from the design document:
+1. After flush() succeeds, is_empty is True
+2. After flush() fails on checkpoint, has_buffered_checkpoint is still True
+3. After flush() fails on write N, writes 0..N-1 removed, N..end remain
+4. get_tuple() returns buffered data when thread_id + checkpoint_ns match
+5. get_tuple() delegates to underlying saver when buffer doesn't match
+6. list() never returns buffered data
+7. Context managers flush in finally — even on exception
+8. Concurrent put() + get_tuple() from different threads never raises
+9. DeferredCheckpointSaver(DeferredCheckpointSaver(x)) raises ValueError
+10. clear() discards all buffered data without persisting
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from langchain_core.runnables import RunnableConfig
+from langgraph.checkpoint.base import (
+    Checkpoint,
+    CheckpointMetadata,
+)
+from langgraph.checkpoint.memory import MemorySaver
+
+from langgraph_checkpoint_aws.deferred_saver import DeferredCheckpointSaver
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config(
+    thread_id: str = "thread-1",
+    checkpoint_ns: str = "",
+    checkpoint_id: str | None = None,
+) -> RunnableConfig:
+    cfg: RunnableConfig = {
+        "configurable": {
+            "thread_id": thread_id,
+            "checkpoint_ns": checkpoint_ns,
+        }
+    }
+    if checkpoint_id is not None:
+        cfg["configurable"]["checkpoint_id"] = checkpoint_id
+    return cfg
+
+
+def _make_checkpoint(checkpoint_id: str = "ckpt-1") -> Checkpoint:
+    return Checkpoint(
+        v=1,
+        id=checkpoint_id,
+        ts="2025-01-01T00:00:00+00:00",
+        channel_values={"messages": ["hello"]},
+        channel_versions={"messages": "v1"},
+        versions_seen={"node1": {"messages": "v1"}},
+        updated_channels=None,
+    )
+
+
+def _make_metadata(step: int = 0) -> CheckpointMetadata:
+    return CheckpointMetadata(
+        source="input",
+        step=step,
+        parents={},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Init tests
+# ---------------------------------------------------------------------------
+
+
+class TestInit:
+    """Initialization and nesting prevention."""
+
+    def test_wraps_saver(self, memory_saver: MemorySaver) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver)
+        assert buffered.saver is memory_saver
+
+    def test_nesting_raises_value_error(self, memory_saver: MemorySaver) -> None:
+        """Property 9: DeferredCheckpointSaver(DeferredCheckpointSaver(x)) raises."""
+        buffered = DeferredCheckpointSaver(memory_saver)
+        with pytest.raises(ValueError, match="Nesting"):
+            DeferredCheckpointSaver(buffered)
+
+    def test_starts_empty(self, memory_saver: MemorySaver) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver)
+        assert buffered.is_empty
+        assert not buffered.has_buffered_checkpoint
+        assert not buffered.has_buffered_writes
+
+
+# ---------------------------------------------------------------------------
+# Buffering tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuffering:
+    """put() and put_writes() buffer correctly."""
+
+    def test_put_buffers_checkpoint(self, memory_saver: MemorySaver) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver)
+        config = _make_config()
+        checkpoint = _make_checkpoint()
+        metadata = _make_metadata()
+
+        result = buffered.put(config, checkpoint, metadata, {})
+
+        assert buffered.has_buffered_checkpoint
+        assert not buffered.is_empty
+        assert result["configurable"]["checkpoint_id"] == "ckpt-1"
+
+    def test_put_overwrites_previous(self, memory_saver: MemorySaver) -> None:
+        """Only the latest checkpoint is kept."""
+        buffered = DeferredCheckpointSaver(memory_saver)
+        config = _make_config()
+
+        buffered.put(config, _make_checkpoint("ckpt-1"), _make_metadata(0), {})
+        buffered.put(config, _make_checkpoint("ckpt-2"), _make_metadata(1), {})
+
+        # get_tuple should return the second checkpoint
+        result = buffered.get_tuple(_make_config())
+        assert result is not None
+        assert result.checkpoint["id"] == "ckpt-2"
+
+    def test_put_writes_accumulates(self, memory_saver: MemorySaver) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver)
+        config = _make_config(checkpoint_id="ckpt-1")
+
+        buffered.put_writes(config, [("ch1", "v1")], "task-1")
+        buffered.put_writes(config, [("ch2", "v2")], "task-2")
+
+        assert buffered.has_buffered_writes
+
+    def test_put_does_not_call_underlying_saver(
+        self, memory_saver: MemorySaver
+    ) -> None:
+        """put() should never trigger I/O on the underlying saver."""
+        buffered = DeferredCheckpointSaver(memory_saver)
+        with patch.object(memory_saver, "put") as mock_put:
+            buffered.put(_make_config(), _make_checkpoint(), _make_metadata(), {})
+            mock_put.assert_not_called()
+
+    def test_put_writes_does_not_call_underlying_saver(
+        self, memory_saver: MemorySaver
+    ) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver)
+        with patch.object(memory_saver, "put_writes") as mock_pw:
+            buffered.put_writes(
+                _make_config(checkpoint_id="ckpt-1"),
+                [("ch", "val")],
+                "task-1",
+            )
+            mock_pw.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# get_tuple tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetTuple:
+    """Buffer-first read logic."""
+
+    def test_returns_buffered_when_matching(self, memory_saver: MemorySaver) -> None:
+        """Property 4: get_tuple returns buffered data on match."""
+        buffered = DeferredCheckpointSaver(memory_saver)
+        config = _make_config(thread_id="t1", checkpoint_ns="ns1")
+        checkpoint = _make_checkpoint("ckpt-1")
+
+        buffered.put(config, checkpoint, _make_metadata(), {})
+
+        result = buffered.get_tuple(_make_config(thread_id="t1", checkpoint_ns="ns1"))
+        assert result is not None
+        assert result.checkpoint["id"] == "ckpt-1"
+
+    def test_delegates_when_no_match(self, memory_saver: MemorySaver) -> None:
+        """Property 5: get_tuple delegates when buffer doesn't match."""
+        buffered = DeferredCheckpointSaver(memory_saver)
+        config = _make_config(thread_id="t1")
+        buffered.put(config, _make_checkpoint(), _make_metadata(), {})
+
+        # Query for a different thread
+        result = buffered.get_tuple(_make_config(thread_id="t2"))
+        # MemorySaver has nothing for t2
+        assert result is None
+
+    def test_delegates_when_checkpoint_ns_differs(
+        self, memory_saver: MemorySaver
+    ) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver)
+        config = _make_config(thread_id="t1", checkpoint_ns="ns1")
+        buffered.put(config, _make_checkpoint(), _make_metadata(), {})
+
+        result = buffered.get_tuple(_make_config(thread_id="t1", checkpoint_ns="ns2"))
+        assert result is None
+
+    def test_matches_specific_checkpoint_id(self, memory_saver: MemorySaver) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver)
+        config = _make_config(thread_id="t1")
+        buffered.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), {})
+
+        # Exact match
+        result = buffered.get_tuple(
+            _make_config(thread_id="t1", checkpoint_id="ckpt-1")
+        )
+        assert result is not None
+        assert result.checkpoint["id"] == "ckpt-1"
+
+    def test_no_match_when_checkpoint_id_differs(
+        self, memory_saver: MemorySaver
+    ) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver)
+        config = _make_config(thread_id="t1")
+        buffered.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), {})
+
+        result = buffered.get_tuple(
+            _make_config(thread_id="t1", checkpoint_id="ckpt-999")
+        )
+        # Falls through to underlying saver which has nothing
+        assert result is None
+
+    def test_includes_matching_pending_writes(self, memory_saver: MemorySaver) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver)
+        config = _make_config(thread_id="t1")
+        buffered.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), {})
+
+        write_config = _make_config(thread_id="t1", checkpoint_id="ckpt-1")
+        buffered.put_writes(write_config, [("ch1", "v1")], "task-1")
+        buffered.put_writes(write_config, [("ch2", "v2")], "task-2")
+
+        result = buffered.get_tuple(_make_config(thread_id="t1"))
+        assert result is not None
+        assert result.pending_writes is not None
+        assert len(result.pending_writes) == 2
+
+    def test_excludes_writes_for_different_checkpoint(
+        self, memory_saver: MemorySaver
+    ) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver)
+        config = _make_config(thread_id="t1")
+        buffered.put(config, _make_checkpoint("ckpt-2"), _make_metadata(), {})
+
+        # Writes for a different checkpoint_id
+        old_write_config = _make_config(thread_id="t1", checkpoint_id="ckpt-1")
+        buffered.put_writes(old_write_config, [("ch1", "v1")], "task-1")
+
+        result = buffered.get_tuple(_make_config(thread_id="t1"))
+        assert result is not None
+        # No matching writes
+        assert result.pending_writes is None
+
+    def test_empty_buffer_delegates(self, memory_saver: MemorySaver) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver)
+        result = buffered.get_tuple(_make_config())
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Flush tests
+# ---------------------------------------------------------------------------
+
+
+class TestFlush:
+    """Flush mechanics and error handling."""
+
+    def test_flush_persists_checkpoint(self, memory_saver: MemorySaver) -> None:
+        """Property 1: After flush() succeeds, is_empty is True."""
+        buffered = DeferredCheckpointSaver(memory_saver)
+        config = _make_config(thread_id="t1")
+        buffered.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), {})
+
+        result = buffered.flush()
+
+        assert buffered.is_empty
+        assert result is not None
+        assert result["configurable"]["checkpoint_id"] == "ckpt-1"
+
+    def test_flush_persists_writes(self, memory_saver: MemorySaver) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver)
+        config = _make_config(thread_id="t1")
+        buffered.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), {})
+
+        write_config = _make_config(thread_id="t1", checkpoint_id="ckpt-1")
+        buffered.put_writes(write_config, [("ch1", "v1")], "task-1")
+
+        buffered.flush()
+        assert buffered.is_empty
+        assert not buffered.has_buffered_writes
+
+    def test_flush_returns_none_when_empty(self, memory_saver: MemorySaver) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver)
+        result = buffered.flush()
+        assert result is None
+
+    def test_flush_checkpoint_failure_restores_buffer(
+        self, memory_saver: MemorySaver
+    ) -> None:
+        """Property 2: flush() fail on checkpoint keeps buffer."""
+        buffered = DeferredCheckpointSaver(memory_saver)
+        config = _make_config(thread_id="t1")
+        buffered.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), {})
+
+        with patch.object(
+            memory_saver, "put", side_effect=RuntimeError("network error")
+        ):
+            with pytest.raises(RuntimeError, match="network error"):
+                buffered.flush()
+
+        assert buffered.has_buffered_checkpoint
+
+    def test_flush_failure_does_not_clobber_new_checkpoint(
+        self, memory_saver: MemorySaver
+    ) -> None:
+        """Restore on failure must not overwrite a checkpoint that arrived
+        during the network I/O window."""
+        deferred = DeferredCheckpointSaver(memory_saver)
+        config = _make_config(thread_id="t1")
+        deferred.put(config, _make_checkpoint("ckpt-old"), _make_metadata(), {})
+
+        def failing_put_that_races(*args, **kwargs):
+            # Simulate a new put() arriving while flush is doing I/O
+            deferred.put(config, _make_checkpoint("ckpt-new"), _make_metadata(1), {})
+            msg = "network error"
+            raise RuntimeError(msg)
+
+        with patch.object(memory_saver, "put", side_effect=failing_put_that_races):
+            with pytest.raises(RuntimeError, match="network error"):
+                deferred.flush()
+
+        # ckpt-new must survive — not be clobbered by ckpt-old restore
+        result = deferred.get_tuple(_make_config(thread_id="t1"))
+        assert result is not None
+        assert result.checkpoint["id"] == "ckpt-new"
+
+    def test_flush_write_failure_keeps_remaining(
+        self, memory_saver: MemorySaver
+    ) -> None:
+        """Property 3: Partial write failure keeps remaining."""
+        buffered = DeferredCheckpointSaver(memory_saver)
+
+        write_config = _make_config(thread_id="t1", checkpoint_id="ckpt-1")
+        buffered.put_writes(write_config, [("ch1", "v1")], "task-1")
+        buffered.put_writes(write_config, [("ch2", "v2")], "task-2")
+        buffered.put_writes(write_config, [("ch3", "v3")], "task-3")
+
+        call_count = 0
+
+        original_put_writes = memory_saver.put_writes
+
+        def failing_put_writes(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                raise RuntimeError("write failed")
+            return original_put_writes(*args, **kwargs)
+
+        with patch.object(memory_saver, "put_writes", side_effect=failing_put_writes):
+            with pytest.raises(RuntimeError, match="write failed"):
+                buffered.flush()
+
+        # First write succeeded and was removed, second failed and remains
+        # along with the third
+        assert buffered.has_buffered_writes
+
+    def test_flush_only_writes_no_checkpoint(self, memory_saver: MemorySaver) -> None:
+        """Flush works when only writes are buffered (no checkpoint)."""
+        buffered = DeferredCheckpointSaver(memory_saver)
+        write_config = _make_config(thread_id="t1", checkpoint_id="ckpt-1")
+        buffered.put_writes(write_config, [("ch1", "v1")], "task-1")
+
+        result = buffered.flush()
+        assert result is None
+        assert buffered.is_empty
+
+
+# ---------------------------------------------------------------------------
+# Context manager tests
+# ---------------------------------------------------------------------------
+
+
+class TestContextManagers:
+    """flush_on_exit and aflush_on_exit."""
+
+    def test_flush_on_exit_flushes(self, memory_saver: MemorySaver) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver)
+        config = _make_config(thread_id="t1")
+
+        with buffered.flush_on_exit():
+            buffered.put(config, _make_checkpoint(), _make_metadata(), {})
+
+        assert buffered.is_empty
+
+    def test_flush_on_exit_yields_self(self, memory_saver: MemorySaver) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver)
+        with buffered.flush_on_exit() as ctx:
+            assert ctx is buffered
+
+    def test_flush_on_exit_flushes_on_exception(
+        self, memory_saver: MemorySaver
+    ) -> None:
+        """Property 7: Context managers flush in finally — even on exception."""
+        buffered = DeferredCheckpointSaver(memory_saver)
+        config = _make_config(thread_id="t1")
+
+        with pytest.raises(ValueError, match="boom"):
+            with buffered.flush_on_exit():
+                buffered.put(config, _make_checkpoint(), _make_metadata(), {})
+                msg = "boom"
+                raise ValueError(msg)
+
+        # Data was flushed despite the exception
+        assert buffered.is_empty
+
+    @pytest.mark.asyncio
+    async def test_aflush_on_exit_flushes(self, memory_saver: MemorySaver) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver)
+        config = _make_config(thread_id="t1")
+
+        async with buffered.aflush_on_exit():
+            buffered.put(config, _make_checkpoint(), _make_metadata(), {})
+
+        assert buffered.is_empty
+
+    @pytest.mark.asyncio
+    async def test_aflush_on_exit_yields_self(self, memory_saver: MemorySaver) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver)
+        async with buffered.aflush_on_exit() as ctx:
+            assert ctx is buffered
+
+    @pytest.mark.asyncio
+    async def test_aflush_on_exit_flushes_on_exception(
+        self, memory_saver: MemorySaver
+    ) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver)
+        config = _make_config(thread_id="t1")
+
+        with pytest.raises(ValueError, match="boom"):
+            async with buffered.aflush_on_exit():
+                buffered.put(config, _make_checkpoint(), _make_metadata(), {})
+                msg = "boom"
+                raise ValueError(msg)
+
+        assert buffered.is_empty
+
+
+# ---------------------------------------------------------------------------
+# Clear tests
+# ---------------------------------------------------------------------------
+
+
+class TestClear:
+    """Property 10: clear() discards all buffered data without persisting."""
+
+    def test_clear_discards_checkpoint(self, memory_saver: MemorySaver) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver)
+        config = _make_config()
+        buffered.put(config, _make_checkpoint(), _make_metadata(), {})
+
+        buffered.clear()
+
+        assert buffered.is_empty
+
+    def test_clear_discards_writes(self, memory_saver: MemorySaver) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver)
+        write_config = _make_config(checkpoint_id="ckpt-1")
+        buffered.put_writes(write_config, [("ch1", "v1")], "task-1")
+
+        buffered.clear()
+
+        assert buffered.is_empty
+
+    def test_clear_does_not_persist(self, memory_saver: MemorySaver) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver)
+        config = _make_config(thread_id="t1")
+        buffered.put(config, _make_checkpoint(), _make_metadata(), {})
+
+        with patch.object(memory_saver, "put") as mock_put:
+            buffered.clear()
+            mock_put.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# list() tests
+# ---------------------------------------------------------------------------
+
+
+class TestList:
+    """Property 6: list() never returns buffered data."""
+
+    def test_list_delegates_to_underlying(self, memory_saver: MemorySaver) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver)
+        config = _make_config(thread_id="t1")
+        buffered.put(config, _make_checkpoint(), _make_metadata(), {})
+
+        results = list(buffered.list(_make_config(thread_id="t1")))
+        # MemorySaver has nothing persisted yet
+        assert len(results) == 0
+
+    def test_list_shows_flushed_data(self, memory_saver: MemorySaver) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver)
+        config = _make_config(thread_id="t1")
+        buffered.put(config, _make_checkpoint(), _make_metadata(), {})
+        buffered.flush()
+
+        results = list(buffered.list(_make_config(thread_id="t1")))
+        assert len(results) == 1
+
+
+# ---------------------------------------------------------------------------
+# get_next_version delegation
+# ---------------------------------------------------------------------------
+
+
+class TestGetNextVersion:
+    """get_next_version always delegates to the underlying saver."""
+
+    def test_delegates_to_saver(self, memory_saver: MemorySaver) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver)
+        v = buffered.get_next_version(None, None)
+        # MemorySaver uses string versions; just verify it returns a value
+        assert v is not None
+
+    def test_type_matches_saver(self, memory_saver: MemorySaver) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver)
+        v_buffered = buffered.get_next_version(None, None)
+        v_saver = memory_saver.get_next_version(None, None)
+        assert type(v_buffered) is type(v_saver)
+
+
+# ---------------------------------------------------------------------------
+# Config preservation
+# ---------------------------------------------------------------------------
+
+
+class TestConfigPreservation:
+    """Returned configs contain the correct identifiers."""
+
+    def test_put_returns_correct_config(self, memory_saver: MemorySaver) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver)
+        config = _make_config(thread_id="t1", checkpoint_ns="ns1")
+        result = buffered.put(config, _make_checkpoint("ckpt-42"), _make_metadata(), {})
+        assert result["configurable"]["thread_id"] == "t1"
+        assert result["configurable"]["checkpoint_ns"] == "ns1"
+        assert result["configurable"]["checkpoint_id"] == "ckpt-42"
+
+    def test_flush_returns_saver_config(self, memory_saver: MemorySaver) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver)
+        config = _make_config(thread_id="t1")
+        buffered.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), {})
+
+        result = buffered.flush()
+        assert result is not None
+        assert "configurable" in result
+
+    def test_get_tuple_config_has_checkpoint_id(
+        self, memory_saver: MemorySaver
+    ) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver)
+        config = _make_config(thread_id="t1")
+        buffered.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), {})
+
+        result = buffered.get_tuple(_make_config(thread_id="t1"))
+        assert result is not None
+        assert result.config["configurable"]["checkpoint_id"] == "ckpt-1"
+
+
+# ---------------------------------------------------------------------------
+# Parent config
+# ---------------------------------------------------------------------------
+
+
+class TestParentConfig:
+    """get_tuple builds parent_config from the original config's checkpoint_id."""
+
+    def test_parent_config_from_original_checkpoint_id(
+        self, memory_saver: MemorySaver
+    ) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver)
+        config = _make_config(thread_id="t1", checkpoint_id="parent-ckpt")
+        buffered.put(config, _make_checkpoint("ckpt-2"), _make_metadata(), {})
+
+        result = buffered.get_tuple(_make_config(thread_id="t1"))
+        assert result is not None
+        assert result.parent_config is not None
+        assert result.parent_config["configurable"]["checkpoint_id"] == "parent-ckpt"
+
+    def test_no_parent_config_on_first_checkpoint(
+        self, memory_saver: MemorySaver
+    ) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver)
+        # No checkpoint_id in the original config
+        config = _make_config(thread_id="t1")
+        buffered.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), {})
+
+        result = buffered.get_tuple(_make_config(thread_id="t1"))
+        assert result is not None
+        assert result.parent_config is None
+
+
+# ---------------------------------------------------------------------------
+# Thread safety
+# ---------------------------------------------------------------------------
+
+
+class TestThreadSafety:
+    """Property 8: Concurrent put() + get_tuple() never raises."""
+
+    def test_concurrent_put_and_get_tuple(self, memory_saver: MemorySaver) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver)
+        errors: list[Exception] = []
+        iterations = 200
+
+        def writer() -> None:
+            try:
+                for i in range(iterations):
+                    config = _make_config(thread_id="t1")
+                    buffered.put(
+                        config,
+                        _make_checkpoint(f"ckpt-{i}"),
+                        _make_metadata(i),
+                        {},
+                    )
+            except Exception as e:
+                errors.append(e)
+
+        def reader() -> None:
+            try:
+                for _ in range(iterations):
+                    buffered.get_tuple(_make_config(thread_id="t1"))
+            except Exception as e:
+                errors.append(e)
+
+        threads = [
+            threading.Thread(target=writer),
+            threading.Thread(target=reader),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(errors) == 0
+
+    def test_concurrent_put_writes(self, memory_saver: MemorySaver) -> None:
+        """Simulates parallel branches calling put_writes concurrently."""
+        buffered = DeferredCheckpointSaver(memory_saver)
+        errors: list[Exception] = []
+        iterations = 200
+
+        def write_worker(task_id: str) -> None:
+            try:
+                for i in range(iterations):
+                    config = _make_config(thread_id="t1", checkpoint_id="ckpt-1")
+                    buffered.put_writes(
+                        config,
+                        [(f"ch-{task_id}-{i}", f"val-{i}")],
+                        task_id,
+                    )
+            except Exception as e:
+                errors.append(e)
+
+        threads = [
+            threading.Thread(target=write_worker, args=("task-a",)),
+            threading.Thread(target=write_worker, args=("task-b",)),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(errors) == 0
+        assert buffered.has_buffered_writes
+
+
+# ---------------------------------------------------------------------------
+# Async tests
+# ---------------------------------------------------------------------------
+
+
+class TestAsync:
+    """Async variants delegate correctly."""
+
+    @pytest.mark.asyncio
+    async def test_aput_buffers(self, memory_saver: MemorySaver) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver)
+        config = _make_config(thread_id="t1")
+        result = await buffered.aput(
+            config, _make_checkpoint("ckpt-1"), _make_metadata(), {}
+        )
+        assert buffered.has_buffered_checkpoint
+        assert result["configurable"]["checkpoint_id"] == "ckpt-1"
+
+    @pytest.mark.asyncio
+    async def test_aput_writes_buffers(self, memory_saver: MemorySaver) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver)
+        config = _make_config(checkpoint_id="ckpt-1")
+        await buffered.aput_writes(config, [("ch1", "v1")], "task-1")
+        assert buffered.has_buffered_writes
+
+    @pytest.mark.asyncio
+    async def test_aget_tuple_returns_buffered(self, memory_saver: MemorySaver) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver)
+        config = _make_config(thread_id="t1")
+        buffered.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), {})
+
+        result = await buffered.aget_tuple(_make_config(thread_id="t1"))
+        assert result is not None
+        assert result.checkpoint["id"] == "ckpt-1"
+
+    @pytest.mark.asyncio
+    async def test_aflush_persists(self, memory_saver: MemorySaver) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver)
+        config = _make_config(thread_id="t1")
+        buffered.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), {})
+
+        result = await buffered.aflush()
+        assert buffered.is_empty
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_aflush_checkpoint_failure_restores(
+        self, memory_saver: MemorySaver
+    ) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver)
+        config = _make_config(thread_id="t1")
+        buffered.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), {})
+
+        with patch.object(
+            memory_saver,
+            "aput",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("async fail"),
+        ):
+            with pytest.raises(RuntimeError, match="async fail"):
+                await buffered.aflush()
+
+        assert buffered.has_buffered_checkpoint
+
+    @pytest.mark.asyncio
+    async def test_alist_delegates(self, memory_saver: MemorySaver) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver)
+        config = _make_config(thread_id="t1")
+        buffered.put(config, _make_checkpoint(), _make_metadata(), {})
+
+        results = [item async for item in buffered.alist(_make_config(thread_id="t1"))]
+        # Not flushed yet, so nothing in underlying saver
+        assert len(results) == 0
+
+
+# ---------------------------------------------------------------------------
+# Multi-session
+# ---------------------------------------------------------------------------
+
+
+class TestMultiSession:
+    """Each flush_on_exit block handles one session independently."""
+
+    def test_sequential_sessions(self, memory_saver: MemorySaver) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver)
+
+        with buffered.flush_on_exit():
+            config1 = _make_config(thread_id="session-1")
+            buffered.put(config1, _make_checkpoint("ckpt-s1"), _make_metadata(), {})
+
+        with buffered.flush_on_exit():
+            config2 = _make_config(thread_id="session-2")
+            buffered.put(config2, _make_checkpoint("ckpt-s2"), _make_metadata(), {})
+
+        # Both sessions persisted
+        r1 = list(buffered.list(_make_config(thread_id="session-1")))
+        r2 = list(buffered.list(_make_config(thread_id="session-2")))
+        assert len(r1) == 1
+        assert len(r2) == 1
+
+
+# ---------------------------------------------------------------------------
+# Clear with combined checkpoint + writes
+# ---------------------------------------------------------------------------
+
+
+class TestClearCombined:
+    """clear() discards both checkpoint and writes when both are buffered."""
+
+    def test_clear_discards_checkpoint_and_writes(
+        self, memory_saver: MemorySaver
+    ) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver)
+        config = _make_config(thread_id="t1")
+        buffered.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), {})
+
+        write_config = _make_config(thread_id="t1", checkpoint_id="ckpt-1")
+        buffered.put_writes(write_config, [("ch1", "v1")], "task-1")
+        buffered.put_writes(write_config, [("ch2", "v2")], "task-2")
+
+        assert buffered.has_buffered_checkpoint
+        assert buffered.has_buffered_writes
+
+        buffered.clear()
+
+        assert buffered.is_empty
+        assert not buffered.has_buffered_checkpoint
+        assert not buffered.has_buffered_writes
+
+    def test_clear_combined_does_not_persist(self, memory_saver: MemorySaver) -> None:
+        """Nothing reaches the backend after clearing combined state."""
+        buffered = DeferredCheckpointSaver(memory_saver)
+        config = _make_config(thread_id="t1")
+        buffered.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), {})
+
+        write_config = _make_config(thread_id="t1", checkpoint_id="ckpt-1")
+        buffered.put_writes(write_config, [("ch1", "v1")], "task-1")
+
+        with (
+            patch.object(memory_saver, "put") as mock_put,
+            patch.object(memory_saver, "put_writes") as mock_pw,
+        ):
+            buffered.clear()
+            mock_put.assert_not_called()
+            mock_pw.assert_not_called()
+
+        # Flushing after clear should be a no-op
+        result = buffered.flush()
+        assert result is None
+        assert len(list(memory_saver.list(_make_config(thread_id="t1")))) == 0
+
+
+# ---------------------------------------------------------------------------
+# get_tuple delegation with pre-populated backend
+# ---------------------------------------------------------------------------
+
+
+class TestGetTupleDelegation:
+    """get_tuple falls through to the underlying saver and returns real data."""
+
+    def test_delegates_to_populated_backend(self, memory_saver: MemorySaver) -> None:
+        """Buffer miss for thread-A delegates to backend which has thread-B data."""
+        # Pre-populate the backend with a checkpoint for thread-B
+        config_b = _make_config(thread_id="thread-B")
+        ckpt_b = _make_checkpoint("ckpt-B")
+        memory_saver.put(config_b, ckpt_b, _make_metadata(), {})
+
+        buffered = DeferredCheckpointSaver(memory_saver)
+
+        # Buffer a checkpoint for thread-A
+        config_a = _make_config(thread_id="thread-A")
+        buffered.put(config_a, _make_checkpoint("ckpt-A"), _make_metadata(), {})
+
+        # Query thread-B — buffer has thread-A, so it must delegate
+        result = buffered.get_tuple(_make_config(thread_id="thread-B"))
+        assert result is not None
+        assert result.checkpoint["id"] == "ckpt-B"
+
+    def test_buffer_hit_does_not_query_backend(self, memory_saver: MemorySaver) -> None:
+        """When the buffer matches, the underlying saver is never called."""
+        buffered = DeferredCheckpointSaver(memory_saver)
+        config = _make_config(thread_id="t1")
+        buffered.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), {})
+
+        with patch.object(memory_saver, "get_tuple") as mock_get:
+            result = buffered.get_tuple(_make_config(thread_id="t1"))
+            mock_get.assert_not_called()
+
+        assert result is not None
+        assert result.checkpoint["id"] == "ckpt-1"
+
+    @pytest.mark.asyncio
+    async def test_aget_tuple_delegates_to_populated_backend(
+        self, memory_saver: MemorySaver
+    ) -> None:
+        """Async variant also delegates on buffer miss."""
+        config_b = _make_config(thread_id="thread-B")
+        memory_saver.put(config_b, _make_checkpoint("ckpt-B"), _make_metadata(), {})
+
+        buffered = DeferredCheckpointSaver(memory_saver)
+        config_a = _make_config(thread_id="thread-A")
+        buffered.put(config_a, _make_checkpoint("ckpt-A"), _make_metadata(), {})
+
+        result = await buffered.aget_tuple(_make_config(thread_id="thread-B"))
+        assert result is not None
+        assert result.checkpoint["id"] == "ckpt-B"
+
+
+# ---------------------------------------------------------------------------
+# list() with filter, before, and limit parameters
+# ---------------------------------------------------------------------------
+
+
+class TestListParameters:
+    """list() and alist() forward filter/before/limit to the underlying saver."""
+
+    def _populate_three_checkpoints(self, memory_saver: MemorySaver) -> list[str]:
+        """Flush three checkpoints into the backend, return their IDs."""
+        ids = ["ckpt-1", "ckpt-2", "ckpt-3"]
+        config = _make_config(thread_id="t1")
+        for i, cid in enumerate(ids):
+            memory_saver.put(config, _make_checkpoint(cid), _make_metadata(i), {})
+        return ids
+
+    def test_list_with_limit(self, memory_saver: MemorySaver) -> None:
+        self._populate_three_checkpoints(memory_saver)
+        buffered = DeferredCheckpointSaver(memory_saver)
+
+        results = list(buffered.list(_make_config(thread_id="t1"), limit=2))
+        assert len(results) == 2
+
+    def test_list_with_before(self, memory_saver: MemorySaver) -> None:
+        self._populate_three_checkpoints(memory_saver)
+        buffered = DeferredCheckpointSaver(memory_saver)
+
+        # Get all checkpoints to find the latest one
+        all_results = list(buffered.list(_make_config(thread_id="t1")))
+        assert len(all_results) == 3
+
+        # Use the latest checkpoint as the "before" cursor
+        latest = all_results[0]
+        before_config = latest.config
+
+        results = list(
+            buffered.list(_make_config(thread_id="t1"), before=before_config)
+        )
+        # Should exclude the latest, returning the older ones
+        assert len(results) == 2
+        for r in results:
+            assert r.checkpoint["id"] != latest.checkpoint["id"]
+
+    def test_list_limit_one_returns_latest(self, memory_saver: MemorySaver) -> None:
+        ids = self._populate_three_checkpoints(memory_saver)
+        buffered = DeferredCheckpointSaver(memory_saver)
+
+        results = list(buffered.list(_make_config(thread_id="t1"), limit=1))
+        assert len(results) == 1
+        # MemorySaver returns newest first
+        assert results[0].checkpoint["id"] == ids[-1]
+
+    @pytest.mark.asyncio
+    async def test_alist_with_limit(self, memory_saver: MemorySaver) -> None:
+        self._populate_three_checkpoints(memory_saver)
+        buffered = DeferredCheckpointSaver(memory_saver)
+
+        results = [
+            item async for item in buffered.alist(_make_config(thread_id="t1"), limit=2)
+        ]
+        assert len(results) == 2
+
+    @pytest.mark.asyncio
+    async def test_alist_with_before(self, memory_saver: MemorySaver) -> None:
+        self._populate_three_checkpoints(memory_saver)
+        buffered = DeferredCheckpointSaver(memory_saver)
+
+        all_results = [
+            item async for item in buffered.alist(_make_config(thread_id="t1"))
+        ]
+        latest = all_results[0]
+
+        results = [
+            item
+            async for item in buffered.alist(
+                _make_config(thread_id="t1"), before=latest.config
+            )
+        ]
+        assert len(results) == 2
+
+
+# ---------------------------------------------------------------------------
+# Flush write-drain identity guard (gap #5)
+# ---------------------------------------------------------------------------
+
+
+class TestFlushWriteDrainIdentityGuard:
+    """The pop after successful write I/O uses ``is`` identity comparison.
+
+    If a concurrent ``put_writes()`` inserts a *new* entry at index 0
+    between the I/O and the pop, the original entry is no longer at
+    index 0.  The guard ``self._pending_writes[0] is write_entry``
+    prevents popping the wrong entry.
+    """
+
+    def test_concurrent_put_writes_during_drain_preserves_new_entry(
+        self, memory_saver: MemorySaver
+    ) -> None:
+        """A put_writes() that races with flush() must not lose its entry."""
+        deferred = DeferredCheckpointSaver(memory_saver)
+        write_config = _make_config(thread_id="t1", checkpoint_id="ckpt-1")
+
+        # Seed one write that will be flushed.
+        deferred.put_writes(write_config, [("ch-original", "v1")], "task-orig")
+
+        new_write_inserted = False
+
+        original_put_writes = memory_saver.put_writes
+
+        def intercepting_put_writes(*args: Any, **kwargs: Any) -> None:
+            nonlocal new_write_inserted
+            # After the underlying saver persists the original write,
+            # but *before* flush() re-acquires the lock to pop, simulate
+            # a concurrent put_writes() that inserts at the tail.  Because
+            # list.insert(0, ...) is not used (put_writes appends), the
+            # new entry lands at the end — but we can simulate the more
+            # adversarial case by directly inserting at index 0 under the
+            # lock to exercise the identity guard.
+            result = original_put_writes(*args, **kwargs)
+            if not new_write_inserted:
+                new_write_inserted = True
+                # Directly manipulate the buffer to simulate a race where
+                # the entry at index 0 is no longer the one we peeked.
+                from langgraph_checkpoint_aws.deferred_saver import _PendingWrite
+
+                intruder = _PendingWrite(
+                    config=write_config,
+                    writes=[("ch-intruder", "v2")],
+                    task_id="task-intruder",
+                    task_path="",
+                )
+                with deferred._lock:
+                    deferred._pending_writes.insert(0, intruder)
+            return result
+
+        with patch.object(
+            memory_saver, "put_writes", side_effect=intercepting_put_writes
+        ):
+            deferred.flush()
+
+        # The intruder entry was inserted at index 0 *after* the original
+        # was peeked but before the pop.  The identity guard should have
+        # skipped the pop for the original iteration, leaving the intruder
+        # in the buffer.  Then the loop continues and flushes the intruder
+        # normally.  But the key property: the intruder was never silently
+        # dropped.
+        #
+        # After full drain, buffer should be empty (both were flushed).
+        assert deferred.is_empty
+
+
+# ---------------------------------------------------------------------------
+# Concurrent flush() + flush() (gap #15)
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrentFlush:
+    """Two threads calling flush() concurrently must not double-persist."""
+
+    def test_concurrent_flush_no_double_persist(
+        self, memory_saver: MemorySaver
+    ) -> None:
+        deferred = DeferredCheckpointSaver(memory_saver)
+        config = _make_config(thread_id="t1")
+        deferred.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), {})
+
+        write_config = _make_config(thread_id="t1", checkpoint_id="ckpt-1")
+        deferred.put_writes(write_config, [("ch1", "v1")], "task-1")
+
+        put_call_count = 0
+        put_writes_call_count = 0
+        original_put = memory_saver.put
+        original_put_writes = memory_saver.put_writes
+
+        count_lock = threading.Lock()
+
+        def counting_put(*args: Any, **kwargs: Any) -> Any:
+            nonlocal put_call_count
+            with count_lock:
+                put_call_count += 1
+            return original_put(*args, **kwargs)
+
+        def counting_put_writes(*args: Any, **kwargs: Any) -> None:
+            nonlocal put_writes_call_count
+            with count_lock:
+                put_writes_call_count += 1
+            return original_put_writes(*args, **kwargs)
+
+        errors: list[Exception] = []
+
+        def flusher() -> None:
+            try:
+                deferred.flush()
+            except Exception as e:
+                errors.append(e)
+
+        with (
+            patch.object(memory_saver, "put", side_effect=counting_put),
+            patch.object(memory_saver, "put_writes", side_effect=counting_put_writes),
+        ):
+            threads = [
+                threading.Thread(target=flusher),
+                threading.Thread(target=flusher),
+            ]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+        assert len(errors) == 0
+        assert deferred.is_empty
+        # The checkpoint must be persisted exactly once, not twice.
+        assert put_call_count == 1
+        # The write must be persisted exactly once.
+        assert put_writes_call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Async flush — write failure keeps remaining (gap #6)
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncFlushWriteFailure:
+    """aflush() partial write failure must keep remaining writes in buffer."""
+
+    @pytest.mark.asyncio
+    async def test_aflush_write_failure_keeps_remaining(
+        self, memory_saver: MemorySaver
+    ) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver)
+
+        write_config = _make_config(thread_id="t1", checkpoint_id="ckpt-1")
+        buffered.put_writes(write_config, [("ch1", "v1")], "task-1")
+        buffered.put_writes(write_config, [("ch2", "v2")], "task-2")
+        buffered.put_writes(write_config, [("ch3", "v3")], "task-3")
+
+        call_count = 0
+        original_aput_writes = memory_saver.aput_writes
+
+        async def failing_aput_writes(*args: Any, **kwargs: Any) -> None:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                msg = "async write failed"
+                raise RuntimeError(msg)
+            return await original_aput_writes(*args, **kwargs)
+
+        with patch.object(
+            memory_saver,
+            "aput_writes",
+            new_callable=AsyncMock,
+            side_effect=failing_aput_writes,
+        ):
+            with pytest.raises(RuntimeError, match="async write failed"):
+                await buffered.aflush()
+
+        # First write succeeded and was removed; second failed and remains
+        # along with the third.
+        assert buffered.has_buffered_writes
+
+
+# ---------------------------------------------------------------------------
+# Async flush — checkpoint failure race guard (gap #7)
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncFlushCheckpointRace:
+    """aflush() checkpoint failure must not clobber a newer put()."""
+
+    @pytest.mark.asyncio
+    async def test_aflush_failure_does_not_clobber_new_checkpoint(
+        self, memory_saver: MemorySaver
+    ) -> None:
+        deferred = DeferredCheckpointSaver(memory_saver)
+        config = _make_config(thread_id="t1")
+        deferred.put(config, _make_checkpoint("ckpt-old"), _make_metadata(), {})
+
+        async def failing_aput_that_races(*args: Any, **kwargs: Any) -> None:
+            # Simulate a new put() arriving while aflush is awaiting I/O.
+            deferred.put(config, _make_checkpoint("ckpt-new"), _make_metadata(1), {})
+            msg = "async network error"
+            raise RuntimeError(msg)
+
+        with patch.object(
+            memory_saver,
+            "aput",
+            new_callable=AsyncMock,
+            side_effect=failing_aput_that_races,
+        ):
+            with pytest.raises(RuntimeError, match="async network error"):
+                await deferred.aflush()
+
+        # ckpt-new must survive — not be clobbered by ckpt-old restore.
+        result = deferred.get_tuple(_make_config(thread_id="t1"))
+        assert result is not None
+        assert result.checkpoint["id"] == "ckpt-new"


### PR DESCRIPTION


Closes #806


### Summary

Adds `DeferredCheckpointSaver`, a `BaseCheckpointSaver` wrapper that defers all checkpoint persistence until the user explicitly calls `flush()` or exits a `flush_on_exit()` context manager. Works with any saver in the package (AgentCore, DynamoDB, Bedrock Session) without modifying existing classes.



### `DeferredCheckpointSaver` wrapper

Follows the `BaseCheckpointSaver` contract. Opt-in — users who don't want deferred persistence never see it.

```python
from langgraph_checkpoint_aws import DeferredCheckpointSaver

saver = AgentCoreMemorySaver(memory_id, region_name="us-east-1")
deferred = DeferredCheckpointSaver(saver)
graph = create_react_agent(model, tools=tools, checkpointer=deferred)

# Context manager (recommended) — auto-flushes on exit
with deferred.flush_on_exit():
    response = graph.invoke({"messages": [user_input]}, config)

# Async context manager
async with deferred.aflush_on_exit():
    await graph.ainvoke({"messages": [user_input]}, config)

# Manual flush
graph.invoke({"messages": [user_input]}, config)
deferred.flush()
```

### Changes

- **`deferred_saver.py`**: New wrapper class
  - `put()` buffers in a single slot (only latest checkpoint kept)
  - `put_writes()` accumulates all writes in a list
  - `get_tuple()` serves from buffer first, then delegates to underlying saver
  - `flush()`/`aflush()` persists with race-condition-safe error recovery (lock never held during I/O)
  - `flush_on_exit()`/`aflush_on_exit()` context managers flush in `finally` block
  - `list()` always delegates (buffered data never appears in history)
  - `clear()` discards without persisting
  - Nesting prevention (`DeferredCheckpointSaver(DeferredCheckpointSaver(x))` raises `ValueError`)
  - Thread-safe via `threading.Lock` (required by LangGraph's `ContextThreadPoolExecutor`)
- **`__init__.py`**: Export `DeferredCheckpointSaver`
- **`tests/integration_tests/utils.py`**: Shared helpers for resource setup (`skip_on_aws_403`, `ensure_dynamodb_table`, `ensure_agentcore_memory`, `create_bedrock_session`)

### Tests

- **64 unit tests** (`test_deferred_saver.py`): init/nesting, buffering, buffer-first get_tuple, flush mechanics, error recovery (checkpoint restore race condition), context managers, clear, list delegation, get_next_version, config preservation, parent config, thread safety (concurrent put + get_tuple, concurrent put_writes), async variants, multi-session
- **63 integration tests** (`test_deferred_saver.py`): Parametrized across AgentCore, DynamoDB, and Bedrock Session backends — nothing persisted before flush, flush persists, flush_on_exit, get_tuple buffered, put overwrites, clear discards, flush with writes, multi-session isolation, exception-safe flush, post-flush delegation, list excludes buffered, double flush safety, flush returns correct config
```
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_nothing_persisted_before_flush[agentcore] PASSED                                     [  1%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_nothing_persisted_before_flush[dynamodb] PASSED                                      [  3%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_nothing_persisted_before_flush[bedrock_session] PASSED                               [  4%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_flush_persists_to_underlying_saver[agentcore] PASSED                                 [  6%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_flush_persists_to_underlying_saver[dynamodb] PASSED                                  [  7%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_flush_persists_to_underlying_saver[bedrock_session] PASSED                           [  9%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_flush_on_exit_context_manager[agentcore] PASSED                                      [ 11%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_flush_on_exit_context_manager[dynamodb] PASSED                                       [ 12%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_flush_on_exit_context_manager[bedrock_session] PASSED                                [ 14%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_get_tuple_returns_buffered_data[agentcore] PASSED                                    [ 15%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_get_tuple_returns_buffered_data[dynamodb] PASSED                                     [ 17%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_get_tuple_returns_buffered_data[bedrock_session] PASSED                              [ 19%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_put_overwrites_keeps_only_latest[agentcore] PASSED                                   [ 20%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_put_overwrites_keeps_only_latest[dynamodb] PASSED                                    [ 22%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_put_overwrites_keeps_only_latest[bedrock_session] PASSED                             [ 23%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_clear_discards_without_persisting[agentcore] PASSED                                  [ 25%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_clear_discards_without_persisting[dynamodb] PASSED                                   [ 26%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_clear_discards_without_persisting[bedrock_session] PASSED                            [ 28%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_flush_persists_writes[agentcore] PASSED                                              [ 30%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_flush_persists_writes[dynamodb] PASSED                                               [ 31%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_flush_persists_writes[bedrock_session] PASSED                                        [ 33%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_multi_session_isolation[agentcore] PASSED                                            [ 34%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_multi_session_isolation[dynamodb] PASSED                                             [ 36%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_multi_session_isolation[bedrock_session] PASSED                                      [ 38%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_flush_on_exit_persists_on_exception[agentcore] PASSED                                [ 39%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_flush_on_exit_persists_on_exception[dynamodb] PASSED                                 [ 41%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_flush_on_exit_persists_on_exception[bedrock_session] PASSED                          [ 42%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_get_tuple_delegates_after_flush[agentcore] PASSED                                    [ 44%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_get_tuple_delegates_after_flush[dynamodb] PASSED                                     [ 46%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_get_tuple_delegates_after_flush[bedrock_session] PASSED                              [ 47%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_list_excludes_buffered_includes_flushed[agentcore] PASSED                            [ 49%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_list_excludes_buffered_includes_flushed[dynamodb] PASSED                             [ 50%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_list_excludes_buffered_includes_flushed[bedrock_session] PASSED                      [ 52%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_double_flush_is_safe[agentcore] PASSED                                               [ 53%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_double_flush_is_safe[dynamodb] PASSED                                                [ 55%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_double_flush_is_safe[bedrock_session] PASSED                                         [ 57%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_flush_returns_correct_config[agentcore] PASSED                                       [ 58%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_flush_returns_correct_config[dynamodb] PASSED                                        [ 60%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_flush_returns_correct_config[bedrock_session] PASSED                                 [ 61%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_checkpoint_ns_isolation[agentcore] PASSED                                            [ 63%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_checkpoint_ns_isolation[dynamodb] PASSED                                             [ 65%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_checkpoint_ns_isolation[bedrock_session] PASSED                                      [ 66%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_pending_writes_retrievable_after_flush[agentcore] PASSED                             [ 68%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_pending_writes_retrievable_after_flush[dynamodb] PASSED                              [ 69%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_pending_writes_retrievable_after_flush[bedrock_session] PASSED                       [ 71%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_multiple_task_ids_flushed[agentcore] PASSED                                          [ 73%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_multiple_task_ids_flushed[dynamodb] PASSED                                           [ 74%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_multiple_task_ids_flushed[bedrock_session] PASSED                                    [ 76%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_async_flush_persists_to_backend[agentcore] PASSED                                    [ 77%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_async_flush_persists_to_backend[dynamodb] PASSED                                     [ 79%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_async_flush_persists_to_backend[bedrock_session] SKIPPED (Backend does not imple...) [ 80%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_async_get_tuple_from_backend[agentcore] PASSED                                       [ 82%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_async_get_tuple_from_backend[dynamodb] PASSED                                        [ 84%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_async_get_tuple_from_backend[bedrock_session] SKIPPED (Backend does not implemen...) [ 85%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_async_flush_on_exit_persists[agentcore] PASSED                                       [ 87%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_async_flush_on_exit_persists[dynamodb] PASSED                                        [ 88%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_async_flush_on_exit_persists[bedrock_session] SKIPPED (Backend does not implemen...) [ 90%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_async_list_after_flush[agentcore] PASSED                                             [ 92%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_async_list_after_flush[dynamodb] PASSED                                              [ 93%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_async_list_after_flush[bedrock_session] SKIPPED (Backend does not implement asyn...) [ 95%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_writes_only_flush_no_checkpoint[agentcore] PASSED                                    [ 96%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_writes_only_flush_no_checkpoint[dynamodb] PASSED                                     [ 98%]
tests/integration_tests/test_deferred_saver.py::TestDeferredCheckpointSaver::test_writes_only_flush_no_checkpoint[bedrock_session] PASSED                              [100%]


```
### Areas requiring careful review

- **Flush race condition fix**: On checkpoint flush failure, the restore only writes back the old checkpoint if `_pending_checkpoint is None` — preventing a concurrent `put()` from being silently overwritten. This is the most subtle concurrency logic in the implementation.
- **Buffer-first read logic in `_get_buffered_tuple`**: Must correctly match `thread_id` + `checkpoint_ns` + optional `checkpoint_id` and filter pending writes. Incorrect matching would break LangGraph's mid-execution reads.