### PR TITLE
fix(aws): Allow inference profile usage with BedrockPromptCachingMiddleware

### DIFF
--- a/libs/aws/langchain_aws/middleware/prompt_caching.py
+++ b/libs/aws/langchain_aws/middleware/prompt_caching.py
@@ -23,7 +23,12 @@ except ImportError as e:
 
 def _is_supported_model(model: Union[ChatBedrock, ChatBedrockConverse]) -> bool:
     """Check if the model supports prompt caching on Bedrock."""
-    model_id = getattr(model, "model_id", "") or getattr(model, "model", "")
+    model_id = (
+        getattr(model, "base_model_id", None)
+        or getattr(model, "model_id", "")
+        or getattr(model, "model", "")
+        or ""
+    )
     return any(name in model_id.lower() for name in ("anthropic", "amazon.nova"))
 
 

--- a/libs/aws/tests/unit_tests/middleware/test_prompt_caching.py
+++ b/libs/aws/tests/unit_tests/middleware/test_prompt_caching.py
@@ -171,6 +171,21 @@ def test_nova_model_accepted_chatbedrock() -> None:
     assert middleware._should_apply_caching(request) is True
 
 
+def test_inference_profile_resolved_via_base_model_id() -> None:
+    middleware = BedrockPromptCachingMiddleware()
+
+    request = MagicMock()
+    request.model = MagicMock(spec=ChatBedrockConverse)
+    request.model.model_id = (
+        "arn:aws:bedrock:us-east-1:123456:application-inference-profile/abc"
+    )
+    request.model.base_model_id = "anthropic.claude-sonnet-4-20250514-v1:0"
+    request.system_prompt = "You are helpful."
+    request.messages = [HumanMessage(content="Hello")]
+
+    assert middleware._should_apply_caching(request) is True
+
+
 def test_unsupported_model_id_with_converse() -> None:
     middleware = BedrockPromptCachingMiddleware(unsupported_model_behavior="ignore")
 


### PR DESCRIPTION
Fixes #988 

Updates BedrockPromptCachingMiddleware's model compatibility check to prioritize `base_model_id`, for compatibility with application inference profile ARNs.