### PR TITLE
docs(aws): Update `bedrock_api_key` docstrings to warn about multitenant incompatibility

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -523,12 +523,20 @@ class ChatBedrockConverse(BaseChatModel):
     """Bedrock API key.
 
     Enables authentication using Bedrock API keys instead of standard AWS
-    credentials. When provided, the key is set as the AWS_BEARER_TOKEN_BEDROCK
+    credentials. When provided, the key is set as the ``AWS_BEARER_TOKEN_BEDROCK``
     environment variable.
+
+    .. warning::
+        Because this sets a **process-wide environment variable**, using
+        ``api_key`` is not compatible with multi-tenant deployments where
+        different model instances in the same process need different API keys.
+        Each new client creation overwrites the previous value. Use standard
+        AWS credentials (IAM roles, profiles, etc.) for multi-tenant scenarios.
 
     See: https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-use.html
 
-    If not provided, will be read from `AWS_BEARER_TOKEN_BEDROCK` environment variable.
+    If not provided, will be read from ``AWS_BEARER_TOKEN_BEDROCK`` environment
+    variable (if it exists).
 
     If both an API key and AWS credentials are present, the API key takes precedence.
     """

--- a/libs/aws/langchain_aws/chat_models/bedrock_nova_sonic.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_nova_sonic.py
@@ -678,7 +678,12 @@ class ChatBedrockNovaSonic(BaseChatModel):
     bedrock_api_key: Optional[SecretStr] = Field(
         default_factory=secret_from_env("AWS_BEARER_TOKEN_BEDROCK", default=None),
         alias="api_key",
-        description="Bedrock API key for bearer-token authentication.",
+        description=(
+            "Bedrock API key for bearer-token authentication. "
+            "Warning: sets the AWS_BEARER_TOKEN_BEDROCK environment variable "
+            "at the process level, so it is not compatible with multi-tenant "
+            "deployments using different API keys in the same process."
+        ),
     )
     voice_id: str = Field(
         default="matthew",

--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -738,15 +738,22 @@ class BedrockBase(BaseLanguageModel, ABC):
     """Bedrock API key.
 
     Enables authentication using Bedrock API keys instead of standard AWS
-    credentials. When provided, the key is set as the AWS_BEARER_TOKEN_BEDROCK
+    credentials. When provided, the key is set as the ``AWS_BEARER_TOKEN_BEDROCK``
     environment variable.
+
+    .. warning::
+        Because this sets a **process-wide environment variable**, using
+        ``api_key`` is not compatible with multi-tenant deployments where
+        different model instances in the same process need different API keys.
+        Each new client creation overwrites the previous value. Use standard
+        AWS credentials (IAM roles, profiles, etc.) for multi-tenant scenarios.
 
     See: https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-use.html
 
-    If not provided, will be read from `AWS_BEARER_TOKEN_BEDROCK` environment variable.
+    If not provided, will be read from ``AWS_BEARER_TOKEN_BEDROCK`` environment
+    variable (if it exists).
 
     If both an API key and AWS credentials are present, the API key takes precedence.
-
     """
 
     config: Any = None

--- a/libs/aws/langchain_aws/utils.py
+++ b/libs/aws/langchain_aws/utils.py
@@ -151,8 +151,12 @@ def create_aws_client(
         aws_session_token: AWS session token.
         endpoint_url: The complete URL to use for the constructed client.
         config: Advanced client configuration options.
-        api_key: Bedrock API key for bearer token authentication.
-            If provided, sets AWS_BEARER_TOKEN_BEDROCK env variable.
+        api_key: Bedrock API key for bearer-token authentication.
+            If provided, sets the ``AWS_BEARER_TOKEN_BEDROCK`` environment
+            variable at the process level. **Not compatible with multi-tenant
+            deployments** where different clients in the same process need
+            different API keys, as each call overwrites the previous value.
+
     Returns:
         boto3.client: An AWS service client instance.
 
@@ -261,7 +265,10 @@ def create_aws_bedrock_runtime_client(
         endpoint_url: Custom endpoint URL. If not provided, the SDK's
             built-in regional endpoint resolver is used.
         api_key: Bedrock API key for bearer-token authentication.
-            If provided, sets the ``AWS_BEARER_TOKEN_BEDROCK`` env variable.
+            If provided, sets the ``AWS_BEARER_TOKEN_BEDROCK`` environment
+            variable at the process level. **Not compatible with multi-tenant
+            deployments** where different clients in the same process need
+            different API keys, as each call overwrites the previous value.
 
     Returns:
         A configured ``BedrockRuntimeClient`` instance.


### PR DESCRIPTION
Addresses action item in https://github.com/langchain-ai/langchain-aws/issues/989#issuecomment-4220191869.