### PR TITLE
feat(langgraph-checkpoint-aws): add S3 key prefix support to S3OffloadConfigDict #986

### DIFF
--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/dynamodb/saver.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/dynamodb/saver.py
@@ -32,13 +32,15 @@ logger = logging.getLogger(__name__)
 
 
 class S3OffloadConfigDict(TypedDict, total=False):
-    """Type alias for S3 offload configuration
+    """Type alias for S3 offload configuration.
+
     Required when user needs to configure Saver, to offload large
     Checkpoints above threshold (350KB) to S3.
     """
 
     bucket_name: str
     endpoint_url: str | None
+    key_prefix: str | None
 
 
 class DynamoDBSaver(BaseCheckpointSaver):
@@ -58,10 +60,14 @@ class DynamoDBSaver(BaseCheckpointSaver):
             Required key: "bucket_name" (str), to be used for checkpoint offloading
             Optional keys:
                 "endpoint_url" (str) Custom endpoint URL for the S3 service
+                "key_prefix" (str) Prefix prepended to all S3 keys, allowing
+                    multiple applications to share a single bucket with
+                    prefix-based isolation
             Example:
             {
                 "bucket_name": "my-checkpoint-bucket",
-                "endpoint_url": "http://localhost:4566"
+                "endpoint_url": "http://localhost:4566",
+                "key_prefix": "my-app/langgraph"
             }
     """
 
@@ -89,6 +95,7 @@ class DynamoDBSaver(BaseCheckpointSaver):
         # S3 configuration if provided
         s3_client_instance = None
         s3_bucket_name = None
+        s3_key_prefix = None
 
         if s3_offload_config:
             # Validate required bucket_name
@@ -99,6 +106,7 @@ class DynamoDBSaver(BaseCheckpointSaver):
                 )
 
             s3_bucket_name = s3_offload_config["bucket_name"]
+            s3_key_prefix = s3_offload_config.get("key_prefix")
 
             s3_client_instance = create_s3_client(
                 session=session,
@@ -121,6 +129,7 @@ class DynamoDBSaver(BaseCheckpointSaver):
             table_name=self.table_name,
             s3_client=s3_client_instance,
             s3_bucket=s3_bucket_name,
+            s3_key_prefix=s3_key_prefix,
             ttl_seconds=ttl_seconds,
         )
 

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/dynamodb/storage_strategy.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/dynamodb/storage_strategy.py
@@ -34,6 +34,7 @@ class StorageStrategy:
         table_name: str,
         s3_client: "S3Client | None" = None,
         s3_bucket: str | None = None,
+        s3_key_prefix: str | None = None,
         ttl_seconds: int | None = None,
     ):
         """Initialize storage strategy.
@@ -43,12 +44,15 @@ class StorageStrategy:
             table_name: Name of the DynamoDB for payload storage
             s3_client: Optional S3 client for large data offloading
             s3_bucket: Optional S3 bucket name for offloading
+            s3_key_prefix: Optional prefix prepended to all S3 keys for
+                bucket-level isolation between applications
             ttl_seconds: Optional TTL in seconds for automatic cleanup
         """
         self.dynamodb_client = dynamodb_client
         self.table_name = table_name
         self.s3_client = s3_client
         self.s3_bucket = s3_bucket
+        self.s3_key_prefix = s3_key_prefix.strip("/") if s3_key_prefix else None
         self.ttl_seconds = ttl_seconds
         self.s3_enabled = s3_client is not None and s3_bucket is not None
 
@@ -82,6 +86,20 @@ class StorageStrategy:
             f"{S3_OFFLOAD_THRESHOLD / 1024:.0f}KB - will store in DynamoDB"
         )
         return False
+
+    def _prefixed_s3_key(self, s3_key: str) -> str:
+        """Prepend the configured key prefix to an S3 key.
+
+        Args:
+            s3_key: Original S3 object key.
+
+        Returns:
+            S3 key with prefix prepended, or the original key if no prefix
+            is configured.
+        """
+        if self.s3_key_prefix:
+            return f"{self.s3_key_prefix}/{s3_key}"
+        return s3_key
 
     def store_data(
         self,
@@ -447,10 +465,12 @@ class StorageStrategy:
         if not self.s3_enabled:
             raise ValueError("S3 is not configured but offloading was attempted")
 
+        prefixed_key = self._prefixed_s3_key(s3_key)
+
         # Build put parameters
         put_params: dict[str, Any] = {
             "Bucket": self.s3_bucket,
-            "Key": s3_key,
+            "Key": prefixed_key,
             "Body": data,
             "Metadata": {},
         }
@@ -502,8 +522,9 @@ class StorageStrategy:
         if not self.s3_enabled or self.s3_client is None:
             raise ValueError("S3 is not configured but retrieval was attempted")
 
+        prefixed_key = self._prefixed_s3_key(s3_key)
         assert self.s3_bucket is not None  # Already checked by s3_enabled
-        response = self.s3_client.get_object(Bucket=self.s3_bucket, Key=s3_key)
+        response = self.s3_client.get_object(Bucket=self.s3_bucket, Key=prefixed_key)
         data = response["Body"].read()
 
         logger.debug(f"Retrieved {len(data) / 1024:.1f}KB from S3: {s3_key}")
@@ -539,7 +560,7 @@ class StorageStrategy:
 
             # Build delete request with proper types
             objects_to_delete: list[ObjectIdentifierTypeDef] = [
-                {"Key": key} for key in batch
+                {"Key": self._prefixed_s3_key(key)} for key in batch
             ]
             delete_request: DeleteTypeDef = {"Objects": objects_to_delete}
 

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/checkpoint/dynamodb/test_saver.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/checkpoint/dynamodb/test_saver.py
@@ -57,6 +57,32 @@ class TestDynamoDBSaverInitialization:
         assert call_kwargs["s3_client"] == mock_s3
         assert call_kwargs["s3_bucket"] == TEST_S3_BUCKET
 
+    def test_init_with_s3_key_prefix(self, mock_saver_dependencies):
+        """Test initialization passes key_prefix to StorageStrategy."""
+        mock_s3 = Mock()
+        mock_saver_dependencies["create_s3_client"].return_value = mock_s3
+
+        # With key_prefix
+        DynamoDBSaver(
+            table_name=TEST_TABLE_NAME,
+            s3_offload_config={
+                "bucket_name": TEST_S3_BUCKET,
+                "key_prefix": "my-app/langgraph",
+            },
+        )
+
+        call_kwargs = mock_saver_dependencies["storage"].call_args[1]
+        assert call_kwargs["s3_key_prefix"] == "my-app/langgraph"
+
+        # Without key_prefix
+        DynamoDBSaver(
+            table_name=TEST_TABLE_NAME,
+            s3_offload_config={"bucket_name": TEST_S3_BUCKET},
+        )
+
+        call_kwargs = mock_saver_dependencies["storage"].call_args[1]
+        assert call_kwargs["s3_key_prefix"] is None
+
     def test_init_with_all_aws_parameters(self, mock_saver_dependencies):
         """Test initialization with all AWS configuration parameters."""
         mock_s3 = Mock()

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/checkpoint/dynamodb/test_storage_strategy.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/checkpoint/dynamodb/test_storage_strategy.py
@@ -882,3 +882,139 @@ class TestStorageStrategyIntegration:
         assert retrieved_after_delete_1 is None
         retrieved_after_delete_2 = strategy.retrieve_data("test_key_2", "DYNAMODB")
         assert retrieved_after_delete_2 is None
+
+
+class TestS3KeyPrefix:
+    """Test S3 key prefix support in StorageStrategy."""
+
+    def test_init_with_key_prefix(self):
+        """Test initialization stores and normalizes key_prefix."""
+        mock_dynamodb = Mock()
+        mock_s3 = Mock()
+
+        # No prefix
+        strategy = StorageStrategy(
+            dynamodb_client=mock_dynamodb,
+            table_name="test_chunks",
+            s3_client=mock_s3,
+            s3_bucket="test-bucket",
+        )
+        assert strategy.s3_key_prefix is None
+
+        # Simple prefix
+        strategy = StorageStrategy(
+            dynamodb_client=mock_dynamodb,
+            table_name="test_chunks",
+            s3_client=mock_s3,
+            s3_bucket="test-bucket",
+            s3_key_prefix="my-app/langgraph",
+        )
+        assert strategy.s3_key_prefix == "my-app/langgraph"
+
+        # Prefix with leading/trailing slashes is stripped
+        strategy = StorageStrategy(
+            dynamodb_client=mock_dynamodb,
+            table_name="test_chunks",
+            s3_client=mock_s3,
+            s3_bucket="test-bucket",
+            s3_key_prefix="/my-app/langgraph/",
+        )
+        assert strategy.s3_key_prefix == "my-app/langgraph"
+
+        # Empty string treated as no prefix
+        strategy = StorageStrategy(
+            dynamodb_client=mock_dynamodb,
+            table_name="test_chunks",
+            s3_client=mock_s3,
+            s3_bucket="test-bucket",
+            s3_key_prefix="",
+        )
+        assert strategy.s3_key_prefix is None
+
+    def test_prefixed_s3_key_without_prefix(self):
+        """Test _prefixed_s3_key returns original key when no prefix set."""
+        mock_dynamodb = Mock()
+        strategy = StorageStrategy(
+            dynamodb_client=mock_dynamodb,
+            table_name="test_chunks",
+        )
+        assert strategy._prefixed_s3_key("thread/checkpoints/ns/id") == (
+            "thread/checkpoints/ns/id"
+        )
+
+    def test_prefixed_s3_key_with_prefix(self):
+        """Test _prefixed_s3_key prepends prefix to key."""
+        mock_dynamodb = Mock()
+        mock_s3 = Mock()
+        strategy = StorageStrategy(
+            dynamodb_client=mock_dynamodb,
+            table_name="test_chunks",
+            s3_client=mock_s3,
+            s3_bucket="test-bucket",
+            s3_key_prefix="my-app",
+        )
+        assert strategy._prefixed_s3_key("thread/checkpoints/ns/id") == (
+            "my-app/thread/checkpoints/ns/id"
+        )
+
+    def test_store_to_s3_uses_prefix(self):
+        """Test that storing to S3 applies the key prefix."""
+        mock_dynamodb = Mock()
+        mock_s3 = Mock()
+        strategy = StorageStrategy(
+            dynamodb_client=mock_dynamodb,
+            table_name="test_chunks",
+            s3_client=mock_s3,
+            s3_bucket="test-bucket",
+            s3_key_prefix="my-app",
+        )
+
+        large_data = b"x" * (S3_OFFLOAD_THRESHOLD + 1)
+        strategy.store_data("chunk_key", "s3_key", large_data, allow_overwrite=True)
+
+        mock_s3.put_object.assert_called_once()
+        call_args = mock_s3.put_object.call_args[1]
+        assert call_args["Key"] == "my-app/s3_key"
+
+    def test_retrieve_from_s3_uses_prefix(self):
+        """Test that retrieving from S3 applies the key prefix."""
+        mock_dynamodb = Mock()
+        mock_s3 = Mock()
+        mock_s3.get_object.return_value = {"Body": Mock(read=lambda: b"data")}
+
+        strategy = StorageStrategy(
+            dynamodb_client=mock_dynamodb,
+            table_name="test_chunks",
+            s3_client=mock_s3,
+            s3_bucket="test-bucket",
+            s3_key_prefix="my-app",
+        )
+
+        strategy.retrieve_data("s3_key", "S3")
+
+        mock_s3.get_object.assert_called_once_with(
+            Bucket="test-bucket", Key="my-app/s3_key"
+        )
+
+    def test_batch_delete_from_s3_uses_prefix(self):
+        """Test that batch deleting from S3 applies the key prefix."""
+        mock_dynamodb = Mock()
+        mock_s3 = Mock()
+        mock_s3.delete_objects.return_value = {
+            "Deleted": [{"Key": "my-app/key1"}, {"Key": "my-app/key2"}]
+        }
+
+        strategy = StorageStrategy(
+            dynamodb_client=mock_dynamodb,
+            table_name="test_chunks",
+            s3_client=mock_s3,
+            s3_bucket="test-bucket",
+            s3_key_prefix="my-app",
+        )
+
+        result = strategy.batch_delete_data([("key1", "S3"), ("key2", "S3")])
+
+        assert result == {"failed": []}
+        call_args = mock_s3.delete_objects.call_args[1]
+        objects = call_args["Delete"]["Objects"]
+        assert objects == [{"Key": "my-app/key1"}, {"Key": "my-app/key2"}]


### PR DESCRIPTION
Closes #986

### Summary

Adds an optional `key_prefix` field to `S3OffloadConfigDict` for the DynamoDB checkpointer's S3 offloading, allowing users to share a single S3 bucket across multiple applications with prefix-based isolation.

### Usage

```python
from langgraph_checkpoint_aws import DynamoDBSaver

saver = DynamoDBSaver(
    table_name="my-checkpoints",
    s3_offload_config={
        "bucket_name": "shared-data-bucket",
        "key_prefix": "my-app/langgraph",
    },
)
```

Without `key_prefix`, S3 keys are generated as:
```
{thread_id}/checkpoints/{checkpoint_ns}/{checkpoint_id}
```

With `key_prefix`, they become:
```
{key_prefix}/{thread_id}/checkpoints/{checkpoint_ns}/{checkpoint_id}
```

### Changes

- **`saver.py`**: Added `key_prefix` to `S3OffloadConfigDict`, extracted and passed through to `StorageStrategy`
- **`storage_strategy.py`**:
  - New `s3_key_prefix` parameter on `StorageStrategy.__init__` (leading/trailing slashes stripped automatically)
  - `_prefixed_s3_key()` helper prepends the prefix when configured
  - Applied in `_store_to_s3`, `_retrieve_from_s3`, and `_batch_delete_from_s3`
- **`__init__.py`**: No changes — `S3OffloadConfigDict` is a `TypedDict` with `total=False`, so the new field is fully backward compatible

### Tests

- **8 new unit tests** across `test_saver.py` and `test_storage_strategy.py`: init normalization (slash stripping, empty string), prefix application, store/retrieve/delete with prefix, saver passthrough with and without `key_prefix`

### Areas requiring careful review

- **Prefix applied at storage layer, not key generation**: The prefix is prepended in `StorageStrategy._store_to_s3` / `_retrieve_from_s3` / `_batch_delete_from_s3` rather than in the `_checkpoint_s3_key` / `_writes_s3_key` functions. This means the `ref_key` stored in DynamoDB remains unprefixed. This is intentional — it keeps the DynamoDB metadata portable and avoids breaking existing data if a user later changes or removes the prefix. Reviewers should verify this design choice aligns with the project's expectations.