### PR TITLE
fix(aws): strip streaming-only fields from invalid tool_use blocks

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -628,8 +628,13 @@ def _format_anthropic_messages(
                                 )
                             )
                         else:
-                            item.pop("text", None)
-                            tool_blocks.append(item)
+                            tool_blocks.append(
+                                {
+                                    k: v
+                                    for k, v in item.items()
+                                    if k not in ("text", "index", "partial_json")
+                                }
+                            )
                     elif item["type"] in ["thinking", "redacted_thinking"]:
                         # Store thinking blocks separately
                         thinking_blocks.append(

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
@@ -174,6 +174,44 @@ def test__format_anthropic_messages_with_tool_calls() -> None:
     assert expected == actual
 
 
+def test__format_anthropic_messages_strips_streaming_fields_on_invalid_tool() -> None:
+    """Regression for langchain-ai/langchain#31208."""
+    ai = AIMessage(
+        content=[
+            {
+                "type": "tool_use",
+                "id": "toolu_bad",
+                "name": "web_search",
+                "input": {},
+                "index": 2,
+                "partial_json": '{"bad": json}',
+            },
+        ],
+        tool_calls=[],
+        invalid_tool_calls=[
+            {
+                "type": "invalid_tool_call",
+                "id": "toolu_bad",
+                "name": "web_search",
+                "args": '{"bad": json}',
+                "error": "JSONDecodeError",
+            }
+        ],
+    )
+    _, formatted = _format_anthropic_messages([HumanMessage("go"), ai])
+    tool_use_block = next(
+        b for b in formatted[1]["content"] if b.get("type") == "tool_use"
+    )
+    assert "index" not in tool_use_block
+    assert "partial_json" not in tool_use_block
+    assert tool_use_block == {
+        "type": "tool_use",
+        "id": "toolu_bad",
+        "name": "web_search",
+        "input": {},
+    }
+
+
 def test__format_anthropic_messages_with_str_content_and_tool_calls() -> None:
     system = SystemMessage("fuzz")  # type: ignore[misc]
     human = HumanMessage("foo")  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Fixes #1010.

When the model emits tool args that fail to parse:
- langchain-core records the failure in `AIMessage.invalid_tool_calls` (instead of `tool_calls`).
- The accumulated `AIMessageChunk` content block keeps the raw Bedrock-streaming state: `input={}`, plus the streaming-protocol-only fields `index` and `partial_json`.

In `_format_anthropic_messages`, the `tool_use` branch has two paths:
- **id in `message.tool_calls`**: rebuilds a clean block via `_lc_tool_calls_to_anthropic_tool_use_blocks` — correct.
- **id not in `message.tool_calls`** (invalid tool call): appended the raw block verbatim. The leaked `index`/`partial_json` fields are rejected by Bedrock's Anthropic validator on the next replay:

  ```
  botocore.errorfactory.ValidationException: An error occurred (ValidationException)
  when calling the InvokeModelWithResponseStream operation:
  messages.N.content.M.tool_use.index: Extra inputs are not permitted
  ```

The fix mirrors what the adjacent `thinking` / `redacted_thinking` branch already does for its own streaming `index` field — strip the accumulation-only fields before append.

## Test plan

- [x] Added `test__format_anthropic_messages_strips_streaming_fields_on_invalid_tool` in `tests/unit_tests/chat_models/test_bedrock.py`. Confirmed it **fails** on `main` and **passes** with this fix (`AssertionError: assert 'index' not in {...}`).
- [x] `uv run pytest tests/unit_tests/chat_models/test_bedrock.py` — 108 passed.
- [x] `uv run --all-groups ruff check` / `ruff format --diff` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)