### PR TITLE
fix(aws): Add `ls_provider` to message `response_metadata`

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -1046,6 +1046,7 @@ class ChatBedrock(BaseChatModel, BedrockBase):
         ):
             if isinstance(chunk, AIMessageChunk):
                 chunk.response_metadata["model_provider"] = "bedrock"
+                chunk.response_metadata["ls_provider"] = "amazon_bedrock"
                 generation_chunk = ChatGenerationChunk(message=chunk)
                 if run_manager:
                     run_manager.on_llm_new_token(
@@ -1079,6 +1080,9 @@ class ChatBedrock(BaseChatModel, BedrockBase):
                     else AIMessageChunk(content=delta)
                 )
                 generation_chunk.message.response_metadata["model_provider"] = "bedrock"
+                generation_chunk.message.response_metadata["ls_provider"] = (
+                    "amazon_bedrock"
+                )
                 if run_manager:
                     run_manager.on_llm_new_token(
                         generation_chunk.text, chunk=generation_chunk
@@ -1224,6 +1228,7 @@ class ChatBedrock(BaseChatModel, BedrockBase):
             usage_metadata=usage_metadata,
             response_metadata={
                 "model_provider": "bedrock",
+                "ls_provider": "amazon_bedrock",
                 "model_name": self.model_id,
             },
         )

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -1206,6 +1206,7 @@ class ChatBedrockConverse(BaseChatModel):
         logger.debug(f"Response from Bedrock: {response}")
         response_message = _parse_response(response)
         response_message.response_metadata["model_provider"] = "bedrock_converse"
+        response_message.response_metadata["ls_provider"] = "amazon_bedrock"
         response_message.response_metadata["model_name"] = self.model_id
         return ChatResult(generations=[ChatGeneration(message=response_message)])
 
@@ -1282,6 +1283,7 @@ class ChatBedrockConverse(BaseChatModel):
                     message_chunk.response_metadata["model_provider"] = (
                         "bedrock_converse"
                     )
+                    message_chunk.response_metadata["ls_provider"] = "amazon_bedrock"
                     generation_chunk = ChatGenerationChunk(message=message_chunk)
                     if run_manager:
                         run_manager.on_llm_new_token(


### PR DESCRIPTION
First part of fix for #946, per https://github.com/langchain-ai/langchain-aws/issues/946#issuecomment-4203871366.

Adds `response_metadata["ls_provider"] = "amazon_bedrock"` in ChatBedrock and ChatBedrockConverse to give a SummarizationMiddleware an accurate way to verify the LangSmith provider from the last message produced by these chat models.

Will be followed by part 2 PR in `langchain-core` to prefer to prefer metadata `ls_provider` over `model_provider`, where available.


