### PR TITLE
fix(langgraph-checkpoint-aws): scope DynamoDB checkpointer S3 lifecycle rules to prefix

### DIFF
--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/dynamodb/storage_strategy.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/dynamodb/storage_strategy.py
@@ -400,7 +400,10 @@ class StorageStrategy:
             # Calculate expiration days (always round up, minimum 1 day)
             # S3 Lifecycle expiration: convert seconds to days (ceil, min 1 day)
             expiration_days = max(1, (self.ttl_seconds + 86399) // 86400)
-            rule_id = f"ttl-expiration-{expiration_days}d"
+            id_prefix = (
+                self.s3_key_prefix.replace("/", "-") if self.s3_key_prefix else "root"
+            )
+            rule_id = f"{id_prefix}-ttl-expiration-{expiration_days}d"
 
             # Get existing rules
             assert self.s3_bucket is not None  # Already checked by s3_enabled
@@ -423,13 +426,29 @@ class StorageStrategy:
                 existing_rules = []
 
             # Add new rule with tag filter for this specific TTL
+            lifecycle_filter: dict[str, Any]
+            if self.s3_key_prefix:
+                lifecycle_filter = {
+                    "And": {
+                        "Prefix": self.s3_key_prefix + "/",
+                        "Tags": [
+                            {
+                                "Key": "ttl-days",
+                                "Value": str(expiration_days),
+                            }
+                        ],
+                    }
+                }
+            else:
+                lifecycle_filter = {
+                    "Tag": {"Key": "ttl-days", "Value": str(expiration_days)}
+                }
+
             existing_rules.append(
                 {
                     "ID": rule_id,
                     "Status": "Enabled",
-                    "Filter": {
-                        "Tag": {"Key": "ttl-days", "Value": str(expiration_days)}
-                    },
+                    "Filter": lifecycle_filter,
                     "Expiration": {"Days": expiration_days},
                 }
             )

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/dynamodb/storage_strategy.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/dynamodb/storage_strategy.py
@@ -12,7 +12,11 @@ if TYPE_CHECKING:
         WriteRequestTypeDef,
     )
     from mypy_boto3_s3.client import S3Client
-    from mypy_boto3_s3.type_defs import DeleteTypeDef, ObjectIdentifierTypeDef
+    from mypy_boto3_s3.type_defs import (
+        DeleteTypeDef,
+        LifecycleRuleFilterOutputTypeDef,
+        ObjectIdentifierTypeDef,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -426,7 +430,7 @@ class StorageStrategy:
                 existing_rules = []
 
             # Add new rule with tag filter for this specific TTL
-            lifecycle_filter: dict[str, Any]
+            lifecycle_filter: LifecycleRuleFilterOutputTypeDef
             if self.s3_key_prefix:
                 lifecycle_filter = {
                     "And": {

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/checkpoint/dynamodb/test_storage_strategy.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/checkpoint/dynamodb/test_storage_strategy.py
@@ -185,7 +185,7 @@ class TestStoreData:
         mock_s3.put_bucket_lifecycle_configuration.assert_called_once()
         call_args = mock_s3.put_bucket_lifecycle_configuration.call_args[1]
         rule = call_args["LifecycleConfiguration"]["Rules"][0]
-        assert rule["ID"] == "ttl-expiration-1d"
+        assert rule["ID"] == "root-ttl-expiration-1d"
         assert rule["Expiration"]["Days"] == 1
         assert rule["Filter"] == {"Tag": {"Key": "ttl-days", "Value": "1"}}
 
@@ -207,7 +207,7 @@ class TestStoreData:
         mock_s3.get_bucket_lifecycle_configuration.return_value = {
             "Rules": [
                 {
-                    "ID": "ttl-expiration-1d",
+                    "ID": "root-ttl-expiration-1d",
                     "Status": "Enabled",
                     "Filter": {"Tag": {"Key": "ttl-days", "Value": "1"}},
                     "Expiration": {"Days": 1},
@@ -223,6 +223,34 @@ class TestStoreData:
         )
         mock_s3.get_bucket_lifecycle_configuration.assert_called_once()
         mock_s3.put_bucket_lifecycle_configuration.assert_not_called()
+
+    def test_s3_lifecycle_policy_scoped_to_prefix(self):
+        """Test S3 lifecycle rule is scoped to key prefix when configured."""
+        mock_dynamodb = Mock()
+        mock_s3 = Mock()
+
+        mock_s3.get_bucket_lifecycle_configuration.side_effect = ClientError(
+            {"Error": {"Code": "NoSuchLifecycleConfiguration"}},
+            "GetBucketLifecycleConfiguration",
+        )
+        StorageStrategy(
+            dynamodb_client=mock_dynamodb,
+            table_name="test_chunks",
+            s3_client=mock_s3,
+            s3_bucket="test-bucket",
+            s3_key_prefix="my-app/langgraph",
+            ttl_seconds=7200,
+        )
+        mock_s3.put_bucket_lifecycle_configuration.assert_called_once()
+        call_args = mock_s3.put_bucket_lifecycle_configuration.call_args[1]
+        rule = call_args["LifecycleConfiguration"]["Rules"][0]
+        assert rule["ID"] == "my-app-langgraph-ttl-expiration-1d"
+        assert rule["Filter"] == {
+            "And": {
+                "Prefix": "my-app/langgraph/",
+                "Tags": [{"Key": "ttl-days", "Value": "1"}],
+            }
+        }
 
     def test_s3_objects_tagged_with_ttl(self):
         """Test S3 objects tagged with TTL for lifecycle filtering."""


### PR DESCRIPTION
Follow up from https://github.com/langchain-ai/langchain-aws/pull/990#pullrequestreview-4103480296.

Currently, in `StorageStrategy` of the DynamoDB checkpointer, the S3 lifecycle rule ID is based only on the TTL configured:
```python
expiration_days = max(1, (self.ttl_seconds + 86399) // 86400)
rule_id = f"ttl-expiration-{expiration_days}d"
```
So, two or more prefix-scoped apps on the same bucket will also share the same lifecycle rule if their TTL config also matches. If the bucket-scoped rule happens to be deleted externally, lifecycle coverage will be broken for all of the prefix-scoped apps. 

This PR scopes the rule ID and filter to the key prefix (if provided), so that each app gets its own independent rule.
