### PR TITLE
feat(aws): Add ChatBedrockMantle for Bedrock Mantle OpenAI-compatible…

### DIFF
--- a/libs/aws/langchain_aws/__init__.py
+++ b/libs/aws/langchain_aws/__init__.py
@@ -14,7 +14,11 @@ if TYPE_CHECKING:
         create_neptune_opencypher_qa_chain,
         create_neptune_sparql_qa_chain,
     )
-    from langchain_aws.chat_models import ChatAnthropicBedrock, ChatBedrockNovaSonic
+    from langchain_aws.chat_models import (
+        ChatAnthropicBedrock,
+        ChatBedrockMantle,
+        ChatBedrockNovaSonic,
+    )
     from langchain_aws.document_compressors.rerank import BedrockRerank
     from langchain_aws.embeddings import BedrockEmbeddings
     from langchain_aws.graphs import NeptuneAnalyticsGraph, NeptuneGraph
@@ -86,6 +90,7 @@ __all__ = [
     "ChatAnthropicBedrock",
     "ChatBedrock",
     "ChatBedrockConverse",
+    "ChatBedrockMantle",
     "ChatBedrockNovaSonic",
     "SagemakerEndpoint",
     "AmazonKendraRetriever",
@@ -119,6 +124,10 @@ def __getattr__(name: str) -> Any:
         "ChatAnthropicBedrock": (
             "langchain_aws.chat_models",
             "pip install langchain-aws[anthropic]",
+        ),
+        "ChatBedrockMantle": (
+            "langchain_aws.chat_models",
+            'pip install "langchain-aws[mantle]"',
         ),
         "ChatBedrockNovaSonic": (
             "langchain_aws.chat_models",

--- a/libs/aws/langchain_aws/chat_models/__init__.py
+++ b/libs/aws/langchain_aws/chat_models/__init__.py
@@ -5,12 +5,14 @@ from langchain_aws.chat_models.bedrock_converse import ChatBedrockConverse
 
 if TYPE_CHECKING:
     from langchain_aws.chat_models.anthropic import ChatAnthropicBedrock
+    from langchain_aws.chat_models.bedrock_mantle import ChatBedrockMantle
     from langchain_aws.chat_models.bedrock_nova_sonic import ChatBedrockNovaSonic
 
 __all__ = [
     "ChatAnthropicBedrock",
     "ChatBedrock",
     "ChatBedrockConverse",
+    "ChatBedrockMantle",
     "ChatBedrockNovaSonic",
 ]
 
@@ -21,6 +23,10 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "ChatAnthropicBedrock": (
         "langchain_aws.chat_models.anthropic",
         'pip install "langchain-aws[anthropic]"',
+    ),
+    "ChatBedrockMantle": (
+        "langchain_aws.chat_models.bedrock_mantle",
+        'pip install "langchain-aws[mantle]"',
     ),
     "ChatBedrockNovaSonic": (
         "langchain_aws.chat_models.bedrock_nova_sonic",

--- a/libs/aws/langchain_aws/chat_models/bedrock_mantle.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_mantle.py
@@ -1,0 +1,1066 @@
+"""ChatBedrockMantle — LangChain chat model for Amazon Bedrock Mantle.
+
+Wraps the OpenAI Python SDK to talk to Mantle's Chat Completions and Responses
+APIs at ``bedrock-mantle.<region>.api.aws``.  Supports both long-term API keys
+and auto-refreshing short-term API keys generated from AWS credentials.
+
+Install with::
+
+    pip install "langchain-aws[mantle]"
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import (
+    Any,
+    AsyncIterator,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Sequence,
+)
+
+from langchain_core.callbacks import (
+    AsyncCallbackManagerForLLMRun,
+    CallbackManagerForLLMRun,
+)
+from langchain_core.language_models import BaseChatModel
+from langchain_core.language_models.base import LangSmithParams
+from langchain_core.messages import (
+    AIMessage,
+    AIMessageChunk,
+    BaseMessage,
+    convert_to_openai_messages,
+)
+from langchain_core.messages.ai import UsageMetadata
+from langchain_core.messages.tool import tool_call_chunk
+from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
+from langchain_core.utils.function_calling import convert_to_openai_tool
+from pydantic import ConfigDict, Field, SecretStr, model_validator
+from typing_extensions import Self
+
+logger = logging.getLogger(__name__)
+
+# Keys that only exist in the Responses API — their presence forces that path.
+_RESPONSES_ONLY_KEYS = frozenset(
+    {
+        "previous_response_id",
+        "text",
+    }
+)
+
+# Keys that only exist in Chat Completions — their presence forces that path.
+_CHAT_COMPLETIONS_ONLY_KEYS = frozenset(
+    {
+        "response_format",
+    }
+)
+
+_MANTLE_BASE_URL_TEMPLATE = "https://bedrock-mantle.{region}.api.aws/v1"
+
+
+def _openai_response_to_ai_message(choice: Any) -> AIMessage:
+    """Convert an OpenAI ChatCompletion choice to an AIMessage."""
+    message = choice.message
+    tool_calls = []
+    if message.tool_calls:
+        for tc in message.tool_calls:
+            args = tc.function.arguments
+            try:
+                parsed = json.loads(args)
+            except (ValueError, TypeError):
+                parsed = args if isinstance(args, dict) else {"raw": args}
+            if not isinstance(parsed, dict):
+                parsed = {"raw": parsed}
+            tool_calls.append(
+                {
+                    "name": tc.function.name,
+                    "args": parsed,
+                    "id": tc.id,
+                    "type": "tool_call",
+                }
+            )
+
+    return AIMessage(
+        content=message.content or "",
+        tool_calls=tool_calls,
+        additional_kwargs={
+            k: v
+            for k, v in {
+                "refusal": getattr(message, "refusal", None),
+            }.items()
+            if v is not None
+        },
+        response_metadata={
+            "finish_reason": choice.finish_reason,
+        },
+    )
+
+
+def _handle_openai_error(error: Exception) -> None:
+    """Handle OpenAI SDK errors with enhanced messages for Mantle.
+
+    Translates OpenAI SDK exceptions into actionable error messages
+    specific to the Bedrock Mantle context.
+    """
+    try:
+        from openai import (
+            AuthenticationError,
+            BadRequestError,
+            NotFoundError,
+            RateLimitError,
+        )
+    except ImportError:
+        raise error
+
+    if isinstance(error, AuthenticationError):
+        raise ValueError(
+            "Bedrock Mantle authentication failed. Your API key or "
+            "short-term token may be invalid or expired. If using "
+            "short-term tokens, ensure your AWS credentials are valid. "
+            "If using a static API key, verify it in the Bedrock Console. "
+            f"Original error: {error}"
+        ) from error
+
+    if isinstance(error, RateLimitError):
+        raise ValueError(
+            "Bedrock Mantle rate limit exceeded. Consider reducing request "
+            "frequency or requesting a quota increase via AWS Support. "
+            f"Original error: {error}"
+        ) from error
+
+    if isinstance(error, NotFoundError):
+        raise ValueError(
+            "Bedrock Mantle model not found. Verify the model ID is correct "
+            "and available in your region. Use list_models() to see available "
+            f"models. Original error: {error}"
+        ) from error
+
+    if isinstance(error, BadRequestError):
+        msg = str(error)
+        if "tool_choice" in msg:
+            raise ValueError(
+                "Bedrock Mantle rejected the tool_choice value. "
+                f"Original error: {error}"
+            ) from error
+        if "does not support" in msg:
+            raise ValueError(
+                "Bedrock Mantle: the requested feature is not supported "
+                f"for this model. Original error: {error}"
+            ) from error
+        raise ValueError(
+            f"Bedrock Mantle bad request. Original error: {error}"
+        ) from error
+
+    raise error
+
+
+def _parse_responses_tool_args(args: Any) -> Dict[str, Any]:
+    """Parse tool-call arguments from the Responses API into a dict.
+
+    LangChain expects tool-call ``args`` to be a ``dict``.  The Responses
+    API may return a JSON string, a dict, a list, or ``None``.
+    """
+    try:
+        parsed = json.loads(args) if isinstance(args, str) else args
+    except (ValueError, TypeError):
+        parsed = args if isinstance(args, dict) else {"raw": args}
+    if not isinstance(parsed, dict):
+        parsed = {"raw": parsed}
+    return parsed
+
+
+def _extract_responses_output(response: Any) -> tuple[str, list]:
+    """Extract content text and tool calls from a Responses API response."""
+    content = ""
+    tool_calls: list = []
+    if response.output:
+        for item in response.output:
+            if hasattr(item, "content"):
+                for block in item.content:
+                    if hasattr(block, "text"):
+                        content += block.text
+            elif hasattr(item, "name"):
+                args = item.arguments if hasattr(item, "arguments") else ""
+                tool_calls.append(
+                    {
+                        "name": item.name,
+                        "args": _parse_responses_tool_args(args),
+                        "id": (item.call_id if hasattr(item, "call_id") else item.id),
+                        "type": "tool_call",
+                    }
+                )
+    return content, tool_calls
+
+
+def _get_last_messages_and_response_id(
+    messages: Sequence[BaseMessage],
+) -> tuple[list[BaseMessage], Optional[str]]:
+    """Extract the most recent ``previous_response_id`` from message history.
+
+    Scans backward for the last ``AIMessage`` whose ``id`` starts with
+    ``resp_``.  Returns the messages after that point and the response ID.
+    If no such message is found, returns all messages and ``None``.
+    """
+    for i in range(len(messages) - 1, -1, -1):
+        msg = messages[i]
+        if isinstance(msg, AIMessage):
+            resp_id = getattr(msg, "id", None) or ""
+            if resp_id.startswith("resp_"):
+                return list(messages[i + 1 :]), resp_id
+    return list(messages), None
+
+
+def _build_chat_completions_result(response: Any) -> ChatResult:
+    """Build a ``ChatResult`` from a Chat Completions API response."""
+    choice = response.choices[0]
+    ai_msg = _openai_response_to_ai_message(choice)
+
+    if response.usage:
+        ai_msg.usage_metadata = UsageMetadata(
+            input_tokens=response.usage.prompt_tokens,
+            output_tokens=response.usage.completion_tokens,
+            total_tokens=response.usage.total_tokens,
+        )
+
+    ai_msg.response_metadata["model"] = response.model
+    ai_msg.response_metadata["id"] = response.id
+    return ChatResult(generations=[ChatGeneration(message=ai_msg)])
+
+
+def _build_responses_result(response: Any) -> ChatResult:
+    """Build a ``ChatResult`` from a Responses API response object."""
+    content, tool_calls = _extract_responses_output(response)
+
+    ai_msg = AIMessage(
+        content=content,
+        tool_calls=tool_calls,
+        id=response.id,
+        response_metadata={
+            "id": response.id,
+            "model": response.model,
+            "status": response.status if hasattr(response, "status") else None,
+        },
+    )
+
+    if hasattr(response, "usage") and response.usage:
+        ai_msg.usage_metadata = UsageMetadata(
+            input_tokens=response.usage.input_tokens,
+            output_tokens=response.usage.output_tokens,
+            total_tokens=response.usage.total_tokens,
+        )
+
+    return ChatResult(generations=[ChatGeneration(message=ai_msg)])
+
+
+class ChatBedrockMantle(BaseChatModel):
+    """LangChain chat model for Amazon Bedrock via the Mantle inference engine.
+
+    Supports models available on the ``bedrock-mantle`` endpoint using the
+    OpenAI-compatible Responses API and Chat Completions API.
+
+    Setup:
+        Install the optional Mantle dependencies::
+
+            pip install "langchain-aws[mantle]"
+
+    Instantiate:
+        .. code-block:: python
+
+            from langchain_aws import ChatBedrockMantle
+
+            llm = ChatBedrockMantle(
+                model="deepseek.v3.2",
+                region_name="us-east-1",
+            )
+
+    Invoke:
+        .. code-block:: python
+
+            response = llm.invoke("What is 2+2?")
+
+    Stream:
+        .. code-block:: python
+
+            for chunk in llm.stream("Say hello in 3 languages"):
+                print(chunk.content)
+
+    Async:
+        .. code-block:: python
+
+            response = await llm.ainvoke("What is 2+2?")
+
+    Conversation state with previous_response_id:
+        .. code-block:: python
+
+            llm = ChatBedrockMantle(
+                model="deepseek.v3.2",
+                region_name="us-east-1",
+            )
+            response = llm.invoke("Hello")
+            response_id = response.response_metadata["id"]
+            followup = llm.invoke(
+                "Tell me more",
+                previous_response_id=response_id,
+            )
+    """
+
+    model: str = Field(..., alias="model")
+    """Mantle model ID, e.g. ``deepseek.v3.2``, ``qwen.qwen3-32b``."""
+
+    region_name: Optional[str] = None
+    """AWS region. Used to construct the Mantle endpoint URL."""
+
+    base_url: Optional[str] = None
+    """Override the Mantle endpoint URL."""
+
+    temperature: Optional[float] = None
+    max_tokens: Optional[int] = None
+    model_kwargs: Dict[str, Any] = Field(default_factory=dict)
+    """Additional parameters passed to the underlying SDK."""
+
+    use_responses_api: Optional[bool] = None
+    """Whether to use the Responses API instead of Chat Completions.
+
+    Applies to OpenAI-compatible models only.
+
+    - ``True``: always use the Responses API.
+    - ``False``: always use the Chat Completions API.
+    - ``None`` (default): auto-detect per request. Defaults to the
+      Responses API unless Chat-Completions-only parameters (e.g.
+      ``response_format``) are present.
+    """
+
+    use_previous_response_id: bool = False
+    """If ``True``, automatically pass ``previous_response_id``.
+
+    Uses the ID of the most recent ``AIMessage`` in the input message
+    sequence. Messages up to that response are dropped from the request
+    payload. Applies to OpenAI-compatible models only (Responses API).
+    """
+
+    stream_usage: Optional[bool] = None
+    """Whether to include usage metadata in streaming output.
+
+    Applies to OpenAI-compatible models only.
+
+    If ``True``, ``stream_options={"include_usage": True}`` is sent.
+    If ``False``, usage is not requested.  If ``None`` (default),
+    usage is included.
+    """
+
+    max_retries: int = 2
+    """Maximum number of retries for transient errors (5xx, connection, timeout)."""
+
+    timeout: Optional[float] = None
+    """Request timeout in seconds. Applies to both connect and read."""
+
+    bedrock_api_key: Optional[SecretStr] = Field(default=None, alias="api_key")
+    """Static Bedrock API key. If provided, short-term key generation is skipped."""
+
+    _sync_client: Any = None
+    _async_client: Any = None
+    _resolved_region: str = ""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    @model_validator(mode="after")
+    def _validate_environment(self) -> Self:
+        try:
+            from openai import AsyncOpenAI, OpenAI
+        except ImportError as exc:
+            raise ModuleNotFoundError(
+                "Could not import openai. "
+                'Please install it via: pip install "langchain-aws[mantle]"'
+            ) from exc
+
+        region = (
+            self.region_name
+            or os.environ.get("AWS_REGION")
+            or os.environ.get("AWS_DEFAULT_REGION")
+        )
+        if not region and not self.base_url:
+            try:
+                import botocore.session
+
+                region = botocore.session.Session().get_config_variable("region")
+            except (ImportError, OSError, ValueError) as exc:
+                # ImportError: botocore not installed
+                # OSError: config file not readable
+                # ValueError: malformed config
+                logger.debug("Could not resolve region from botocore: %s", exc)
+        if not region and not self.base_url:
+            raise ValueError(
+                "region_name must be provided, or set AWS_REGION / "
+                "AWS_DEFAULT_REGION, or provide base_url."
+            )
+        self._resolved_region = region or ""
+
+        url = self.base_url or _MANTLE_BASE_URL_TEMPLATE.format(
+            region=self._resolved_region
+        )
+
+        if self.bedrock_api_key:
+            api_key: Any = self.bedrock_api_key.get_secret_value()
+        else:
+            try:
+                from importlib.util import find_spec
+
+                if find_spec("aws_bedrock_token_generator") is None:
+                    raise ImportError("aws_bedrock_token_generator not found")
+            except ImportError as exc:
+                raise ModuleNotFoundError(
+                    "Could not import aws-bedrock-token-generator. "
+                    'Please install it via: pip install "langchain-aws[mantle]"'
+                ) from exc
+
+            from langchain_aws.utils import _BedrockApiKeyProvider
+
+            api_key = _BedrockApiKeyProvider(self._resolved_region)
+
+        client_kwargs: Dict[str, Any] = {
+            "api_key": api_key,
+            "base_url": url,
+            "max_retries": self.max_retries,
+            "default_headers": {
+                "x-client-framework": "langchain-aws",
+            },
+        }
+        if self.timeout is not None:
+            client_kwargs["timeout"] = self.timeout
+
+        self._sync_client = OpenAI(**client_kwargs)
+        async_kwargs = {**client_kwargs}
+        if callable(api_key) and hasattr(api_key, "async_call"):
+            async_kwargs["api_key"] = api_key.async_call
+        self._async_client = AsyncOpenAI(**async_kwargs)  # type: ignore[arg-type]
+        return self
+
+    @property
+    def _llm_type(self) -> str:
+        return "bedrock-mantle"
+
+    def _get_ls_params(
+        self, stop: Optional[List[str]] = None, **kwargs: Any
+    ) -> LangSmithParams:
+        """Get standard params for LangSmith tracing."""
+        ls_params = LangSmithParams(
+            ls_provider="amazon_bedrock_mantle",
+            ls_model_name=self.model,
+            ls_model_type="chat",
+            ls_temperature=self.temperature,
+        )
+        if self.max_tokens:
+            ls_params["ls_max_tokens"] = self.max_tokens
+        if stop:
+            ls_params["ls_stop"] = stop
+        return ls_params
+
+    def _use_responses_api(self, params: Dict[str, Any]) -> bool:
+        """Decide whether to route this request to the Responses API.
+
+        If ``use_responses_api`` is set explicitly (``True`` / ``False``),
+        that value is honored.  Otherwise defaults to the Responses API
+        unless Chat-Completions-only parameters are present.
+        """
+        if isinstance(self.use_responses_api, bool):
+            return self.use_responses_api
+
+        # If Responses-API-only keys are present, always use Responses API
+        if _RESPONSES_ONLY_KEYS.intersection(params):
+            return True
+
+        # Fall back to Chat Completions for Chat-Completions-only keys
+        if _CHAT_COMPLETIONS_ONLY_KEYS.intersection(params):
+            return False
+
+        # Default: Responses API
+        return True
+
+    def _generate(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        if self.use_previous_response_id:
+            messages, prev_id = _get_last_messages_and_response_id(messages)
+            if prev_id:
+                kwargs.setdefault("previous_response_id", prev_id)
+        params = self._build_params(stop=stop, stream=False, **kwargs)
+        logger.debug("ChatBedrockMantle input messages: %s", messages)
+        logger.debug("ChatBedrockMantle params: %s", params)
+
+        try:
+            if self._use_responses_api(params):
+                return self._generate_responses_api(messages, params)
+            return self._generate_chat_completions(messages, params)
+        except Exception as e:
+            _handle_openai_error(e)
+            raise  # unreachable, but satisfies type checker
+
+    def _generate_chat_completions(
+        self,
+        messages: List[BaseMessage],
+        params: Dict[str, Any],
+    ) -> ChatResult:
+        """Generate via the Chat Completions API."""
+        openai_msgs = convert_to_openai_messages(messages)
+        response = self._sync_client.chat.completions.create(
+            messages=openai_msgs, **params
+        )
+        logger.debug("ChatBedrockMantle response: %s", response)
+        return _build_chat_completions_result(response)
+
+    def _generate_responses_api(
+        self,
+        messages: List[BaseMessage],
+        params: Dict[str, Any],
+    ) -> ChatResult:
+        """Generate via the Responses API (``/v1/responses``)."""
+        resp_params = self._prepare_responses_params(params)
+        openai_msgs = convert_to_openai_messages(messages)
+
+        response = self._sync_client.responses.create(input=openai_msgs, **resp_params)
+        return _build_responses_result(response)
+
+    async def _agenerate(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[AsyncCallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        if self.use_previous_response_id:
+            messages, prev_id = _get_last_messages_and_response_id(messages)
+            if prev_id:
+                kwargs.setdefault("previous_response_id", prev_id)
+        params = self._build_params(stop=stop, stream=False, **kwargs)
+
+        try:
+            if self._use_responses_api(params):
+                return await self._agenerate_responses_api(messages, params)
+            return await self._agenerate_chat_completions(messages, params)
+        except Exception as e:
+            _handle_openai_error(e)
+            raise
+
+    async def _agenerate_chat_completions(
+        self,
+        messages: List[BaseMessage],
+        params: Dict[str, Any],
+    ) -> ChatResult:
+        """Async generate via the Chat Completions API."""
+        openai_msgs = convert_to_openai_messages(messages)
+        response = await self._async_client.chat.completions.create(
+            messages=openai_msgs, **params
+        )
+        return _build_chat_completions_result(response)
+
+    async def _agenerate_responses_api(
+        self,
+        messages: List[BaseMessage],
+        params: Dict[str, Any],
+    ) -> ChatResult:
+        """Async generate via the Responses API (``/v1/responses``)."""
+        resp_params = self._prepare_responses_params(params)
+        openai_msgs = convert_to_openai_messages(messages)
+
+        response = await self._async_client.responses.create(
+            input=openai_msgs, **resp_params
+        )
+        return _build_responses_result(response)
+
+    def _stream(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> Iterator[ChatGenerationChunk]:
+        if self.use_previous_response_id:
+            messages, prev_id = _get_last_messages_and_response_id(messages)
+            if prev_id:
+                kwargs.setdefault("previous_response_id", prev_id)
+        params = self._build_params(stop=stop, stream=True, **kwargs)
+        if self._use_responses_api(params):
+            yield from self._stream_responses(messages, params, run_manager)
+        else:
+            yield from self._stream_chat_completions(messages, params, run_manager)
+
+    def _stream_chat_completions(
+        self,
+        messages: List[BaseMessage],
+        params: Dict[str, Any],
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+    ) -> Iterator[ChatGenerationChunk]:
+        """Stream via the Chat Completions API."""
+        openai_msgs = convert_to_openai_messages(messages)
+        logger.debug("ChatBedrockMantle streaming (chat) with params: %s", params)
+
+        try:
+            stream = self._sync_client.chat.completions.create(
+                messages=openai_msgs, **params
+            )
+        except Exception as e:
+            _handle_openai_error(e)
+            raise
+
+        for chunk in stream:
+            result = self._process_chat_stream_chunk(chunk)
+            if result is None:
+                continue
+            token, gen_chunk = result
+            if run_manager:
+                run_manager.on_llm_new_token(token, chunk=gen_chunk)
+            yield gen_chunk
+
+    def _stream_responses(
+        self,
+        messages: List[BaseMessage],
+        params: Dict[str, Any],
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+    ) -> Iterator[ChatGenerationChunk]:
+        """Stream via the Responses API (``/v1/responses``)."""
+        resp_params = self._prepare_responses_params(params)
+        openai_msgs = convert_to_openai_messages(messages)
+        logger.debug(
+            "ChatBedrockMantle streaming (responses) with params: %s", resp_params
+        )
+
+        try:
+            stream = self._sync_client.responses.create(
+                input=openai_msgs, stream=True, **resp_params
+            )
+        except Exception as e:
+            _handle_openai_error(e)
+            raise
+
+        for event in stream:
+            result = self._process_responses_stream_event(event)
+            if result is None:
+                continue
+            token, gen_chunk = result
+            if run_manager:
+                run_manager.on_llm_new_token(token, chunk=gen_chunk)
+            yield gen_chunk
+
+    async def _astream(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[AsyncCallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[ChatGenerationChunk]:
+        if self.use_previous_response_id:
+            messages, prev_id = _get_last_messages_and_response_id(messages)
+            if prev_id:
+                kwargs.setdefault("previous_response_id", prev_id)
+        params = self._build_params(stop=stop, stream=True, **kwargs)
+        if self._use_responses_api(params):
+            async for chunk in self._astream_responses(messages, params, run_manager):
+                yield chunk
+        else:
+            async for chunk in self._astream_chat_completions(
+                messages, params, run_manager
+            ):
+                yield chunk
+
+    async def _astream_chat_completions(
+        self,
+        messages: List[BaseMessage],
+        params: Dict[str, Any],
+        run_manager: Optional[AsyncCallbackManagerForLLMRun] = None,
+    ) -> AsyncIterator[ChatGenerationChunk]:
+        """Async stream via the Chat Completions API."""
+        openai_msgs = convert_to_openai_messages(messages)
+
+        try:
+            stream = await self._async_client.chat.completions.create(
+                messages=openai_msgs, **params
+            )
+        except Exception as e:
+            _handle_openai_error(e)
+            raise
+
+        async for chunk in stream:
+            result = self._process_chat_stream_chunk(chunk)
+            if result is None:
+                continue
+            token, gen_chunk = result
+            if run_manager:
+                await run_manager.on_llm_new_token(token, chunk=gen_chunk)
+            yield gen_chunk
+
+    async def _astream_responses(
+        self,
+        messages: List[BaseMessage],
+        params: Dict[str, Any],
+        run_manager: Optional[AsyncCallbackManagerForLLMRun] = None,
+    ) -> AsyncIterator[ChatGenerationChunk]:
+        """Async stream via the Responses API (``/v1/responses``)."""
+        resp_params = self._prepare_responses_params(params)
+        openai_msgs = convert_to_openai_messages(messages)
+
+        try:
+            stream = await self._async_client.responses.create(
+                input=openai_msgs, stream=True, **resp_params
+            )
+        except Exception as e:
+            _handle_openai_error(e)
+            raise
+
+        async for event in stream:
+            result = self._process_responses_stream_event(event)
+            if result is None:
+                continue
+            token, gen_chunk = result
+            if run_manager:
+                await run_manager.on_llm_new_token(token, chunk=gen_chunk)
+            yield gen_chunk
+
+    def _process_chat_stream_chunk(
+        self, chunk: Any
+    ) -> Optional[tuple[str, ChatGenerationChunk]]:
+        """Convert a Chat Completions streaming chunk to a (token, chunk) pair."""
+        if not chunk.choices:
+            return None
+        delta = chunk.choices[0].delta
+        content: str = delta.content or ""
+
+        tc_chunks = []
+        if delta.tool_calls:
+            for tc in delta.tool_calls:
+                tc_chunks.append(
+                    tool_call_chunk(
+                        name=tc.function.name if tc.function else None,
+                        args=tc.function.arguments if tc.function else None,
+                        id=tc.id,
+                        index=tc.index,
+                    )
+                )
+
+        msg_chunk = AIMessageChunk(
+            content=content,
+            tool_call_chunks=tc_chunks,
+        )
+
+        if chunk.choices[0].finish_reason:
+            msg_chunk.response_metadata["finish_reason"] = chunk.choices[
+                0
+            ].finish_reason
+
+        if hasattr(chunk, "usage") and chunk.usage:
+            msg_chunk.usage_metadata = UsageMetadata(
+                input_tokens=chunk.usage.prompt_tokens or 0,
+                output_tokens=chunk.usage.completion_tokens or 0,
+                total_tokens=chunk.usage.total_tokens or 0,
+            )
+
+        return content, ChatGenerationChunk(message=msg_chunk)
+
+    def _process_responses_stream_event(
+        self, event: Any
+    ) -> Optional[tuple[str, ChatGenerationChunk]]:
+        """Convert a Responses API SSE event to a (token, chunk) pair.
+
+        Handled event types:
+
+        - ``response.output_text.delta`` — text token
+        - ``response.output_item.added`` (type ``function_call``) — tool-call start
+        - ``response.function_call_arguments.delta`` — tool-call arg fragment
+        - ``response.completed`` — final usage metadata
+        """
+        if event.type == "response.output_text.delta":
+            text: str = event.delta or ""
+            msg_chunk = AIMessageChunk(content=text)
+            return text, ChatGenerationChunk(message=msg_chunk)
+
+        if (
+            event.type == "response.output_item.added"
+            and hasattr(event, "item")
+            and getattr(event.item, "type", None) == "function_call"
+        ):
+            tc = tool_call_chunk(
+                name=event.item.name,
+                args="",
+                id=event.item.call_id,
+                index=event.output_index if hasattr(event, "output_index") else 0,
+            )
+            msg_chunk = AIMessageChunk(content="", tool_call_chunks=[tc])
+            return "", ChatGenerationChunk(message=msg_chunk)
+
+        if event.type == "response.function_call_arguments.delta":
+            tc = tool_call_chunk(
+                name=None,
+                args=event.delta,
+                id=None,
+                index=event.output_index if hasattr(event, "output_index") else 0,
+            )
+            msg_chunk = AIMessageChunk(content="", tool_call_chunks=[tc])
+            return "", ChatGenerationChunk(message=msg_chunk)
+
+        if event.type == "response.completed":
+            response = event.response
+            usage_metadata = None
+            if hasattr(response, "usage") and response.usage:
+                usage_metadata = UsageMetadata(
+                    input_tokens=response.usage.input_tokens,
+                    output_tokens=response.usage.output_tokens,
+                    total_tokens=response.usage.total_tokens,
+                )
+            msg_chunk = AIMessageChunk(
+                content="",
+                id=response.id,
+                usage_metadata=usage_metadata,
+                response_metadata={
+                    "id": response.id,
+                    "model": response.model,
+                    "finish_reason": "stop",
+                },
+            )
+            return "", ChatGenerationChunk(message=msg_chunk)
+
+        return None
+
+    def bind_tools(
+        self,
+        tools: Sequence[Any],
+        *,
+        tool_choice: Optional[str | Dict] = None,
+        **kwargs: Any,
+    ) -> "ChatBedrockMantle":
+        """Bind tool definitions for function calling."""
+        formatted = [convert_to_openai_tool(t) for t in tools]
+        bind_kwargs: Dict[str, Any] = {"tools": formatted, **kwargs}
+        if tool_choice:
+            bind_kwargs["tool_choice"] = tool_choice
+        return super().bind(**bind_kwargs)  # type: ignore[return-value]
+
+    def with_structured_output(
+        self,
+        schema: Any,
+        *,
+        method: str = "json_schema",
+        include_raw: bool = False,
+        **kwargs: Any,
+    ) -> Any:
+        """Return a runnable that produces structured output.
+
+        Args:
+            schema: A Pydantic model, TypedDict, or JSON Schema dict
+                describing the desired output shape.
+            method: One of ``"json_schema"`` (default — uses the Responses
+                API ``text.format``), ``"function_calling"`` (uses tool
+                calling), or ``"json_mode"`` (uses Chat Completions
+                ``response_format={"type": "json_object"}``).
+            include_raw: If ``True``, return a dict with ``raw``,
+                ``parsed``, and ``parsing_error`` keys.
+            kwargs: Additional keyword arguments passed to the model.
+
+        Returns:
+            A ``Runnable`` that outputs structured data.
+        """
+        from operator import itemgetter
+
+        from langchain_core.output_parsers import (
+            JsonOutputParser,
+            PydanticOutputParser,
+        )
+        from langchain_core.output_parsers.openai_tools import (
+            JsonOutputKeyToolsParser,
+            PydanticToolsParser,
+        )
+        from langchain_core.runnables import Runnable, RunnableMap, RunnablePassthrough
+        from langchain_core.utils.pydantic import is_basemodel_subclass
+
+        is_pydantic = isinstance(schema, type) and is_basemodel_subclass(schema)
+
+        if method == "function_calling":
+            tool_name = convert_to_openai_tool(schema)["function"]["name"]
+            llm: Runnable = self.bind_tools([schema], tool_choice=tool_name, **kwargs)
+            if is_pydantic:
+                output_parser: Any = PydanticToolsParser(
+                    tools=[schema], first_tool_only=True
+                )
+            else:
+                output_parser = JsonOutputKeyToolsParser(
+                    key_name=tool_name, first_tool_only=True
+                )
+        elif method == "json_mode":
+            llm = self.bind(response_format={"type": "json_object"}, **kwargs)
+            output_parser = (
+                PydanticOutputParser(pydantic_object=schema)
+                if is_pydantic
+                else JsonOutputParser()
+            )
+        elif method == "json_schema":
+            if self.use_responses_api is False:
+                logger.warning(
+                    "with_structured_output(method='json_schema') uses the "
+                    "Responses API text.format parameter, but "
+                    "use_responses_api=False is set. The text parameter "
+                    "will be ignored by Chat Completions. Use "
+                    "method='json_mode' or method='function_calling' instead."
+                )
+            if is_pydantic:
+                json_schema = schema.model_json_schema()
+            elif isinstance(schema, dict):
+                json_schema = schema
+            else:
+                msg = (
+                    f"Unsupported schema type for json_schema method: "
+                    f"{type(schema)}. Use a Pydantic model or dict."
+                )
+                raise ValueError(msg)
+
+            schema_name = json_schema.get(
+                "title", getattr(schema, "__name__", "Output")
+            )
+            text_format = {
+                "type": "json_schema",
+                "name": schema_name,
+                "schema": json_schema,
+                "strict": True,
+            }
+            llm = self.bind(text={"format": text_format}, **kwargs)
+            output_parser = (
+                PydanticOutputParser(pydantic_object=schema)
+                if is_pydantic
+                else JsonOutputParser()
+            )
+        else:
+            msg = (
+                f"Unrecognized method '{method}'. Expected one of "
+                f"'function_calling', 'json_mode', or 'json_schema'."
+            )
+            raise ValueError(msg)
+
+        if include_raw:
+            parser_assign = RunnablePassthrough.assign(
+                parsed=itemgetter("raw") | output_parser,
+                parsing_error=lambda _: None,
+            )
+            parser_none = RunnablePassthrough.assign(parsed=lambda _: None)
+            parser_with_fallback = parser_assign.with_fallbacks(
+                [parser_none], exception_key="parsing_error"
+            )
+            return RunnableMap(raw=llm) | parser_with_fallback
+        return llm | output_parser
+
+    def list_models(self) -> List[Dict[str, Any]]:
+        """List available models from the Mantle ``/v1/models`` endpoint."""
+        try:
+            response = self._sync_client.models.list()
+        except Exception as e:
+            _handle_openai_error(e)
+            raise
+        return [
+            {"id": m.id, "created": m.created, "owned_by": m.owned_by} for m in response
+        ]
+
+    def _build_params(
+        self,
+        stop: Optional[List[str]] = None,
+        stream: bool = False,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Build parameters dict for the OpenAI SDK call."""
+        params: Dict[str, Any] = {
+            "model": self.model,
+            "stream": stream,
+        }
+        if self.temperature is not None:
+            params["temperature"] = self.temperature
+        if self.max_tokens is not None:
+            params["max_tokens"] = self.max_tokens
+        if stop:
+            params["stop"] = stop
+
+        merged = {**self.model_kwargs, **kwargs}
+        if "tools" in merged:
+            params["tools"] = merged.pop("tools")
+        if "tool_choice" in merged:
+            params["tool_choice"] = merged.pop("tool_choice")
+        if "previous_response_id" in merged:
+            params["previous_response_id"] = merged.pop("previous_response_id")
+
+        for k, v in merged.items():
+            if k not in params:
+                params[k] = v
+
+        if stream:
+            should_include_usage = (
+                self.stream_usage if self.stream_usage is not None else True
+            )
+            if should_include_usage:
+                params["stream_options"] = {"include_usage": True}
+
+        return params
+
+    def _prepare_responses_params(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Adapt ``_build_params`` output for the Responses API.
+
+        Pops/remaps keys that differ between Chat Completions and the
+        Responses API so callers don't need to worry about the difference.
+        """
+        resp_params = dict(params)
+        resp_params.pop("stream", None)
+        stop = resp_params.pop("stop", None)
+        if stop:
+            logger.warning(
+                "Bedrock Mantle Responses API does not support 'stop' "
+                "sequences. The stop=%r parameter will be ignored. Use "
+                "use_responses_api=False to route through Chat Completions "
+                "which supports stop sequences.",
+                stop,
+            )
+        resp_params.pop("stream_options", None)
+        max_tokens = resp_params.pop("max_tokens", None)
+        if max_tokens is not None:
+            resp_params["max_output_tokens"] = max_tokens
+
+        # Convert Chat Completions tool format to Responses API format.
+        # Chat Completions: {"type": "function", "function": {"name": ..., ...}}
+        # Responses API:    {"type": "function", "name": ..., ...}
+        if "tools" in resp_params:
+            converted: List[Dict[str, Any]] = []
+            for tool in resp_params["tools"]:
+                if (
+                    isinstance(tool, dict)
+                    and tool.get("type") == "function"
+                    and "function" in tool
+                ):
+                    converted.append({"type": "function", **tool["function"]})
+                else:
+                    converted.append(tool)
+            resp_params["tools"] = converted
+
+        # Validate tool_choice — Mantle may only support "auto" or "none".
+        if "tool_choice" in resp_params:
+            tc = resp_params["tool_choice"]
+            # Convert Chat Completions dict format to Responses API format
+            if (
+                isinstance(tc, dict)
+                and tc.get("type") == "function"
+                and "function" in tc
+            ):
+                resp_params["tool_choice"] = {
+                    "type": "function",
+                    **tc["function"],
+                }
+                tc = resp_params["tool_choice"]
+            if isinstance(tc, str) and tc not in ("auto", "none"):
+                logger.warning(
+                    "Bedrock Mantle Responses API may only support "
+                    "tool_choice='auto' or 'none'. Got %r — the API "
+                    "may reject this.",
+                    tc,
+                )
+
+        return resp_params

--- a/libs/aws/langchain_aws/chat_models/bedrock_mantle.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_mantle.py
@@ -1,14 +1,3 @@
-"""ChatBedrockMantle — LangChain chat model for Amazon Bedrock Mantle.
-
-Wraps the OpenAI Python SDK to talk to Mantle's Chat Completions and Responses
-APIs at ``bedrock-mantle.<region>.api.aws``.  Supports both long-term API keys
-and auto-refreshing short-term API keys generated from AWS credentials.
-
-Install with::
-
-    pip install "langchain-aws[mantle]"
-"""
-
 from __future__ import annotations
 
 import json
@@ -20,36 +9,49 @@ from typing import (
     Dict,
     Iterator,
     List,
+    Literal,
     Optional,
     Sequence,
+    Union,
 )
 
 from langchain_core.callbacks import (
     AsyncCallbackManagerForLLMRun,
     CallbackManagerForLLMRun,
 )
-from langchain_core.language_models import BaseChatModel
+from langchain_core.language_models import BaseChatModel, LanguageModelInput
 from langchain_core.language_models.base import LangSmithParams
 from langchain_core.messages import (
     AIMessage,
     AIMessageChunk,
     BaseMessage,
+    HumanMessage,
+    SystemMessage,
+    ToolMessage,
     convert_to_openai_messages,
 )
 from langchain_core.messages.ai import UsageMetadata
 from langchain_core.messages.tool import tool_call_chunk
 from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
+from langchain_core.runnables import Runnable
+from langchain_core.utils import secret_from_env
 from langchain_core.utils.function_calling import convert_to_openai_tool
 from pydantic import ConfigDict, Field, SecretStr, model_validator
 from typing_extensions import Self
+
+from langchain_aws.utils import _BEDROCK_API_KEY_MAX_TTL_SECONDS
 
 logger = logging.getLogger(__name__)
 
 # Keys that only exist in the Responses API — their presence forces that path.
 _RESPONSES_ONLY_KEYS = frozenset(
     {
+        "context_management",
+        "include",
         "previous_response_id",
+        "reasoning",
         "text",
+        "truncation",
     }
 )
 
@@ -102,44 +104,34 @@ def _openai_response_to_ai_message(choice: Any) -> AIMessage:
 
 
 def _handle_openai_error(error: Exception) -> None:
-    """Handle OpenAI SDK errors with enhanced messages for Mantle.
+    """Handle OpenAI SDK errors, re-raising the original exception.
 
-    Translates OpenAI SDK exceptions into actionable error messages
-    specific to the Bedrock Mantle context.
+    Preserves the original error type hierarchy so callers can catch
+    specific OpenAI exceptions (AuthenticationError, RateLimitError, etc.).
+    Only wraps errors when additional Mantle-specific context is needed.
     """
     try:
-        from openai import (
-            AuthenticationError,
-            BadRequestError,
-            NotFoundError,
-            RateLimitError,
-        )
+        from openai import AuthenticationError, BadRequestError
     except ImportError:
         raise error
 
-    if isinstance(error, AuthenticationError):
-        raise ValueError(
-            "Bedrock Mantle authentication failed. Your API key or "
-            "short-term token may be invalid or expired. If using "
-            "short-term tokens, ensure your AWS credentials are valid. "
-            "If using a static API key, verify it in the Bedrock Console. "
-            f"Original error: {error}"
-        ) from error
+    # Some models (openai.gpt-5.*, google.gemma-4-*, xai.grok-4.3) are
+    # served at /openai/v1/* instead of /v1/*. Hitting the wrong base
+    # path returns "Berm is not enabled for this account" as an
+    # AuthenticationError. Log a routing hint; the exception is re-raised
+    # unchanged so type-based handling continues to work.
+    if isinstance(error, AuthenticationError) and "Berm is not enabled" in str(error):
+        logger.warning(
+            "Bedrock Mantle returned 'Berm is not enabled for this "
+            "account'. This typically means the model requires the "
+            "'/openai/v1' base path instead of '/v1'. Affected families "
+            "include openai.gpt-5.*, google.gemma-4-*, and xai.grok-4.3. "
+            "Set base_url to include the '/openai/v1' prefix — e.g. "
+            "'https://bedrock-mantle.<region>.api.aws/openai/v1'."
+        )
 
-    if isinstance(error, RateLimitError):
-        raise ValueError(
-            "Bedrock Mantle rate limit exceeded. Consider reducing request "
-            "frequency or requesting a quota increase via AWS Support. "
-            f"Original error: {error}"
-        ) from error
-
-    if isinstance(error, NotFoundError):
-        raise ValueError(
-            "Bedrock Mantle model not found. Verify the model ID is correct "
-            "and available in your region. Use list_models() to see available "
-            f"models. Original error: {error}"
-        ) from error
-
+    # Only add context for BadRequestError cases where Mantle-specific
+    # guidance helps the user. All other errors are re-raised unchanged.
     if isinstance(error, BadRequestError):
         msg = str(error)
         if "tool_choice" in msg:
@@ -152,9 +144,6 @@ def _handle_openai_error(error: Exception) -> None:
                 "Bedrock Mantle: the requested feature is not supported "
                 f"for this model. Original error: {error}"
             ) from error
-        raise ValueError(
-            f"Bedrock Mantle bad request. Original error: {error}"
-        ) from error
 
     raise error
 
@@ -175,26 +164,190 @@ def _parse_responses_tool_args(args: Any) -> Dict[str, Any]:
 
 
 def _extract_responses_output(response: Any) -> tuple[str, list]:
-    """Extract content text and tool calls from a Responses API response."""
+    """Extract content text and tool calls from a Responses API response.
+
+    The Responses API emits heterogeneous output items — text messages,
+    tool/function calls, reasoning summaries, and others. Some item kinds
+    (notably ``reasoning`` items on gpt-5.x) expose a ``content``
+    attribute whose value is ``None``, so we guard against that when
+    iterating.
+    """
     content = ""
     tool_calls: list = []
-    if response.output:
-        for item in response.output:
-            if hasattr(item, "content"):
-                for block in item.content:
-                    if hasattr(block, "text"):
-                        content += block.text
-            elif hasattr(item, "name"):
-                args = item.arguments if hasattr(item, "arguments") else ""
-                tool_calls.append(
-                    {
-                        "name": item.name,
-                        "args": _parse_responses_tool_args(args),
-                        "id": (item.call_id if hasattr(item, "call_id") else item.id),
-                        "type": "tool_call",
-                    }
-                )
+    if not response.output:
+        return content, tool_calls
+    for item in response.output:
+        item_content = getattr(item, "content", None)
+        if item_content is not None:
+            for block in item_content:
+                block_text = getattr(block, "text", None)
+                if block_text:
+                    content += block_text
+        elif hasattr(item, "name"):
+            args = getattr(item, "arguments", "") or ""
+            tool_calls.append(
+                {
+                    "name": item.name,
+                    "args": _parse_responses_tool_args(args),
+                    "id": getattr(item, "call_id", None) or item.id,
+                    "type": "tool_call",
+                }
+            )
     return content, tool_calls
+
+
+_ApiFormat = Literal["chat", "responses"]
+
+
+def _reduce_content_to_text(content: Any) -> str:
+    """Reduce a message ``content`` to a plain text string.
+
+    ``content`` may be a plain ``str``, ``None``, or a list of typed
+    blocks (``{"type": "text", "text": ...}``, ``{"type": "tool_call",
+    ...}``, etc). We keep only text-shaped blocks and drop typed
+    non-text blocks — tool calls are re-emitted separately as Responses
+    API ``function_call`` items, and multimodal (image / audio / PDF)
+    input isn't currently in scope for this class.
+
+    Follow-up: ``MANTLE_FOLLOWUPS.md`` — extend to preserve typed blocks
+    when multimodal support is added.
+    """
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: List[str] = []
+        for block in content:
+            if isinstance(block, dict):
+                block_type = block.get("type")
+                if block_type in (None, "text", "input_text", "output_text"):
+                    parts.append(block.get("text", ""))
+                # Skip tool_call / tool_use / thinking / image_url /
+                # refusal / annotation / other typed blocks.
+            elif isinstance(block, str):
+                parts.append(block)
+        return "".join(parts)
+    return str(content)
+
+
+def _convert_message_to_dict(
+    msg: BaseMessage, api: _ApiFormat
+) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
+    """Serialize a LangChain message to the requested API's shape.
+
+    Mirrors the architecture of ``ChatOpenAI._convert_message_to_dict``:
+    one helper dispatches on the ``api`` flag to produce either a Chat
+    Completions message dict OR a Responses API input-item dict/list.
+
+    Chat Completions returns a single dict per message. Responses API
+    may return a **list** of items for one ``AIMessage`` (an assistant
+    text turn plus one ``function_call`` item per tool call), or a
+    ``function_call_output`` item for a ``ToolMessage``.
+
+    Args:
+        msg: A LangChain ``BaseMessage`` subclass.
+        api: ``"chat"`` for Chat Completions, ``"responses"`` for the
+            Responses API.
+
+    Returns:
+        A dict for Chat Completions; a dict or list of dicts for
+        Responses API.
+
+    Notes:
+        Multimodal content blocks (image URL, audio, PDF), refusal
+        blocks, and annotation blocks are currently reduced to plain
+        text via ``_reduce_content_to_text``. Extending this helper is
+        the canonical place to add multimodal support — tracked in
+        ``MANTLE_FOLLOWUPS.md``.
+    """
+    text = _reduce_content_to_text(msg.content)
+
+    if isinstance(msg, HumanMessage):
+        return {"role": "user", "content": text}
+
+    if isinstance(msg, SystemMessage):
+        return {"role": "system", "content": text}
+
+    if isinstance(msg, ToolMessage):
+        if api == "responses":
+            return {
+                "type": "function_call_output",
+                "call_id": msg.tool_call_id,
+                "output": text,
+            }
+        return {
+            "role": "tool",
+            "tool_call_id": msg.tool_call_id,
+            "content": text,
+        }
+
+    if isinstance(msg, AIMessage):
+        if api == "chat":
+            out: Dict[str, Any] = {"role": "assistant", "content": text}
+            if msg.tool_calls:
+                out["tool_calls"] = [
+                    {
+                        "type": "function",
+                        "id": tc.get("id"),
+                        "function": {
+                            "name": tc.get("name"),
+                            "arguments": (
+                                tc["args"]
+                                if isinstance(tc.get("args"), str)
+                                else json.dumps(tc.get("args", {}))
+                            ),
+                        },
+                    }
+                    for tc in msg.tool_calls
+                ]
+            return out
+
+        # api == "responses": emit text (if any), then a
+        # ``function_call`` item per tool call.
+        items: List[Dict[str, Any]] = []
+        if text:
+            items.append({"role": "assistant", "content": text})
+        for tc in msg.tool_calls:
+            args = tc.get("args", {})
+            args_str = args if isinstance(args, str) else json.dumps(args)
+            items.append(
+                {
+                    "type": "function_call",
+                    "call_id": tc.get("id"),
+                    "name": tc.get("name"),
+                    "arguments": args_str,
+                }
+            )
+        return items
+
+    # Unknown message subclass — fall back to langchain-core's
+    # canonical Chat-Completions adapter.
+    fallback = convert_to_openai_messages([msg])
+    if isinstance(fallback, list) and fallback:
+        return fallback[0]
+    if isinstance(fallback, dict):
+        return fallback
+    return {"role": "user", "content": text}
+
+
+def _messages_to_api_input(
+    messages: Sequence[BaseMessage], api: _ApiFormat
+) -> List[Dict[str, Any]]:
+    """Convert a sequence of LangChain messages to the target API's input list.
+
+    Flattens the per-message result of ``_convert_message_to_dict``:
+    Responses API messages that fan out into multiple items (assistant
+    text + one item per tool call) are appended in order.
+    """
+    out: List[Dict[str, Any]] = []
+    for msg in messages:
+        result = _convert_message_to_dict(msg, api)
+        if isinstance(result, list):
+            out.extend(result)
+        else:
+            out.append(result)
+    return out
 
 
 def _get_last_messages_and_response_id(
@@ -202,14 +355,15 @@ def _get_last_messages_and_response_id(
 ) -> tuple[list[BaseMessage], Optional[str]]:
     """Extract the most recent ``previous_response_id`` from message history.
 
-    Scans backward for the last ``AIMessage`` whose ``id`` starts with
-    ``resp_``.  Returns the messages after that point and the response ID.
-    If no such message is found, returns all messages and ``None``.
+    Scans backward for the last ``AIMessage`` whose ``response_metadata["id"]``
+    starts with ``resp_``. Returns the messages after that point and the
+    response ID. If no such message is found, returns all messages and
+    ``None``.
     """
     for i in range(len(messages) - 1, -1, -1):
         msg = messages[i]
         if isinstance(msg, AIMessage):
-            resp_id = getattr(msg, "id", None) or ""
+            resp_id = msg.response_metadata.get("id", "") or ""
             if resp_id.startswith("resp_"):
                 return list(messages[i + 1 :]), resp_id
     return list(messages), None
@@ -228,6 +382,8 @@ def _build_chat_completions_result(response: Any) -> ChatResult:
         )
 
     ai_msg.response_metadata["model"] = response.model
+    ai_msg.response_metadata["model_name"] = response.model
+    ai_msg.response_metadata["model_provider"] = "bedrock_mantle"
     ai_msg.response_metadata["id"] = response.id
     return ChatResult(generations=[ChatGeneration(message=ai_msg)])
 
@@ -243,7 +399,23 @@ def _build_responses_result(response: Any) -> ChatResult:
         response_metadata={
             "id": response.id,
             "model": response.model,
-            "status": response.status if hasattr(response, "status") else None,
+            "model_name": response.model,
+            "model_provider": "bedrock_mantle",
+            "status": getattr(response, "status", None),
+            # ``incomplete_details`` is only populated when the model
+            # hit ``max_output_tokens`` or the content filter — mirrors
+            # ChatOpenAI's Responses API metadata (base.py:4434-4448).
+            **(
+                {
+                    "incomplete_details": (
+                        response.incomplete_details.model_dump(exclude_none=True)
+                        if hasattr(response.incomplete_details, "model_dump")
+                        else response.incomplete_details
+                    )
+                }
+                if getattr(response, "incomplete_details", None) is not None
+                else {}
+            ),
         },
     )
 
@@ -336,11 +508,32 @@ class ChatBedrockMantle(BaseChatModel):
     """
 
     use_previous_response_id: bool = False
-    """If ``True``, automatically pass ``previous_response_id``.
+    """If ``True``, automatically pass ``previous_response_id`` using the ID
+    of the most recent ``AIMessage`` in the input message sequence. Messages
+    up to that response are dropped from the request payload. Applies to
+    OpenAI-compatible models only (Responses API).
 
-    Uses the ID of the most recent ``AIMessage`` in the input message
-    sequence. Messages up to that response are dropped from the request
-    payload. Applies to OpenAI-compatible models only (Responses API).
+    Trade-offs to be aware of:
+
+    - **Server-side state dependency.** The Responses API stores conversation
+      state server-side and looks it up by response ID. If Mantle's retention
+      window has elapsed between calls (e.g. a LangGraph graph resumed after
+      a long delay), the ``previous_response_id`` will be rejected. The
+      client does not retry with the full message history; the error
+      propagates to the caller. If you cannot tolerate this failure mode
+      (e.g. long-running agentic workflows), keep this ``False`` and send
+      the full message history each time.
+    - **Not portable across endpoints.** ``resp_*`` IDs are bound to the
+      region and endpoint that produced them. Resuming in a different region
+      or with a different ``base_url`` will fail.
+    - **Intermediate tool messages are dropped.** When enabled, only messages
+      after the last ``AIMessage`` with a ``resp_*`` id are sent; earlier
+      tool-call / tool-result messages are assumed to be reconstructible
+      from server-side state.
+    - **Redundant storage with checkpointers.** If a LangGraph checkpointer
+      is also in use, it will store the full message history but those
+      messages are never sent to the API when this flag is on. That is
+      redundant storage cost with no functional benefit.
     """
 
     stream_usage: Optional[bool] = None
@@ -362,6 +555,87 @@ class ChatBedrockMantle(BaseChatModel):
     bedrock_api_key: Optional[SecretStr] = Field(default=None, alias="api_key")
     """Static Bedrock API key. If provided, short-term key generation is skipped."""
 
+    # TODO: Consolidate the AWS credential fields below with the identical
+    # declarations on ChatBedrockConverse and BedrockLLM into a shared
+    # mixin. Deferred to keep this PR scoped to reviewer comment #21.
+    aws_access_key_id: Optional[SecretStr] = Field(
+        default_factory=secret_from_env("AWS_ACCESS_KEY_ID", default=None)
+    )
+    """AWS access key id used to generate short-term Bedrock API keys.
+
+    If provided, ``aws_secret_access_key`` must also be provided. Takes
+    precedence over ``credentials_profile_name`` and the default AWS
+    credential chain. Not used when a static ``bedrock_api_key`` /
+    ``api_key`` is supplied.
+
+    Falls back to the ``AWS_ACCESS_KEY_ID`` environment variable.
+    """
+
+    aws_secret_access_key: Optional[SecretStr] = Field(
+        default_factory=secret_from_env("AWS_SECRET_ACCESS_KEY", default=None)
+    )
+    """AWS secret access key used to generate short-term Bedrock API keys.
+
+    Required when ``aws_access_key_id`` is set. Falls back to the
+    ``AWS_SECRET_ACCESS_KEY`` environment variable.
+    """
+
+    aws_session_token: Optional[SecretStr] = Field(
+        default_factory=secret_from_env("AWS_SESSION_TOKEN", default=None)
+    )
+    """Optional AWS session token for temporary credentials.
+
+    Only meaningful when ``aws_access_key_id`` and ``aws_secret_access_key``
+    are also provided. Falls back to the ``AWS_SESSION_TOKEN`` environment
+    variable.
+    """
+
+    credentials_profile_name: Optional[str] = Field(default=None, exclude=True)
+    """Named AWS profile from ``~/.aws/credentials`` / ``~/.aws/config``.
+
+    Used only when explicit ``aws_access_key_id`` / ``aws_secret_access_key``
+    are not set. If neither explicit creds nor a profile name are
+    provided, the default AWS credential chain is used (env vars, IAM
+    instance role, container credentials, etc.).
+    """
+
+    bedrock_api_key_ttl_seconds: int = _BEDROCK_API_KEY_MAX_TTL_SECONDS
+    """Requested TTL (in seconds) for auto-refreshed short-term Bedrock API keys.
+
+    Only applies when short-term keys are auto-generated from AWS
+    credentials (not when a static ``bedrock_api_key`` / ``api_key`` is
+    supplied).
+
+    - Must be greater than 0 and less than or equal to ``43200`` (12
+      hours). Bedrock rejects longer expiries at the server side.
+    - Default: ``43200`` (12 hours) — the longest lifetime Bedrock
+      allows; minimizes refresh overhead.
+    - The effective TTL is further capped by the underlying IAM
+      credentials' remaining lifetime, so passing a value longer than
+      your STS session lifetime has no effect beyond the credentials'
+      natural expiry.
+
+    Set a lower value to trade slightly higher refresh overhead for a
+    tighter security posture (shorter-lived tokens on the wire).
+    """
+
+    disabled_params: Optional[Dict[str, Any]] = None
+    """Parameters to silently drop before sending to the API.
+
+    Useful when a model does not support certain parameters that are
+    set internally (e.g., by ``with_structured_output``).
+
+    Format: ``{"param_name": None}`` to always drop, or
+    ``{"param_name": ["val1", "val2"]}`` to drop only specific values.
+
+    Example::
+
+        llm = ChatBedrockMantle(
+            model="some-model",
+            disabled_params={"parallel_tool_calls": None},
+        )
+    """
+
     _sync_client: Any = None
     _async_client: Any = None
     _resolved_region: str = ""
@@ -377,6 +651,21 @@ class ChatBedrockMantle(BaseChatModel):
                 "Could not import openai. "
                 'Please install it via: pip install "langchain-aws[mantle]"'
             ) from exc
+
+        if bool(self.aws_access_key_id) != bool(self.aws_secret_access_key):
+            msg = (
+                "aws_access_key_id and aws_secret_access_key must both be "
+                "provided, or both left unset."
+            )
+            raise ValueError(msg)
+        if not 0 < self.bedrock_api_key_ttl_seconds <= _BEDROCK_API_KEY_MAX_TTL_SECONDS:
+            msg = (
+                "bedrock_api_key_ttl_seconds must be between 1 and "
+                f"{_BEDROCK_API_KEY_MAX_TTL_SECONDS} "
+                "(12 hours, Bedrock's server-side max); got "
+                f"{self.bedrock_api_key_ttl_seconds}."
+            )
+            raise ValueError(msg)
 
         region = (
             self.region_name
@@ -420,7 +709,26 @@ class ChatBedrockMantle(BaseChatModel):
 
             from langchain_aws.utils import _BedrockApiKeyProvider
 
-            api_key = _BedrockApiKeyProvider(self._resolved_region)
+            api_key = _BedrockApiKeyProvider(
+                self._resolved_region,
+                ttl_seconds=self.bedrock_api_key_ttl_seconds,
+                aws_access_key_id=(
+                    self.aws_access_key_id.get_secret_value()
+                    if self.aws_access_key_id
+                    else None
+                ),
+                aws_secret_access_key=(
+                    self.aws_secret_access_key.get_secret_value()
+                    if self.aws_secret_access_key
+                    else None
+                ),
+                aws_session_token=(
+                    self.aws_session_token.get_secret_value()
+                    if self.aws_session_token
+                    else None
+                ),
+                credentials_profile_name=self.credentials_profile_name,
+            )
 
         client_kwargs: Dict[str, Any] = {
             "api_key": api_key,
@@ -444,13 +752,43 @@ class ChatBedrockMantle(BaseChatModel):
     def _llm_type(self) -> str:
         return "bedrock-mantle"
 
+    @property
+    def _identifying_params(self) -> Dict[str, Any]:
+        """Get the identifying parameters for tracing and callbacks."""
+        return {
+            "model": self.model,
+            "region_name": self._resolved_region,
+            "base_url": self.base_url,
+            "temperature": self.temperature,
+            "max_tokens": self.max_tokens,
+            "use_responses_api": self.use_responses_api,
+        }
+
+    def _filter_disabled_params(self, **kwargs: Any) -> Dict[str, Any]:
+        """Remove parameters listed in ``disabled_params``.
+
+        If a param is mapped to ``None``, it is always removed.
+        If mapped to a list of values, it is removed only when its
+        value is in that list.
+        """
+        if not self.disabled_params:
+            return kwargs
+        filtered = {}
+        for k, v in kwargs.items():
+            if k in self.disabled_params:
+                disabled_values = self.disabled_params[k]
+                if disabled_values is None or v in disabled_values:
+                    continue
+            filtered[k] = v
+        return filtered
+
     def _get_ls_params(
         self, stop: Optional[List[str]] = None, **kwargs: Any
     ) -> LangSmithParams:
         """Get standard params for LangSmith tracing."""
         ls_params = LangSmithParams(
             ls_provider="amazon_bedrock_mantle",
-            ls_model_name=self.model,
+            ls_model_name=kwargs.get("model") or self.model,
             ls_model_type="chat",
             ls_temperature=self.temperature,
         )
@@ -510,7 +848,7 @@ class ChatBedrockMantle(BaseChatModel):
         params: Dict[str, Any],
     ) -> ChatResult:
         """Generate via the Chat Completions API."""
-        openai_msgs = convert_to_openai_messages(messages)
+        openai_msgs = _messages_to_api_input(messages, "chat")
         response = self._sync_client.chat.completions.create(
             messages=openai_msgs, **params
         )
@@ -524,9 +862,9 @@ class ChatBedrockMantle(BaseChatModel):
     ) -> ChatResult:
         """Generate via the Responses API (``/v1/responses``)."""
         resp_params = self._prepare_responses_params(params)
-        openai_msgs = convert_to_openai_messages(messages)
+        input_items = _messages_to_api_input(messages, "responses")
 
-        response = self._sync_client.responses.create(input=openai_msgs, **resp_params)
+        response = self._sync_client.responses.create(input=input_items, **resp_params)
         return _build_responses_result(response)
 
     async def _agenerate(
@@ -556,7 +894,7 @@ class ChatBedrockMantle(BaseChatModel):
         params: Dict[str, Any],
     ) -> ChatResult:
         """Async generate via the Chat Completions API."""
-        openai_msgs = convert_to_openai_messages(messages)
+        openai_msgs = _messages_to_api_input(messages, "chat")
         response = await self._async_client.chat.completions.create(
             messages=openai_msgs, **params
         )
@@ -569,10 +907,10 @@ class ChatBedrockMantle(BaseChatModel):
     ) -> ChatResult:
         """Async generate via the Responses API (``/v1/responses``)."""
         resp_params = self._prepare_responses_params(params)
-        openai_msgs = convert_to_openai_messages(messages)
+        input_items = _messages_to_api_input(messages, "responses")
 
         response = await self._async_client.responses.create(
-            input=openai_msgs, **resp_params
+            input=input_items, **resp_params
         )
         return _build_responses_result(response)
 
@@ -600,25 +938,33 @@ class ChatBedrockMantle(BaseChatModel):
         run_manager: Optional[CallbackManagerForLLMRun] = None,
     ) -> Iterator[ChatGenerationChunk]:
         """Stream via the Chat Completions API."""
-        openai_msgs = convert_to_openai_messages(messages)
+        openai_msgs = _messages_to_api_input(messages, "chat")
         logger.debug("ChatBedrockMantle streaming (chat) with params: %s", params)
 
         try:
-            stream = self._sync_client.chat.completions.create(
+            context_manager = self._sync_client.chat.completions.create(
                 messages=openai_msgs, **params
             )
         except Exception as e:
             _handle_openai_error(e)
             raise
 
-        for chunk in stream:
-            result = self._process_chat_stream_chunk(chunk)
-            if result is None:
-                continue
-            token, gen_chunk = result
-            if run_manager:
-                run_manager.on_llm_new_token(token, chunk=gen_chunk)
-            yield gen_chunk
+        with context_manager as stream:
+            for chunk in stream:
+                result = self._process_chat_stream_chunk(chunk)
+                if result is None:
+                    continue
+                token, gen_chunk = result
+                # Tag the chunk with the provider identifier — mirrors
+                # ChatBedrockConverse / ChatOpenAI: ``model_provider`` is
+                # a client-side constant emitted on every chunk so
+                # downstream consumers can identify the source in
+                # real time. ``model_name`` is set once (in the
+                # terminal-chunk branch of the event handlers).
+                gen_chunk.message.response_metadata["model_provider"] = "bedrock_mantle"
+                if run_manager:
+                    run_manager.on_llm_new_token(token, chunk=gen_chunk)
+                yield gen_chunk
 
     def _stream_responses(
         self,
@@ -628,27 +974,35 @@ class ChatBedrockMantle(BaseChatModel):
     ) -> Iterator[ChatGenerationChunk]:
         """Stream via the Responses API (``/v1/responses``)."""
         resp_params = self._prepare_responses_params(params)
-        openai_msgs = convert_to_openai_messages(messages)
+        input_items = _messages_to_api_input(messages, "responses")
         logger.debug(
             "ChatBedrockMantle streaming (responses) with params: %s", resp_params
         )
 
         try:
-            stream = self._sync_client.responses.create(
-                input=openai_msgs, stream=True, **resp_params
+            context_manager = self._sync_client.responses.create(
+                input=input_items, stream=True, **resp_params
             )
         except Exception as e:
             _handle_openai_error(e)
             raise
 
-        for event in stream:
-            result = self._process_responses_stream_event(event)
-            if result is None:
-                continue
-            token, gen_chunk = result
-            if run_manager:
-                run_manager.on_llm_new_token(token, chunk=gen_chunk)
-            yield gen_chunk
+        with context_manager as stream:
+            for event in stream:
+                result = self._process_responses_stream_event(event)
+                if result is None:
+                    continue
+                token, gen_chunk = result
+                # Tag the chunk with the provider identifier — mirrors
+                # ChatBedrockConverse / ChatOpenAI: ``model_provider`` is
+                # a client-side constant emitted on every chunk so
+                # downstream consumers can identify the source in
+                # real time. ``model_name`` is set once (in the
+                # terminal-chunk branch of the event handlers).
+                gen_chunk.message.response_metadata["model_provider"] = "bedrock_mantle"
+                if run_manager:
+                    run_manager.on_llm_new_token(token, chunk=gen_chunk)
+                yield gen_chunk
 
     async def _astream(
         self,
@@ -678,24 +1032,26 @@ class ChatBedrockMantle(BaseChatModel):
         run_manager: Optional[AsyncCallbackManagerForLLMRun] = None,
     ) -> AsyncIterator[ChatGenerationChunk]:
         """Async stream via the Chat Completions API."""
-        openai_msgs = convert_to_openai_messages(messages)
+        openai_msgs = _messages_to_api_input(messages, "chat")
 
         try:
-            stream = await self._async_client.chat.completions.create(
+            context_manager = await self._async_client.chat.completions.create(
                 messages=openai_msgs, **params
             )
         except Exception as e:
             _handle_openai_error(e)
             raise
 
-        async for chunk in stream:
-            result = self._process_chat_stream_chunk(chunk)
-            if result is None:
-                continue
-            token, gen_chunk = result
-            if run_manager:
-                await run_manager.on_llm_new_token(token, chunk=gen_chunk)
-            yield gen_chunk
+        async with context_manager as stream:
+            async for chunk in stream:
+                result = self._process_chat_stream_chunk(chunk)
+                if result is None:
+                    continue
+                token, gen_chunk = result
+                gen_chunk.message.response_metadata["model_provider"] = "bedrock_mantle"
+                if run_manager:
+                    await run_manager.on_llm_new_token(token, chunk=gen_chunk)
+                yield gen_chunk
 
     async def _astream_responses(
         self,
@@ -705,31 +1061,62 @@ class ChatBedrockMantle(BaseChatModel):
     ) -> AsyncIterator[ChatGenerationChunk]:
         """Async stream via the Responses API (``/v1/responses``)."""
         resp_params = self._prepare_responses_params(params)
-        openai_msgs = convert_to_openai_messages(messages)
+        input_items = _messages_to_api_input(messages, "responses")
 
         try:
-            stream = await self._async_client.responses.create(
-                input=openai_msgs, stream=True, **resp_params
+            context_manager = await self._async_client.responses.create(
+                input=input_items, stream=True, **resp_params
             )
         except Exception as e:
             _handle_openai_error(e)
             raise
 
-        async for event in stream:
-            result = self._process_responses_stream_event(event)
-            if result is None:
-                continue
-            token, gen_chunk = result
-            if run_manager:
-                await run_manager.on_llm_new_token(token, chunk=gen_chunk)
-            yield gen_chunk
+        async with context_manager as stream:
+            async for event in stream:
+                result = self._process_responses_stream_event(event)
+                if result is None:
+                    continue
+                token, gen_chunk = result
+                gen_chunk.message.response_metadata["model_provider"] = "bedrock_mantle"
+                if run_manager:
+                    await run_manager.on_llm_new_token(token, chunk=gen_chunk)
+                yield gen_chunk
 
     def _process_chat_stream_chunk(
         self, chunk: Any
     ) -> Optional[tuple[str, ChatGenerationChunk]]:
-        """Convert a Chat Completions streaming chunk to a (token, chunk) pair."""
+        """Convert a Chat Completions streaming chunk to a (token, chunk) pair.
+
+        With ``stream_options.include_usage=True``, the OpenAI spec emits a
+        terminal chunk with an empty ``choices`` array and populated
+        ``usage``. That chunk is surfaced here as an empty-content
+        ``AIMessageChunk`` carrying ``usage_metadata``.
+        """
+        has_usage = hasattr(chunk, "usage") and chunk.usage
+
         if not chunk.choices:
+            if has_usage:
+                # Terminal chunk carrying only ``usage`` (emitted when
+                # ``stream_options.include_usage=True``). Populate the
+                # same identifying fields the non-streaming path sets so
+                # the merged final AIMessage carries them.
+                msg_chunk = AIMessageChunk(
+                    content="",
+                    id=chunk.id,
+                    usage_metadata=UsageMetadata(
+                        input_tokens=chunk.usage.prompt_tokens or 0,
+                        output_tokens=chunk.usage.completion_tokens or 0,
+                        total_tokens=chunk.usage.total_tokens or 0,
+                    ),
+                    response_metadata={
+                        "id": chunk.id,
+                        "model": chunk.model,
+                        "model_name": chunk.model,
+                    },
+                )
+                return "", ChatGenerationChunk(message=msg_chunk)
             return None
+
         delta = chunk.choices[0].delta
         content: str = delta.content or ""
 
@@ -755,7 +1142,7 @@ class ChatBedrockMantle(BaseChatModel):
                 0
             ].finish_reason
 
-        if hasattr(chunk, "usage") and chunk.usage:
+        if has_usage:
             msg_chunk.usage_metadata = UsageMetadata(
                 input_tokens=chunk.usage.prompt_tokens or 0,
                 output_tokens=chunk.usage.completion_tokens or 0,
@@ -805,7 +1192,20 @@ class ChatBedrockMantle(BaseChatModel):
             msg_chunk = AIMessageChunk(content="", tool_call_chunks=[tc])
             return "", ChatGenerationChunk(message=msg_chunk)
 
-        if event.type == "response.completed":
+        if event.type in ("response.completed", "response.incomplete"):
+            # ``response.incomplete`` fires when the model hit
+            # ``max_output_tokens`` (typically during reasoning) before
+            # producing text. We still emit a final chunk so callers
+            # never see "No generation chunks were returned".
+            #
+            # Match ChatOpenAI's Responses API convention: surface
+            # ``status`` and ``incomplete_details`` verbatim from the
+            # SDK rather than synthesizing a ``finish_reason`` field.
+            # ``finish_reason`` is a Chat Completions concept —
+            # ``ChatOpenAI`` deliberately doesn't invent it for
+            # Responses, and callers of both classes drill into
+            # ``response_metadata["incomplete_details"]["reason"]`` for
+            # the same information.
             response = event.response
             usage_metadata = None
             if hasattr(response, "usage") and response.usage:
@@ -814,15 +1214,27 @@ class ChatBedrockMantle(BaseChatModel):
                     output_tokens=response.usage.output_tokens,
                     total_tokens=response.usage.total_tokens,
                 )
+            metadata: Dict[str, Any] = {
+                "id": response.id,
+                "model": response.model,
+                "model_name": response.model,
+                "status": getattr(response, "status", None),
+            }
+            incomplete = getattr(response, "incomplete_details", None)
+            if incomplete is not None:
+                # Pydantic model on the SDK — dump to a plain dict so it
+                # serializes cleanly through LangSmith / model_dump().
+                if hasattr(incomplete, "model_dump"):
+                    metadata["incomplete_details"] = incomplete.model_dump(
+                        exclude_none=True
+                    )
+                else:
+                    metadata["incomplete_details"] = incomplete
             msg_chunk = AIMessageChunk(
                 content="",
                 id=response.id,
                 usage_metadata=usage_metadata,
-                response_metadata={
-                    "id": response.id,
-                    "model": response.model,
-                    "finish_reason": "stop",
-                },
+                response_metadata=metadata,
             )
             return "", ChatGenerationChunk(message=msg_chunk)
 
@@ -832,15 +1244,46 @@ class ChatBedrockMantle(BaseChatModel):
         self,
         tools: Sequence[Any],
         *,
-        tool_choice: Optional[str | Dict] = None,
+        tool_choice: Optional[str | Dict | bool] = None,
+        strict: Optional[bool] = None,
+        parallel_tool_calls: Optional[bool] = None,
         **kwargs: Any,
-    ) -> "ChatBedrockMantle":
-        """Bind tool definitions for function calling."""
-        formatted = [convert_to_openai_tool(t) for t in tools]
-        bind_kwargs: Dict[str, Any] = {"tools": formatted, **kwargs}
+    ) -> Runnable[LanguageModelInput, AIMessage]:
+        """Bind tool definitions for function calling.
+
+        Args:
+            tools: A list of tool definitions to bind.
+            tool_choice: Which tool to require. Options:
+                - str tool name: forces that specific tool
+                - ``"auto"``: model decides (default)
+                - ``"none"``: no tool calling
+                - ``"required"`` or ``True``: force at least one tool call
+                - dict: raw tool_choice object
+            strict: If ``True``, model output is guaranteed to match the
+                tool's JSON Schema exactly.
+            parallel_tool_calls: If ``False``, disable parallel tool use.
+            kwargs: Additional parameters passed to ``bind()``.
+        """
+        if parallel_tool_calls is not None:
+            kwargs["parallel_tool_calls"] = parallel_tool_calls
+        formatted = [convert_to_openai_tool(t, strict=strict) for t in tools]
         if tool_choice:
-            bind_kwargs["tool_choice"] = tool_choice
-        return super().bind(**bind_kwargs)  # type: ignore[return-value]
+            if isinstance(tool_choice, bool):
+                tool_choice = "required"
+            elif isinstance(tool_choice, str):
+                # Map tool names to the dict format
+                tool_names = [
+                    t["function"]["name"] for t in formatted if "function" in t
+                ]
+                if tool_choice in tool_names:
+                    tool_choice = {
+                        "type": "function",
+                        "function": {"name": tool_choice},
+                    }
+                elif tool_choice == "any":
+                    tool_choice = "required"
+            kwargs["tool_choice"] = tool_choice
+        return super().bind(tools=formatted, **kwargs)
 
     def with_structured_output(
         self,
@@ -876,14 +1319,19 @@ class ChatBedrockMantle(BaseChatModel):
             JsonOutputKeyToolsParser,
             PydanticToolsParser,
         )
-        from langchain_core.runnables import Runnable, RunnableMap, RunnablePassthrough
+        from langchain_core.runnables import RunnableMap, RunnablePassthrough
         from langchain_core.utils.pydantic import is_basemodel_subclass
 
         is_pydantic = isinstance(schema, type) and is_basemodel_subclass(schema)
 
         if method == "function_calling":
             tool_name = convert_to_openai_tool(schema)["function"]["name"]
-            llm: Runnable = self.bind_tools([schema], tool_choice=tool_name, **kwargs)
+            bind_kwargs = self._filter_disabled_params(
+                tool_choice=tool_name,
+                parallel_tool_calls=False,
+                **kwargs,
+            )
+            llm = self.bind_tools([schema], **bind_kwargs)
             if is_pydantic:
                 output_parser: Any = PydanticToolsParser(
                     tools=[schema], first_tool_only=True
@@ -900,35 +1348,52 @@ class ChatBedrockMantle(BaseChatModel):
                 else JsonOutputParser()
             )
         elif method == "json_schema":
-            if self.use_responses_api is False:
-                logger.warning(
-                    "with_structured_output(method='json_schema') uses the "
-                    "Responses API text.format parameter, but "
-                    "use_responses_api=False is set. The text parameter "
-                    "will be ignored by Chat Completions. Use "
-                    "method='json_mode' or method='function_calling' instead."
-                )
-            if is_pydantic:
-                json_schema = schema.model_json_schema()
-            elif isinstance(schema, dict):
-                json_schema = schema
+            # ``convert_to_json_schema`` handles Pydantic v2, Pydantic v1,
+            # and TypedDict uniformly. Plain-dict inputs are treated as
+            # already-formed JSON Schema and deep-copied — passing them
+            # through ``convert_to_json_schema`` would silently rewrite
+            # openai-tool-shaped dicts (``{name, description, parameters}``)
+            # in ways the caller didn't ask for. Matches
+            # ``ChatBedrockConverse._with_structured_output_prompt_prefill``
+            # (bedrock_converse.py:1701-1706).
+            import copy
+
+            from langchain_core.utils.function_calling import (
+                convert_to_json_schema,
+            )
+
+            if isinstance(schema, dict):
+                json_schema = copy.deepcopy(schema)
             else:
-                msg = (
-                    f"Unsupported schema type for json_schema method: "
-                    f"{type(schema)}. Use a Pydantic model or dict."
-                )
-                raise ValueError(msg)
+                json_schema = convert_to_json_schema(schema)
 
             schema_name = json_schema.get(
                 "title", getattr(schema, "__name__", "Output")
             )
-            text_format = {
+            # Always bind in Chat Completions shape. ``_prepare_responses_params``
+            # transparently remaps to the Responses API's ``text.format`` if
+            # the request is routed there. Callers on Responses-only models
+            # (e.g. ``openai.gpt-5.x``) must set ``use_responses_api=True``
+            # so the router doesn't force Chat Completions.
+            response_format = {
                 "type": "json_schema",
-                "name": schema_name,
-                "schema": json_schema,
-                "strict": True,
+                "json_schema": {
+                    "name": schema_name,
+                    "schema": json_schema,
+                    "strict": True,
+                },
             }
-            llm = self.bind(text={"format": text_format}, **kwargs)
+            # LangSmith tracing hint: identifies the structured-output
+            # method/schema for callback consumers (matches the shape used
+            # by ChatBedrockConverse and ChatOpenAI).
+            llm = self.bind(
+                response_format=response_format,
+                ls_structured_output_format={
+                    "kwargs": {"method": "json_schema"},
+                    "schema": json_schema,
+                },
+                **kwargs,
+            )
             output_parser = (
                 PydanticOutputParser(pydantic_object=schema)
                 if is_pydantic
@@ -1025,6 +1490,26 @@ class ChatBedrockMantle(BaseChatModel):
         if max_tokens is not None:
             resp_params["max_output_tokens"] = max_tokens
 
+        # Remap response_format to text (Responses API equivalent).
+        # Chat Completions:
+        #   response_format={"type": "json_schema", "json_schema": {...}}
+        # Responses API:
+        #   text={"format": {"type": "json_schema", ...}}
+        if "response_format" in resp_params:
+            rf = resp_params.pop("response_format")
+            if isinstance(rf, dict) and rf.get("type") == "json_schema":
+                json_schema_config = rf.get("json_schema", {})
+                resp_params["text"] = {
+                    "format": {
+                        "type": "json_schema",
+                        "name": json_schema_config.get("name", "Output"),
+                        "schema": json_schema_config.get("schema", {}),
+                        "strict": json_schema_config.get("strict", True),
+                    }
+                }
+            elif isinstance(rf, dict) and rf.get("type") == "json_object":
+                resp_params["text"] = {"format": {"type": "json_object"}}
+
         # Convert Chat Completions tool format to Responses API format.
         # Chat Completions: {"type": "function", "function": {"name": ..., ...}}
         # Responses API:    {"type": "function", "name": ..., ...}
@@ -1041,10 +1526,9 @@ class ChatBedrockMantle(BaseChatModel):
                     converted.append(tool)
             resp_params["tools"] = converted
 
-        # Validate tool_choice — Mantle may only support "auto" or "none".
+        # Convert tool_choice from Chat Completions dict format to Responses API format.
         if "tool_choice" in resp_params:
             tc = resp_params["tool_choice"]
-            # Convert Chat Completions dict format to Responses API format
             if (
                 isinstance(tc, dict)
                 and tc.get("type") == "function"
@@ -1054,13 +1538,5 @@ class ChatBedrockMantle(BaseChatModel):
                     "type": "function",
                     **tc["function"],
                 }
-                tc = resp_params["tool_choice"]
-            if isinstance(tc, str) and tc not in ("auto", "none"):
-                logger.warning(
-                    "Bedrock Mantle Responses API may only support "
-                    "tool_choice='auto' or 'none'. Got %r — the API "
-                    "may reject this.",
-                    tc,
-                )
 
         return resp_params

--- a/libs/aws/langchain_aws/utils.py
+++ b/libs/aws/langchain_aws/utils.py
@@ -537,6 +537,31 @@ def trim_message_whitespace(messages: List[Any]) -> List[Any]:
     return messages
 
 
+class _StaticCredentialProvider:
+    """Wraps resolved botocore credentials in the shape ``provide_token`` expects.
+
+    ``aws_bedrock_token_generator.provide_token`` accepts an
+    ``aws_credentials_provider`` that must expose a ``.load()`` method
+    returning a ``botocore.credentials.Credentials`` (or subclass). This
+    class adapts a pre-resolved credentials object to that contract.
+    """
+
+    METHOD = "explicit"
+
+    def __init__(self, credentials: Any) -> None:
+        self._credentials = credentials
+
+    def load(self) -> Any:
+        return self._credentials
+
+
+#: Server-side maximum lifetime (in seconds) of a short-term Bedrock API
+#: key issued by ``aws-bedrock-token-generator``. Bedrock rejects longer
+#: expiries at the token-verification layer, so this is both the default
+#: and the upper-bound of the ``ttl_seconds`` knob.
+_BEDROCK_API_KEY_MAX_TTL_SECONDS = 43200  # 12 h
+
+
 class _BedrockApiKeyProvider:
     """Generates and caches short-term Bedrock API keys.
 
@@ -549,18 +574,28 @@ class _BedrockApiKeyProvider:
     See: https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-generate.html
     """
 
-    # Bedrock short-term API keys have a 12 h max lifetime as of 2026-04.
-    # If the service changes this, update accordingly or parse the actual
-    # expiry from the token response when available.
-    _TTL_SECONDS = 43200  # 12 h max
     # Matches botocore's _DEFAULT_ADVISORY_REFRESH_TIMEOUT (900s) and
     # _DEFAULT_MANDATORY_REFRESH_TIMEOUT (600s) for credential refresh.
     _ADVISORY_REFRESH_SECONDS = 900  # try to refresh 15 min before expiry
     _MANDATORY_REFRESH_SECONDS = 600  # must refresh 10 min before expiry
 
-    def __init__(self, region: str) -> None:
+    def __init__(
+        self,
+        region: str,
+        *,
+        ttl_seconds: int = _BEDROCK_API_KEY_MAX_TTL_SECONDS,
+        aws_access_key_id: Optional[str] = None,
+        aws_secret_access_key: Optional[str] = None,
+        aws_session_token: Optional[str] = None,
+        credentials_profile_name: Optional[str] = None,
+    ) -> None:
         self._region = region
-        self._token: Optional[str] = None
+        self._ttl_seconds = ttl_seconds
+        self._aws_access_key_id = aws_access_key_id
+        self._aws_secret_access_key = aws_secret_access_key
+        self._aws_session_token = aws_session_token
+        self._credentials_profile_name = credentials_profile_name
+        self._token: str = ""
         self._expires_at: float = 0.0
         self._lock = threading.Lock()
 
@@ -575,17 +610,17 @@ class _BedrockApiKeyProvider:
           completes or raise on failure.
         """
         if not self._refresh_needed(self._ADVISORY_REFRESH_SECONDS):
-            return self._token  # type: ignore[return-value]
+            return self._token
 
         if self._lock.acquire(blocking=False):
             try:
                 # Re-check: another thread may have refreshed before we
                 # acquired the lock.
                 if not self._refresh_needed(self._ADVISORY_REFRESH_SECONDS):
-                    return self._token  # type: ignore[return-value]
+                    return self._token
                 is_mandatory = self._refresh_needed(self._MANDATORY_REFRESH_SECONDS)
                 self._protected_refresh(is_mandatory=is_mandatory)
-                return self._token  # type: ignore[return-value]
+                return self._token
             finally:
                 self._lock.release()
         elif self._refresh_needed(self._MANDATORY_REFRESH_SECONDS):
@@ -594,19 +629,19 @@ class _BedrockApiKeyProvider:
                 # Re-check: another thread may have refreshed while we
                 # were waiting for the lock.
                 if not self._refresh_needed(self._MANDATORY_REFRESH_SECONDS):
-                    return self._token  # type: ignore[return-value]
+                    return self._token
                 self._protected_refresh(is_mandatory=True)
-                return self._token  # type: ignore[return-value]
+                return self._token
 
-        # Another thread is refreshing; return current token.
-        # Note: self._token is never None here because when _token is None,
-        # _refresh_needed() returns True for the mandatory threshold, so the
-        # elif branch above always triggers and blocks until a token exists.
-        return self._token  # type: ignore[return-value]
+        # Another thread is refreshing; return current token. self._token is
+        # never empty here because when it is, _refresh_needed() returns True
+        # for the mandatory threshold, so the elif branch above always
+        # triggers and blocks until a token exists.
+        return self._token
 
     def _refresh_needed(self, refresh_in: int) -> bool:
         """Check if a refresh is needed within ``refresh_in`` seconds."""
-        if self._token is None:
+        if not self._token:
             return True
         return time.monotonic() >= self._expires_at - refresh_in
 
@@ -632,12 +667,86 @@ class _BedrockApiKeyProvider:
 
         return await asyncio.to_thread(self)
 
+    @staticmethod
+    def _credentials_seconds_remaining(credentials: Any) -> Optional[int]:
+        """Return remaining lifetime (s) for ``RefreshableCredentials``.
+
+        Uses botocore's ``_seconds_remaining`` — a private method, but
+        stable across botocore versions and the one botocore's own auth
+        code uses internally. If botocore ever renames or removes it,
+        the resulting ``AttributeError`` is swallowed and the caller
+        degrades to its configured TTL.
+
+        Args:
+            credentials: A boto3 / botocore ``Credentials`` instance
+                (any subclass).
+
+        Returns:
+            Remaining seconds if the credentials are a
+            ``RefreshableCredentials`` and report a positive value;
+            ``None`` for static credentials or on any error.
+        """
+        from botocore.credentials import RefreshableCredentials
+
+        if not isinstance(credentials, RefreshableCredentials):
+            return None
+        try:
+            remaining = credentials._seconds_remaining()  # type: ignore[attr-defined]
+        except Exception:
+            logger.debug(
+                "RefreshableCredentials._seconds_remaining() raised; "
+                "falling back to configured TTL.",
+                exc_info=True,
+            )
+            return None
+        return int(remaining) if remaining > 0 else None
+
     def _do_refresh(self) -> None:
         from aws_bedrock_token_generator import provide_token
+        from botocore.credentials import Credentials
+        from botocore.session import Session as BotocoreSession
+
+        # Resolve credentials with precedence:
+        # explicit access_key + secret_key > profile > default chain.
+        credentials: Any = None
+        if self._aws_access_key_id and self._aws_secret_access_key:
+            credentials = Credentials(
+                access_key=self._aws_access_key_id,
+                secret_key=self._aws_secret_access_key,
+                token=self._aws_session_token,
+            )
+        else:
+            try:
+                if self._credentials_profile_name:
+                    session = BotocoreSession(profile=self._credentials_profile_name)
+                else:
+                    session = BotocoreSession()
+                credentials = session.get_credentials()
+            except Exception:
+                logger.debug(
+                    "Could not resolve credentials via botocore session; "
+                    "provide_token will fall back to its own default chain.",
+                    exc_info=True,
+                )
+                credentials = None
+
+        # Cap TTL by underlying credential lifetime for refreshable creds
+        # (AssumeRole, SSO, IRSA, etc.). Static creds have no expiry
+        # metadata so we use the configured TTL directly.
+        effective_ttl = self._ttl_seconds
+        remaining = self._credentials_seconds_remaining(credentials)
+        if remaining is not None:
+            effective_ttl = min(self._ttl_seconds, remaining)
+
+        # Wrap the resolved credentials in a CredentialProvider shape so
+        # provide_token uses them; passing None lets provide_token fall
+        # back to its own default resolution.
+        provider = _StaticCredentialProvider(credentials) if credentials else None
 
         token = provide_token(
             region=self._region,
-            expiry=timedelta(seconds=self._TTL_SECONDS),
+            expiry=timedelta(seconds=effective_ttl),
+            aws_credentials_provider=provider,
         )
         self._token = token
-        self._expires_at = time.monotonic() + self._TTL_SECONDS
+        self._expires_at = time.monotonic() + effective_ttl

--- a/libs/aws/langchain_aws/utils.py
+++ b/libs/aws/langchain_aws/utils.py
@@ -1,7 +1,10 @@
 import logging
 import os
 import re
+import threading
+import time
 from abc import abstractmethod
+from datetime import timedelta
 from typing import Any, Dict, Generic, Iterator, List, Literal, Optional, TypeVar, Union
 
 from botocore.exceptions import BotoCoreError, UnknownServiceError
@@ -532,3 +535,109 @@ def trim_message_whitespace(messages: List[Any]) -> List[Any]:
                     last_message.content[j] = block_dict
 
     return messages
+
+
+class _BedrockApiKeyProvider:
+    """Generates and caches short-term Bedrock API keys.
+
+    Uses ``aws-bedrock-token-generator`` to produce short-term API keys from
+    AWS credentials.  Keys are cached and regenerated when near expiry.
+
+    The instance is callable (sync) and also exposes an ``async_call`` method
+    for use with async clients.
+
+    See: https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-generate.html
+    """
+
+    # Bedrock short-term API keys have a 12 h max lifetime as of 2026-04.
+    # If the service changes this, update accordingly or parse the actual
+    # expiry from the token response when available.
+    _TTL_SECONDS = 43200  # 12 h max
+    # Matches botocore's _DEFAULT_ADVISORY_REFRESH_TIMEOUT (900s) and
+    # _DEFAULT_MANDATORY_REFRESH_TIMEOUT (600s) for credential refresh.
+    _ADVISORY_REFRESH_SECONDS = 900  # try to refresh 15 min before expiry
+    _MANDATORY_REFRESH_SECONDS = 600  # must refresh 10 min before expiry
+
+    def __init__(self, region: str) -> None:
+        self._region = region
+        self._token: Optional[str] = None
+        self._expires_at: float = 0.0
+        self._lock = threading.Lock()
+
+    def __call__(self) -> str:
+        """Return a cached API key, refreshing if near expiry.
+
+        Follows botocore's ``RefreshableCredentials._refresh`` pattern:
+        - Outside advisory window: return cached token immediately.
+        - Advisory window (15–10 min before expiry): try non-blocking
+          refresh. If lock is held or refresh fails, return old token.
+        - Mandatory window (<10 min before expiry): block until refresh
+          completes or raise on failure.
+        """
+        if not self._refresh_needed(self._ADVISORY_REFRESH_SECONDS):
+            return self._token  # type: ignore[return-value]
+
+        if self._lock.acquire(blocking=False):
+            try:
+                # Re-check: another thread may have refreshed before we
+                # acquired the lock.
+                if not self._refresh_needed(self._ADVISORY_REFRESH_SECONDS):
+                    return self._token  # type: ignore[return-value]
+                is_mandatory = self._refresh_needed(self._MANDATORY_REFRESH_SECONDS)
+                self._protected_refresh(is_mandatory=is_mandatory)
+                return self._token  # type: ignore[return-value]
+            finally:
+                self._lock.release()
+        elif self._refresh_needed(self._MANDATORY_REFRESH_SECONDS):
+            # Token is close to expiry — must block until refreshed.
+            with self._lock:
+                # Re-check: another thread may have refreshed while we
+                # were waiting for the lock.
+                if not self._refresh_needed(self._MANDATORY_REFRESH_SECONDS):
+                    return self._token  # type: ignore[return-value]
+                self._protected_refresh(is_mandatory=True)
+                return self._token  # type: ignore[return-value]
+
+        # Another thread is refreshing; return current token.
+        # Note: self._token is never None here because when _token is None,
+        # _refresh_needed() returns True for the mandatory threshold, so the
+        # elif branch above always triggers and blocks until a token exists.
+        return self._token  # type: ignore[return-value]
+
+    def _refresh_needed(self, refresh_in: int) -> bool:
+        """Check if a refresh is needed within ``refresh_in`` seconds."""
+        if self._token is None:
+            return True
+        return time.monotonic() >= self._expires_at - refresh_in
+
+    def _protected_refresh(self, *, is_mandatory: bool) -> None:
+        """Attempt to refresh the token. Only raises if mandatory."""
+        try:
+            self._do_refresh()
+        except Exception:
+            if is_mandatory:
+                raise
+            logger.debug(
+                "Advisory refresh failed, using existing token.",
+                exc_info=True,
+            )
+
+    async def async_call(self) -> str:
+        """Async-compatible version that returns a cached API key.
+
+        Offloads to a thread to avoid blocking the event loop if a
+        token refresh (network call) is needed.
+        """
+        import asyncio
+
+        return await asyncio.to_thread(self)
+
+    def _do_refresh(self) -> None:
+        from aws_bedrock_token_generator import provide_token
+
+        token = provide_token(
+            region=self._region,
+            expiry=timedelta(seconds=self._TTL_SECONDS),
+        )
+        self._token = token
+        self._expires_at = time.monotonic() + self._TTL_SECONDS

--- a/libs/aws/pyproject.toml
+++ b/libs/aws/pyproject.toml
@@ -27,6 +27,7 @@ tools = ["bedrock-agentcore>=1.4.0; python_version>='3.10'", "playwright>=1.53.0
 anthropic = ["langchain-anthropic", "anthropic[bedrock]"]
 valkey = ["valkey-glide-sync>=2.0.0"]
 nova-sonic = ["aws-sdk-bedrock-runtime; python_version>='3.12'"]
+mantle = ["openai>=1.106.0", "aws-bedrock-token-generator>=1.1.0"]  # openai>=1.106.0 for callable api_key support (short-term tokens)
 
 [dependency-groups]
 test = [
@@ -50,6 +51,8 @@ test_integration = [
     "langchain-anthropic",
     "anthropic[bedrock]",
     "aws-sdk-bedrock-runtime; python_version>='3.12'",
+    "openai>=1.106.0",
+    "aws-bedrock-token-generator>=1.1.0",
 ]
 lint = ["ruff>=0.13.0"]
 typing = [

--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock_mantle.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock_mantle.py
@@ -1,0 +1,341 @@
+"""Integration tests for ChatBedrockMantle.
+
+These tests require:
+  - pip install "langchain-aws[mantle]"
+  - Valid AWS credentials with Bedrock access
+  - Access to Mantle models in the configured region
+
+Run with:
+  AWS_REGION=us-east-1 \
+    uv run --group test --group test_integration \
+    pytest tests/integration_tests/chat_models/test_bedrock_mantle.py -v
+"""
+
+import os
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+try:
+    from langchain_aws import ChatBedrockMantle
+
+    MANTLE_AVAILABLE = True
+except (ImportError, ModuleNotFoundError):
+    MANTLE_AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(
+    not MANTLE_AVAILABLE,
+    reason='Mantle deps not installed. Run: pip install "langchain-aws[mantle]"',
+)
+
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+
+MODELS = [
+    "openai.gpt-oss-20b",
+]
+
+# Models that only support Chat Completions (not Responses API)
+CHAT_COMPLETIONS_MODELS = [
+    "qwen.qwen3-32b",
+    "deepseek.v3.2",
+]
+
+
+@pytest.fixture(params=MODELS)
+def llm(request: pytest.FixtureRequest) -> "ChatBedrockMantle":
+    return ChatBedrockMantle(model=request.param, region_name=REGION)
+
+
+@pytest.fixture
+def llm_default() -> "ChatBedrockMantle":
+    return ChatBedrockMantle(model=MODELS[0], region_name=REGION)
+
+
+# ── Basic invoke ────────────────────────────────────────────────────
+
+
+class TestBasicInvoke:
+    def test_invoke(self, llm: "ChatBedrockMantle") -> None:
+        response = llm.invoke("What is 2+2? Answer with just the number.")
+        assert isinstance(response, AIMessage)
+        assert response.content
+        assert "4" in response.content
+
+    def test_invoke_with_system(self, llm: "ChatBedrockMantle") -> None:
+        messages = [
+            SystemMessage(content="You are a helpful math tutor."),
+            HumanMessage(content="What is 3*3? Answer with just the number."),
+        ]
+        response = llm.invoke(messages)
+        assert isinstance(response, AIMessage)
+        assert "9" in response.content
+
+    def test_response_has_id(self, llm_default: "ChatBedrockMantle") -> None:
+        """AIMessage.id should be set from the response ID."""
+        response = llm_default.invoke("Say hi")
+        assert isinstance(response, AIMessage)
+        assert response.id is not None
+        assert response.id.startswith("resp_")
+        assert response.response_metadata["id"] == response.id
+
+
+# ── Streaming ───────────────────────────────────────────────────────
+
+
+class TestStreaming:
+    def test_stream(self, llm: "ChatBedrockMantle") -> None:
+        """Default streaming uses the Responses API."""
+        chunks = list(llm.stream("Say hello in one word"))
+        assert len(chunks) > 0
+        full_content = "".join(
+            c.content for c in chunks if isinstance(c.content, str) and c.content
+        )
+        assert full_content
+
+    def test_stream_chat_completions(self) -> None:
+        """Streaming falls back to Chat Completions with response_format."""
+        llm = ChatBedrockMantle(
+            model=MODELS[0],
+            region_name=REGION,
+            use_responses_api=False,
+        )
+        chunks = list(llm.stream("Say hello in one word"))
+        assert len(chunks) > 0
+        full_content = "".join(
+            c.content for c in chunks if isinstance(c.content, str) and c.content
+        )
+        assert full_content
+
+
+# ── Async ───────────────────────────────────────────────────────────
+
+
+class TestAsync:
+    @pytest.mark.asyncio
+    async def test_ainvoke(self, llm: "ChatBedrockMantle") -> None:
+        response = await llm.ainvoke("What is 2+2? Answer with just the number.")
+        assert isinstance(response, AIMessage)
+        assert response.content
+        assert "4" in response.content
+
+    @pytest.mark.asyncio
+    async def test_astream(self, llm: "ChatBedrockMantle") -> None:
+        chunks = []
+        async for chunk in llm.astream("Say hello in one word"):
+            chunks.append(chunk)
+        assert len(chunks) > 0
+        full_content = "".join(
+            c.content for c in chunks if isinstance(c.content, str) and c.content
+        )
+        assert full_content
+
+
+# ── Tool calling ────────────────────────────────────────────────────
+
+
+class TestToolCalling:
+    def test_bind_tools(self, llm: "ChatBedrockMantle") -> None:
+        from pydantic import BaseModel, Field
+
+        class GetWeather(BaseModel):
+            """Get the current weather in a given location."""
+
+            location: str = Field(description="City and state")
+
+        llm_with_tools = llm.bind_tools([GetWeather])
+        try:
+            response = llm_with_tools.invoke("What's the weather in Seattle?")
+        except Exception as e:
+            if "not supported" in str(e).lower() or "tool" in str(e).lower():
+                pytest.skip(f"Model does not support tool calling: {e}")
+            raise
+        assert isinstance(response, AIMessage)
+        assert response.content or response.tool_calls
+
+    def test_streaming_tool_calls(self, llm_default: "ChatBedrockMantle") -> None:
+        """Tool calls should stream via Responses API."""
+        from pydantic import BaseModel, Field
+
+        class GetWeather(BaseModel):
+            """Get the current weather in a given location."""
+
+            location: str = Field(description="City and state")
+
+        llm_with_tools = llm_default.bind_tools([GetWeather])
+        chunks = list(llm_with_tools.stream("What's the weather in Seattle?"))
+        assert len(chunks) > 0
+        # At least one chunk should have tool call info or text
+        has_content = any(isinstance(c.content, str) and c.content for c in chunks)
+        has_tool_chunks = any(c.tool_call_chunks for c in chunks)
+        assert has_content or has_tool_chunks
+
+
+# ── Model discovery ─────────────────────────────────────────────────
+
+
+class TestModelDiscovery:
+    def test_list_models(self, llm_default: "ChatBedrockMantle") -> None:
+        models = llm_default.list_models()
+        assert isinstance(models, list)
+        assert len(models) > 0
+        assert "id" in models[0]
+
+
+# ── Usage metadata ──────────────────────────────────────────────────
+
+
+class TestUsageMetadata:
+    def test_usage_in_invoke(self, llm_default: "ChatBedrockMantle") -> None:
+        response = llm_default.invoke("Hi")
+        assert isinstance(response, AIMessage)
+        if response.usage_metadata:
+            assert response.usage_metadata["input_tokens"] > 0
+            assert response.usage_metadata["output_tokens"] > 0
+
+    def test_usage_in_stream(self, llm_default: "ChatBedrockMantle") -> None:
+        """Last streaming chunk should carry usage metadata."""
+        chunks = list(llm_default.stream("Hi"))
+        last = chunks[-1]
+        if last.usage_metadata:
+            assert last.usage_metadata["total_tokens"] > 0
+
+
+# ── Conversation state (previous_response_id) ──────────────────────
+
+
+class TestConversationState:
+    def test_previous_response_id(self, llm_default: "ChatBedrockMantle") -> None:
+        first = llm_default.invoke("My name is Alice.")
+        assert isinstance(first, AIMessage)
+        response_id = first.response_metadata.get("id")
+        assert response_id
+
+        followup = llm_default.invoke(
+            "What is my name?", previous_response_id=response_id
+        )
+        assert isinstance(followup, AIMessage)
+        assert followup.content
+
+    def test_use_previous_response_id_auto(self) -> None:
+        """use_previous_response_id extracts ID from message history."""
+        llm = ChatBedrockMantle(
+            model=MODELS[0],
+            region_name=REGION,
+            use_previous_response_id=True,
+        )
+        first = llm.invoke("My name is Bob.")
+        assert isinstance(first, AIMessage)
+        assert first.id and first.id.startswith("resp_")
+
+        # Pass full history — llm should extract previous_response_id
+        messages = [
+            HumanMessage(content="My name is Bob."),
+            first,
+            HumanMessage(content="What is my name?"),
+        ]
+        followup = llm.invoke(messages)
+        assert isinstance(followup, AIMessage)
+        assert followup.content
+
+
+# ── Chat Completions fallback ───────────────────────────────────────
+
+
+class TestChatCompletionsFallback:
+    def test_response_format_routes_to_chat_completions(self) -> None:
+        llm = ChatBedrockMantle(model=MODELS[0], region_name=REGION)
+        response = llm.invoke(
+            "Return a JSON object with fields name and age for Alice who is 30. "
+            "Output only valid JSON, no other text.",
+            response_format={"type": "json_object"},
+        )
+        assert isinstance(response, AIMessage)
+        assert response.content
+
+    def test_explicit_chat_completions(self) -> None:
+        llm = ChatBedrockMantle(
+            model=MODELS[0],
+            region_name=REGION,
+            use_responses_api=False,
+        )
+        response = llm.invoke("Say hi")
+        assert isinstance(response, AIMessage)
+        assert response.content
+
+    def test_chat_completions_only_model(self) -> None:
+        """Models that don't support Responses API work via Chat Completions."""
+        for model in CHAT_COMPLETIONS_MODELS:
+            llm = ChatBedrockMantle(
+                model=model,
+                region_name=REGION,
+                use_responses_api=False,
+            )
+            response = llm.invoke("Say hi in one word")
+            assert isinstance(response, AIMessage)
+            assert response.content
+
+    def test_chat_completions_only_model_stream(self) -> None:
+        """Streaming works for Chat Completions-only models."""
+        llm = ChatBedrockMantle(
+            model=CHAT_COMPLETIONS_MODELS[0],
+            region_name=REGION,
+            use_responses_api=False,
+        )
+        chunks = list(llm.stream("Say hi"))
+        assert len(chunks) > 0
+        full = "".join(
+            c.content for c in chunks if isinstance(c.content, str) and c.content
+        )
+        assert full
+
+
+# ── Structured output ────────────────────────────────────────────────
+
+
+class TestStructuredOutput:
+    def test_with_structured_output_json_mode(self) -> None:
+        """json_mode routes through Chat Completions response_format
+        and returns valid JSON."""
+        llm = ChatBedrockMantle(model=MODELS[0], region_name=REGION)
+        structured = llm.with_structured_output(
+            {"type": "object", "properties": {"answer": {"type": "string"}}},
+            method="json_mode",
+        )
+        result = structured.invoke(
+            "Return a JSON object with a single key 'answer' "
+            "whose value is 'hello'. Output only valid JSON."
+        )
+        assert isinstance(result, dict)
+
+
+# ── Explicit use_responses_api ──────────────────────────────────────
+
+
+class TestExplicitResponsesApi:
+    def test_use_responses_api_true(self) -> None:
+        llm = ChatBedrockMantle(
+            model=MODELS[0],
+            region_name=REGION,
+            use_responses_api=True,
+        )
+        response = llm.invoke("Say hi")
+        assert isinstance(response, AIMessage)
+        assert response.content
+        assert response.id and response.id.startswith("resp_")
+
+
+# ── Retry and timeout ───────────────────────────────────────────────
+
+
+class TestRetryAndTimeout:
+    def test_custom_timeout(self) -> None:
+        llm = ChatBedrockMantle(model=MODELS[0], region_name=REGION, timeout=60.0)
+        response = llm.invoke("Say hi")
+        assert isinstance(response, AIMessage)
+        assert response.content
+
+    def test_custom_max_retries(self) -> None:
+        llm = ChatBedrockMantle(model=MODELS[0], region_name=REGION, max_retries=3)
+        response = llm.invoke("Say hi")
+        assert isinstance(response, AIMessage)
+        assert response.content

--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock_mantle.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock_mantle.py
@@ -1,20 +1,18 @@
-"""Integration tests for ChatBedrockMantle.
-
-These tests require:
-  - pip install "langchain-aws[mantle]"
-  - Valid AWS credentials with Bedrock access
-  - Access to Mantle models in the configured region
-
-Run with:
-  AWS_REGION=us-east-1 \
-    uv run --group test --group test_integration \
-    pytest tests/integration_tests/chat_models/test_bedrock_mantle.py -v
-"""
+"""Integration tests for ChatBedrockMantle."""
 
 import os
+from typing import Type
 
 import pytest
-from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import (
+    AIMessage,
+    AIMessageChunk,
+    HumanMessage,
+    SystemMessage,
+)
+from langchain_core.tools import BaseTool
+from langchain_tests.integration_tests import ChatModelIntegrationTests
 
 try:
     from langchain_aws import ChatBedrockMantle
@@ -29,6 +27,132 @@ pytestmark = pytest.mark.skipif(
 )
 
 REGION = os.environ.get("AWS_REGION", "us-east-1")
+
+
+# ── Standard LangChain interface tests ──────────────────────────────
+
+
+_STANDARD_MAX_TOKENS = 5000  # matches ChatBedrockConverse's config
+
+
+@pytest.mark.skipif(
+    not MANTLE_AVAILABLE,
+    reason="Mantle deps not installed or CI lacks Mantle API permissions.",
+)
+class TestBedrockMantleStandardOpenWeights(ChatModelIntegrationTests):
+    """Conformance run against an open-weight OpenAI model on ``/v1``.
+
+    ``openai.gpt-oss-120b`` serves both Chat Completions and Responses
+    at the default ``/v1`` base URL. It does not currently accept
+    ``tool_choice="required"`` on this path, so we disable the
+    ``has_tool_choice`` capability flag for this model.
+    """
+
+    @property
+    def chat_model_class(self) -> Type[BaseChatModel]:
+        return ChatBedrockMantle
+
+    @property
+    def chat_model_params(self) -> dict:
+        return {
+            "model": "openai.gpt-oss-120b",
+            "region_name": REGION,
+        }
+
+    @property
+    def standard_chat_model_params(self) -> dict:
+        return {"max_tokens": _STANDARD_MAX_TOKENS}
+
+    @property
+    def has_tool_choice(self) -> bool:
+        # Mantle rejects ``tool_choice="required"`` for gpt-oss-* on
+        # ``/v1/responses`` with a 400 validation error.
+        return False
+
+    @property
+    def has_structured_output(self) -> bool:
+        # ``openai.gpt-oss-120b`` does not strictly honor
+        # ``strict=True`` for ``response_format={"type": "json_schema"}``
+        # — it often prefixes free-form text (e.g. ``"Why{...}"``)
+        # before the JSON payload, breaking the output parser. The
+        # class-level structured-output plumbing is exercised by
+        # ``TestBedrockMantleStandardFrontier`` against ``gpt-5.5``.
+        return False
+
+    # These two tests internally use ``tool_choice="any"`` (which the
+    # class maps to ``tool_choice="required"``). Mantle rejects
+    # ``tool_choice="required"`` for ``openai.gpt-oss-120b`` on
+    # ``/v1/responses`` — same underlying limitation as
+    # ``has_tool_choice=False``, but this pair of tests uses
+    # ``tool_choice`` as a means to a different end so the flag
+    # doesn't skip them.
+    @pytest.mark.xfail(
+        reason=(
+            "openai.gpt-oss-120b rejects tool_choice='required' on "
+            "/v1/responses; exercised by TestBedrockMantleStandardFrontier "
+            "against a model that supports it."
+        )
+    )
+    def test_unicode_tool_call_integration(
+        self,
+        model: BaseChatModel,
+        *,
+        tool_choice: str | None = None,
+        force_tool_call: bool = True,
+    ) -> None:
+        super().test_unicode_tool_call_integration(
+            model, tool_choice=tool_choice, force_tool_call=force_tool_call
+        )
+
+    @pytest.mark.xfail(
+        reason=(
+            "openai.gpt-oss-120b rejects tool_choice='required' on "
+            "/v1/responses; exercised by TestBedrockMantleStandardFrontier "
+            "against a model that supports it."
+        )
+    )
+    def test_structured_few_shot_examples(
+        self, model: BaseChatModel, my_adder_tool: BaseTool
+    ) -> None:
+        super().test_structured_few_shot_examples(model, my_adder_tool)
+
+
+@pytest.mark.skipif(
+    not MANTLE_AVAILABLE,
+    reason="Mantle deps not installed or CI lacks Mantle API permissions.",
+)
+class TestBedrockMantleStandardFrontier(ChatModelIntegrationTests):
+    """Conformance run against a frontier OpenAI model on ``/openai/v1``.
+
+    ``openai.gpt-5.5`` lives on ``/openai/v1`` and supports the
+    Responses API only (no Chat Completions). Users select it by
+    passing an explicit ``base_url``. Frontier models allocate a
+    portion of the budget to internal reasoning, so we use a larger
+    ``max_tokens`` to ensure text output is produced.
+    """
+
+    @property
+    def chat_model_class(self) -> Type[BaseChatModel]:
+        return ChatBedrockMantle
+
+    @property
+    def chat_model_params(self) -> dict:
+        return {
+            "model": "openai.gpt-5.5",
+            "region_name": REGION,
+            "base_url": f"https://bedrock-mantle.{REGION}.api.aws/openai/v1",
+            # gpt-5.x is Responses-API-only — pin routing so structured
+            # output and other Chat-Completions-hinted params don't
+            # trigger a fallback to an endpoint the model doesn't serve.
+            "use_responses_api": True,
+        }
+
+    @property
+    def standard_chat_model_params(self) -> dict:
+        return {"max_tokens": _STANDARD_MAX_TOKENS}
+
+
+# ── Custom integration tests ────────────────────────────────────────
 
 MODELS = [
     "openai.gpt-oss-20b",
@@ -166,7 +290,9 @@ class TestToolCalling:
         assert len(chunks) > 0
         # At least one chunk should have tool call info or text
         has_content = any(isinstance(c.content, str) and c.content for c in chunks)
-        has_tool_chunks = any(c.tool_call_chunks for c in chunks)
+        has_tool_chunks = any(
+            isinstance(c, AIMessageChunk) and c.tool_call_chunks for c in chunks
+        )
         assert has_content or has_tool_chunks
 
 
@@ -337,5 +463,97 @@ class TestRetryAndTimeout:
     def test_custom_max_retries(self) -> None:
         llm = ChatBedrockMantle(model=MODELS[0], region_name=REGION, max_retries=3)
         response = llm.invoke("Say hi")
+        assert isinstance(response, AIMessage)
+        assert response.content
+
+
+# ── Explicit AWS credentials & configurable TTL ─────────────────────
+
+
+class TestExplicitCredsAndTTL:
+    """Live tests for the credential kwargs + TTL knob added in this
+    revision. Each test resolves creds from the ambient chain and passes
+    them explicitly, exercising the ``aws_access_key_id`` / secret / token
+    path end-to-end against a real Bedrock Mantle endpoint.
+    """
+
+    def _resolve_ambient_creds(self) -> dict:
+        """Snapshot the current default-chain creds for reuse as explicit kwargs."""
+        import boto3
+        from pydantic import SecretStr
+
+        creds = boto3.Session().get_credentials()
+        if creds is None:
+            pytest.skip("No AWS credentials available in this environment.")
+        frozen = creds.get_frozen_credentials()
+        if not frozen.access_key or not frozen.secret_key:
+            pytest.skip("Ambient AWS credentials missing access/secret key.")
+        result: dict = {
+            "aws_access_key_id": SecretStr(frozen.access_key),
+            "aws_secret_access_key": SecretStr(frozen.secret_key),
+        }
+        if frozen.token:
+            result["aws_session_token"] = SecretStr(frozen.token)
+        return result
+
+    def test_invoke_with_explicit_creds(self) -> None:
+        """End-to-end: explicit access_key + secret_key (+ session token if
+        present) produce a working short-term Bedrock API key."""
+        explicit_creds = self._resolve_ambient_creds()
+        llm = ChatBedrockMantle(
+            model=MODELS[0],
+            region_name=REGION,
+            **explicit_creds,
+        )
+        response = llm.invoke("Say hi in one word")
+        assert isinstance(response, AIMessage)
+        assert response.content
+
+    def test_invoke_with_custom_ttl(self) -> None:
+        """Non-default TTL propagates to the token generator and the
+        generated key still works."""
+        llm = ChatBedrockMantle(
+            model=MODELS[0],
+            region_name=REGION,
+            bedrock_api_key_ttl_seconds=3600,  # 1 hour instead of default 12h
+        )
+        response = llm.invoke("Say hi in one word")
+        assert isinstance(response, AIMessage)
+        assert response.content
+
+    def test_invoke_with_explicit_creds_and_custom_ttl(self) -> None:
+        """Combined: explicit creds + custom TTL both flow through."""
+        explicit_creds = self._resolve_ambient_creds()
+        llm = ChatBedrockMantle(
+            model=MODELS[0],
+            region_name=REGION,
+            bedrock_api_key_ttl_seconds=1800,  # 30 min
+            **explicit_creds,
+        )
+        response = llm.invoke("Say hi in one word")
+        assert isinstance(response, AIMessage)
+        assert response.content
+
+    def test_invoke_with_profile_name(self) -> None:
+        """Profile-only path: BotocoreSession(profile=...) resolves creds."""
+        profile = os.environ.get("LANGCHAIN_AWS_MANTLE_TEST_PROFILE") or os.environ.get(
+            "AWS_PROFILE"
+        )
+        if not profile:
+            pytest.skip("Set AWS_PROFILE or LANGCHAIN_AWS_MANTLE_TEST_PROFILE to run.")
+        # Verify the profile actually exists in ~/.aws/config.
+        import botocore.session
+
+        try:
+            botocore.session.Session(profile=profile).get_credentials()
+        except Exception as exc:
+            pytest.skip(f"Profile {profile!r} not resolvable: {exc}")
+
+        llm = ChatBedrockMantle(
+            model=MODELS[0],
+            region_name=REGION,
+            credentials_profile_name=profile,
+        )
+        response = llm.invoke("Say hi in one word")
         assert isinstance(response, AIMessage)
         assert response.content

--- a/libs/aws/tests/integration_tests/chat_models/test_standard.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_standard.py
@@ -56,3 +56,39 @@ class TestBedrockUseConverseStandard(ChatModelIntegrationTests):
     @property
     def supports_image_inputs(self) -> bool:
         return True
+
+
+try:
+    from langchain_aws import ChatBedrockMantle
+
+    _MANTLE_AVAILABLE = True
+except (ImportError, ModuleNotFoundError):
+    _MANTLE_AVAILABLE = False
+
+
+@pytest.mark.skipif(
+    not _MANTLE_AVAILABLE,
+    reason="Mantle deps not installed or CI lacks Mantle API permissions. "
+    'Run: pip install "langchain-aws[mantle]"',
+)
+class TestBedrockMantleStandard(ChatModelIntegrationTests):
+    @property
+    def chat_model_class(self) -> Type[BaseChatModel]:
+        return ChatBedrockMantle
+
+    @property
+    def chat_model_params(self) -> dict:
+        return {
+            "model": "openai.gpt-5.5",
+            "region_name": "us-east-1",
+            "base_url": "https://bedrock-mantle.us-east-1.api.aws/openai/v1",
+            # gpt-5.x is Responses-API-only.
+            "use_responses_api": True,
+        }
+
+    @property
+    def standard_chat_model_params(self) -> dict:
+        # 5000 matches ChatBedrockConverse's standard config; frontier
+        # OpenAI models (gpt-5.x) allocate a large slice of the budget to
+        # internal reasoning before emitting response text.
+        return {"max_tokens": 5000}

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_mantle.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_mantle.py
@@ -1,0 +1,926 @@
+"""Unit tests for ChatBedrockMantle."""
+
+from unittest import mock
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain_core.messages import (
+    AIMessage,
+    AIMessageChunk,
+    BaseMessage,
+    HumanMessage,
+    SystemMessage,
+    ToolMessage,
+    convert_to_openai_messages,
+)
+from pydantic import SecretStr
+
+# We need to mock openai and aws_bedrock_token_generator before importing
+# ChatBedrockMantle since they are optional deps.
+
+
+@pytest.fixture(autouse=True)
+def _mock_optional_deps(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mock the optional dependencies so tests run without installing them."""
+    mock_openai_mod = MagicMock()
+    mock_token_mod = MagicMock()
+    mock_token_mod.provide_token.return_value = "bedrock-api-key-dGVzdA==&Version=1"
+    monkeypatch.setitem(__import__("sys").modules, "openai", mock_openai_mod)
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "aws_bedrock_token_generator",
+        mock_token_mod,
+    )
+
+
+from langchain_aws.chat_models.bedrock_mantle import (  # noqa: E402
+    ChatBedrockMantle,
+    _handle_openai_error,
+    _openai_response_to_ai_message,
+    _parse_responses_tool_args,
+)
+from langchain_aws.utils import _BedrockApiKeyProvider  # noqa: E402
+
+# ── helpers ──────────────────────────────────────────────────────────
+
+
+def _make_llm(**overrides: object) -> ChatBedrockMantle:
+    defaults: dict = {
+        "model": "test",
+        "region_name": "us-east-1",
+        "api_key": SecretStr("k"),
+    }
+    defaults.update(overrides)
+    return ChatBedrockMantle(**defaults)
+
+
+def _mock_responses_response(
+    text: str = "hello",
+    resp_id: str = "resp_123",
+    model: str = "test",
+) -> MagicMock:
+    """Build a mock matching the Responses API shape."""
+    mock_text_block = MagicMock()
+    mock_text_block.text = text
+
+    mock_output_item = MagicMock()
+    mock_output_item.content = [mock_text_block]
+    del mock_output_item.name  # so hasattr(item, "name") is False
+
+    mock_response = MagicMock()
+    mock_response.id = resp_id
+    mock_response.model = model
+    mock_response.status = "completed"
+    mock_response.output = [mock_output_item]
+    mock_response.usage = MagicMock()
+    mock_response.usage.input_tokens = 10
+    mock_response.usage.output_tokens = 5
+    mock_response.usage.total_tokens = 15
+    return mock_response
+
+
+# ── OpenAI response conversion ──────────────────────────────────────
+
+
+class TestOpenAIResponseConversion:
+    """Tests for _openai_response_to_ai_message."""
+
+    def test_plain_text_response(self) -> None:
+        choice = MagicMock()
+        choice.message.content = "Hello there"
+        choice.message.tool_calls = None
+        choice.finish_reason = "stop"
+
+        msg = _openai_response_to_ai_message(choice)
+        assert isinstance(msg, AIMessage)
+        assert msg.content == "Hello there"
+        assert msg.tool_calls == []
+        assert msg.response_metadata["finish_reason"] == "stop"
+
+    def test_empty_content_response(self) -> None:
+        choice = MagicMock()
+        choice.message.content = None
+        choice.message.tool_calls = None
+        choice.finish_reason = "stop"
+
+        msg = _openai_response_to_ai_message(choice)
+        assert msg.content == ""
+
+    def test_response_with_tool_calls(self) -> None:
+        tc = MagicMock()
+        tc.function.name = "get_weather"
+        tc.function.arguments = '{"location": "Seattle"}'
+        tc.id = "call_abc"
+
+        choice = MagicMock()
+        choice.message.content = ""
+        choice.message.tool_calls = [tc]
+        choice.finish_reason = "tool_calls"
+
+        msg = _openai_response_to_ai_message(choice)
+        assert len(msg.tool_calls) == 1
+        assert msg.tool_calls[0]["name"] == "get_weather"
+        assert msg.tool_calls[0]["args"] == {"location": "Seattle"}
+        assert msg.tool_calls[0]["id"] == "call_abc"
+
+    def test_response_with_malformed_tool_args(self) -> None:
+        tc = MagicMock()
+        tc.function.name = "my_tool"
+        tc.function.arguments = "not valid json"
+        tc.id = "call_xyz"
+
+        choice = MagicMock()
+        choice.message.content = ""
+        choice.message.tool_calls = [tc]
+        choice.finish_reason = "tool_calls"
+
+        msg = _openai_response_to_ai_message(choice)
+        assert msg.tool_calls[0]["args"] == {"raw": "not valid json"}
+
+
+# ── Responses API tool-arg parsing ──────────────────────────────────
+
+
+class TestParseResponsesToolArgs:
+    def test_valid_json_dict(self) -> None:
+        assert _parse_responses_tool_args('{"a": 1}') == {"a": 1}
+
+    def test_json_list_wrapped(self) -> None:
+        assert _parse_responses_tool_args("[1, 2]") == {"raw": [1, 2]}
+
+    def test_invalid_json_wrapped(self) -> None:
+        assert _parse_responses_tool_args("not json") == {"raw": "not json"}
+
+    def test_dict_passthrough(self) -> None:
+        assert _parse_responses_tool_args({"x": 1}) == {"x": 1}
+
+    def test_none_wrapped(self) -> None:
+        assert _parse_responses_tool_args(None) == {"raw": None}
+
+
+# ── Message conversion ──────────────────────────────────────────────
+
+
+class TestMessageConversion:
+    def test_human_message(self) -> None:
+        msgs = convert_to_openai_messages([HumanMessage(content="hello")])
+        assert msgs == [{"role": "user", "content": "hello"}]
+
+    def test_system_message(self) -> None:
+        msgs = convert_to_openai_messages([SystemMessage(content="you are helpful")])
+        assert msgs == [{"role": "system", "content": "you are helpful"}]
+
+    def test_ai_message_plain(self) -> None:
+        msgs = convert_to_openai_messages([AIMessage(content="hi there")])
+        assert msgs == [{"role": "assistant", "content": "hi there"}]
+
+    def test_tool_message(self) -> None:
+        msgs = convert_to_openai_messages(
+            [ToolMessage(content="72F", tool_call_id="call_123")]
+        )
+        assert msgs == [{"role": "tool", "tool_call_id": "call_123", "content": "72F"}]
+
+    def test_multi_turn(self) -> None:
+        msgs = convert_to_openai_messages(
+            [
+                SystemMessage(content="be helpful"),
+                HumanMessage(content="hi"),
+                AIMessage(content="hello"),
+                HumanMessage(content="bye"),
+            ]
+        )
+        assert len(msgs) == 4
+        assert [m["role"] for m in msgs] == ["system", "user", "assistant", "user"]
+
+
+# ── Token provider ──────────────────────────────────────────────────
+
+
+class TestBedrockApiKeyProvider:
+    def test_caches_token(self) -> None:
+        provider = _BedrockApiKeyProvider("us-east-1")
+        with patch(
+            "langchain_aws.utils._BedrockApiKeyProvider._do_refresh"
+        ) as mock_refresh:
+
+            def _set_token() -> None:
+                provider._token = "token-1"
+                provider._expires_at = __import__("time").monotonic() + 50000
+
+            mock_refresh.side_effect = _set_token
+            provider()
+            assert mock_refresh.call_count == 1
+
+            t2 = provider()
+            assert mock_refresh.call_count == 1
+            assert t2 == "token-1"
+
+    def test_advisory_refresh_succeeds(self) -> None:
+        """Between advisory (15 min) and mandatory (10 min) thresholds,
+        refresh is attempted and succeeds."""
+        import time
+
+        provider = _BedrockApiKeyProvider("us-east-1")
+        provider._token = "old-token"
+        # Set expiry so we're in the advisory window (12 min remaining)
+        provider._expires_at = time.monotonic() + 720  # 12 min
+
+        with patch(
+            "langchain_aws.utils._BedrockApiKeyProvider._do_refresh"
+        ) as mock_refresh:
+
+            def _set_new_token() -> None:
+                provider._token = "new-token"
+                provider._expires_at = time.monotonic() + 43200
+
+            mock_refresh.side_effect = _set_new_token
+            result = provider()
+            assert result == "new-token"
+            mock_refresh.assert_called_once()
+
+    def test_advisory_refresh_fails_returns_existing_token(self) -> None:
+        """If advisory refresh fails but token is still valid (>10 min),
+        return the existing token instead of raising."""
+        import time
+
+        provider = _BedrockApiKeyProvider("us-east-1")
+        provider._token = "still-valid-token"
+        # Set expiry so we're in advisory window but not mandatory (12 min)
+        provider._expires_at = time.monotonic() + 720
+
+        with patch(
+            "langchain_aws.utils._BedrockApiKeyProvider._do_refresh"
+        ) as mock_refresh:
+            mock_refresh.side_effect = RuntimeError("network error")
+            result = provider()
+            assert result == "still-valid-token"
+
+    def test_mandatory_refresh_fails_raises(self) -> None:
+        """If mandatory refresh fails (<10 min remaining), must raise."""
+        import time
+
+        provider = _BedrockApiKeyProvider("us-east-1")
+        provider._token = "expiring-token"
+        # Set expiry so we're in the mandatory window (5 min remaining)
+        provider._expires_at = time.monotonic() + 300
+
+        with patch(
+            "langchain_aws.utils._BedrockApiKeyProvider._do_refresh"
+        ) as mock_refresh:
+            mock_refresh.side_effect = RuntimeError("network error")
+            with pytest.raises(RuntimeError, match="network error"):
+                provider()
+
+    def test_no_token_refresh_fails_raises(self) -> None:
+        """First call with no cached token — refresh failure must raise."""
+        provider = _BedrockApiKeyProvider("us-east-1")
+        assert provider._token is None
+
+        with patch(
+            "langchain_aws.utils._BedrockApiKeyProvider._do_refresh"
+        ) as mock_refresh:
+            mock_refresh.side_effect = RuntimeError("no creds")
+            with pytest.raises(RuntimeError, match="no creds"):
+                provider()
+
+
+# ── Init ────────────────────────────────────────────────────────────
+
+
+class TestChatBedrockMantleInit:
+    def test_missing_region_raises(self) -> None:
+        with pytest.raises(ValueError, match="region_name"):
+            with mock.patch.dict("os.environ", {}, clear=True):
+                ChatBedrockMantle(model="test-model")
+
+    def test_with_api_key(self) -> None:
+        llm = _make_llm(model="deepseek.v3.2", api_key=SecretStr("my-static-key"))
+        assert llm.model == "deepseek.v3.2"
+        assert llm._resolved_region == "us-east-1"
+
+    def test_with_region_constructs_url(self) -> None:
+        llm = _make_llm(region_name="us-west-2")
+        assert llm._resolved_region == "us-west-2"
+
+    def test_with_base_url_override(self) -> None:
+        llm = _make_llm(base_url="https://custom-endpoint.example.com/v1")
+        assert llm.base_url == "https://custom-endpoint.example.com/v1"
+
+    def test_llm_type(self) -> None:
+        assert _make_llm()._llm_type == "bedrock-mantle"
+
+    def test_max_retries_default(self) -> None:
+        assert _make_llm().max_retries == 2
+
+    def test_max_retries_custom(self) -> None:
+        assert _make_llm(max_retries=5).max_retries == 5
+
+    def test_timeout_custom(self) -> None:
+        assert _make_llm(timeout=30.0).timeout == 30.0
+
+
+# ── _build_params ───────────────────────────────────────────────────
+
+
+class TestBuildParams:
+    def test_basic_params(self) -> None:
+        llm = _make_llm(model="deepseek.v3.2", temperature=0.5, max_tokens=100)
+        params = llm._build_params(stop=["END"], stream=False)
+        assert params["model"] == "deepseek.v3.2"
+        assert params["temperature"] == 0.5
+        assert params["max_tokens"] == 100
+        assert params["stop"] == ["END"]
+        assert params["stream"] is False
+
+    def test_stream_includes_usage(self) -> None:
+        params = _make_llm()._build_params(stream=True)
+        assert params["stream_options"] == {"include_usage": True}
+
+    def test_previous_response_id_passthrough(self) -> None:
+        params = _make_llm()._build_params(
+            stream=False, previous_response_id="resp_abc123"
+        )
+        assert params["previous_response_id"] == "resp_abc123"
+
+
+# ── _use_responses_api routing ──────────────────────────────────────
+
+
+class TestUseResponsesApiRouting:
+    """Responses API is the default; Chat Completions is the fallback."""
+
+    def test_default_is_responses_api(self) -> None:
+        llm = _make_llm()
+        params = {"model": "test", "stream": False}
+        assert llm._use_responses_api(params) is True
+
+    def test_response_format_triggers_chat_completions(self) -> None:
+        llm = _make_llm()
+        params = {"model": "test", "response_format": {"type": "json_object"}}
+        assert llm._use_responses_api(params) is False
+
+    def test_previous_response_id_stays_on_responses(self) -> None:
+        llm = _make_llm()
+        params = {"model": "test", "previous_response_id": "resp_abc"}
+        assert llm._use_responses_api(params) is True
+
+    def test_explicit_true_always_responses(self) -> None:
+        llm = _make_llm(use_responses_api=True)
+        # Even with response_format, explicit True wins
+        params = {"model": "test", "response_format": {"type": "json_object"}}
+        assert llm._use_responses_api(params) is True
+
+    def test_explicit_false_always_chat_completions(self) -> None:
+        llm = _make_llm(use_responses_api=False)
+        params = {"model": "test", "stream": False}
+        assert llm._use_responses_api(params) is False
+
+    def test_generate_routes_to_responses_by_default(self) -> None:
+        llm = _make_llm()
+        mock_resp = _mock_responses_response(text="from responses api")
+        llm._sync_client.responses.create = MagicMock(return_value=mock_resp)
+        llm._sync_client.chat.completions.create = MagicMock(
+            side_effect=AssertionError("should not call chat completions")
+        )
+
+        result = llm._generate([HumanMessage(content="hi")])
+        assert result.generations[0].message.content == "from responses api"
+        llm._sync_client.responses.create.assert_called_once()
+
+    def test_generate_falls_back_to_chat_completions(self) -> None:
+        llm = _make_llm()
+
+        mock_choice = MagicMock()
+        mock_choice.message.content = "from chat completions"
+        mock_choice.message.tool_calls = None
+        mock_choice.finish_reason = "stop"
+        mock_resp = MagicMock()
+        mock_resp.choices = [mock_choice]
+        mock_resp.usage = None
+        mock_resp.model = "test"
+        mock_resp.id = "chatcmpl_123"
+
+        llm._sync_client.chat.completions.create = MagicMock(return_value=mock_resp)
+        llm._sync_client.responses.create = MagicMock(
+            side_effect=AssertionError("should not call responses")
+        )
+
+        result = llm._generate(
+            [HumanMessage(content="hi")],
+            response_format={"type": "json_object"},
+        )
+        assert result.generations[0].message.content == "from chat completions"
+        llm._sync_client.chat.completions.create.assert_called_once()
+
+
+# ── Error handling ──────────────────────────────────────────────────
+
+
+class TestErrorHandling:
+    def _make_mock_openai(self) -> MagicMock:
+        mock_mod = MagicMock()
+        for name in (
+            "AuthenticationError",
+            "RateLimitError",
+            "NotFoundError",
+            "BadRequestError",
+        ):
+            cls = type(name, (Exception,), {"__module__": "openai"})
+            setattr(mock_mod, name, cls)
+        return mock_mod
+
+    def test_authentication_error(self) -> None:
+        mock_mod = self._make_mock_openai()
+        error = mock_mod.AuthenticationError("invalid key")
+        with patch.dict(__import__("sys").modules, {"openai": mock_mod}):
+            with pytest.raises(ValueError, match="authentication failed"):
+                _handle_openai_error(error)
+
+    def test_rate_limit_error(self) -> None:
+        mock_mod = self._make_mock_openai()
+        error = mock_mod.RateLimitError("rate limited")
+        with patch.dict(__import__("sys").modules, {"openai": mock_mod}):
+            with pytest.raises(ValueError, match="rate limit"):
+                _handle_openai_error(error)
+
+    def test_not_found_error(self) -> None:
+        mock_mod = self._make_mock_openai()
+        error = mock_mod.NotFoundError("model not found")
+        with patch.dict(__import__("sys").modules, {"openai": mock_mod}):
+            with pytest.raises(ValueError, match="model not found"):
+                _handle_openai_error(error)
+
+    def test_bad_request_tool_choice(self) -> None:
+        mock_mod = self._make_mock_openai()
+        error = mock_mod.BadRequestError("Invalid 'tool_choice': value did not match")
+        with patch.dict(__import__("sys").modules, {"openai": mock_mod}):
+            with pytest.raises(ValueError, match="rejected the tool_choice"):
+                _handle_openai_error(error)
+
+    def test_bad_request_not_supported(self) -> None:
+        mock_mod = self._make_mock_openai()
+        error = mock_mod.BadRequestError("model does not support /v1/responses")
+        with patch.dict(__import__("sys").modules, {"openai": mock_mod}):
+            with pytest.raises(ValueError, match="not supported"):
+                _handle_openai_error(error)
+
+    def test_unknown_error_reraised(self) -> None:
+        mock_mod = self._make_mock_openai()
+        error = RuntimeError("something else")
+        with patch.dict(__import__("sys").modules, {"openai": mock_mod}):
+            with pytest.raises(RuntimeError, match="something else"):
+                _handle_openai_error(error)
+
+    def test_bad_request_generic(self) -> None:
+        mock_mod = self._make_mock_openai()
+        error = mock_mod.BadRequestError("some other bad request")
+        with patch.dict(__import__("sys").modules, {"openai": mock_mod}):
+            with pytest.raises(ValueError, match="bad request"):
+                _handle_openai_error(error)
+
+
+# ── Refusal propagation ────────────────────────────────────────────
+
+
+class TestRefusalPropagation:
+    def test_refusal_in_additional_kwargs(self) -> None:
+        choice = MagicMock()
+        choice.message.content = ""
+        choice.message.tool_calls = None
+        choice.message.refusal = "I cannot help with that."
+        choice.finish_reason = "stop"
+
+        msg = _openai_response_to_ai_message(choice)
+        assert msg.additional_kwargs["refusal"] == "I cannot help with that."
+
+    def test_no_refusal_omitted(self) -> None:
+        choice = MagicMock()
+        choice.message.content = "Hello"
+        choice.message.tool_calls = None
+        choice.message.refusal = None
+        choice.finish_reason = "stop"
+
+        msg = _openai_response_to_ai_message(choice)
+        assert "refusal" not in msg.additional_kwargs
+
+
+# ── Async: Responses API uses async client ──────────────────────────
+
+
+class TestAGenerateResponsesApi:
+    def test_agenerate_uses_async_client(self) -> None:
+        """Regression: _agenerate must use _async_client, not _sync_client."""
+        import asyncio
+
+        llm = _make_llm()
+        mock_resp = _mock_responses_response(text="async response", resp_id="resp_a1")
+
+        async def _mock_create(**kwargs):  # type: ignore[no-untyped-def]
+            return mock_resp
+
+        llm._async_client.responses.create = _mock_create
+        llm._sync_client.responses.create = MagicMock(
+            side_effect=AssertionError("sync client should not be called")
+        )
+
+        result = asyncio.run(llm._agenerate([HumanMessage(content="hi")]))
+        assert result.generations[0].message.content == "async response"
+        assert result.generations[0].message.response_metadata["id"] == "resp_a1"
+        llm._sync_client.responses.create.assert_not_called()
+
+
+# ── Responses API streaming ─────────────────────────────────────────
+
+
+class TestResponsesApiStreaming:
+    """Verify streaming works for the Responses API (default path)."""
+
+    def _make_text_delta_event(self, text: str) -> MagicMock:
+        event = MagicMock()
+        event.type = "response.output_text.delta"
+        event.delta = text
+        return event
+
+    def _make_completed_event(
+        self,
+        resp_id: str = "resp_s1",
+        model: str = "test",
+    ) -> MagicMock:
+        event = MagicMock()
+        event.type = "response.completed"
+        event.response.id = resp_id
+        event.response.model = model
+        event.response.usage.input_tokens = 5
+        event.response.usage.output_tokens = 3
+        event.response.usage.total_tokens = 8
+        return event
+
+    def test_stream_yields_text_chunks(self) -> None:
+        llm = _make_llm()
+        events = [
+            self._make_text_delta_event("Hel"),
+            self._make_text_delta_event("lo"),
+            self._make_completed_event(),
+        ]
+        llm._sync_client.responses.create = MagicMock(return_value=iter(events))
+
+        chunks = list(llm._stream([HumanMessage(content="hi")]))
+        text = "".join(
+            c.message.content
+            for c in chunks
+            if isinstance(c.message.content, str) and c.message.content
+        )
+        assert text == "Hello"
+
+    def test_stream_final_chunk_has_usage(self) -> None:
+        llm = _make_llm()
+        events = [
+            self._make_text_delta_event("ok"),
+            self._make_completed_event(),
+        ]
+        llm._sync_client.responses.create = MagicMock(return_value=iter(events))
+
+        chunks = list(llm._stream([HumanMessage(content="hi")]))
+        last = chunks[-1]
+        assert isinstance(last.message, AIMessageChunk)
+        assert last.message.usage_metadata is not None
+        assert last.message.usage_metadata["input_tokens"] == 5
+        assert last.message.usage_metadata["output_tokens"] == 3
+
+    def test_stream_skips_unknown_events(self) -> None:
+        llm = _make_llm()
+        unknown = MagicMock()
+        unknown.type = "response.reasoning_text.delta"
+        events = [
+            unknown,
+            self._make_text_delta_event("hi"),
+            self._make_completed_event(),
+        ]
+        llm._sync_client.responses.create = MagicMock(return_value=iter(events))
+
+        chunks = list(llm._stream([HumanMessage(content="hi")]))
+        text = "".join(
+            c.message.content
+            for c in chunks
+            if isinstance(c.message.content, str) and c.message.content
+        )
+        assert text == "hi"
+
+    def test_astream_yields_text_chunks(self) -> None:
+        import asyncio
+
+        llm = _make_llm()
+        events = [
+            self._make_text_delta_event("async "),
+            self._make_text_delta_event("stream"),
+            self._make_completed_event(),
+        ]
+
+        async def _async_iter():  # type: ignore[no-untyped-def]
+            for e in events:
+                yield e
+
+        async def _mock_create(**kwargs):  # type: ignore[no-untyped-def]
+            return _async_iter()
+
+        llm._async_client.responses.create = _mock_create
+
+        async def _collect() -> list:
+            return [chunk async for chunk in llm._astream([HumanMessage(content="hi")])]
+
+        chunks = asyncio.run(_collect())
+        text = "".join(
+            c.message.content
+            for c in chunks
+            if isinstance(c.message.content, str) and c.message.content
+        )
+        assert text == "async stream"
+
+
+# ── Tool format conversion ──────────────────────────────────────────
+
+
+class TestToolFormatConversion:
+    """_prepare_responses_params must convert Chat Completions tool format
+    to Responses API format."""
+
+    def test_converts_chat_completions_tool_format(self) -> None:
+        llm = _make_llm()
+        params = llm._build_params(
+            stream=False,
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "description": "Get weather.",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"location": {"type": "string"}},
+                            "required": ["location"],
+                        },
+                    },
+                }
+            ],
+        )
+        resp_params = llm._prepare_responses_params(params)
+        tool = resp_params["tools"][0]
+        # Responses API format: flat, no nested "function" key
+        assert tool["type"] == "function"
+        assert tool["name"] == "get_weather"
+        assert "function" not in tool
+        assert "parameters" in tool
+
+    def test_passes_through_responses_format_tools(self) -> None:
+        llm = _make_llm()
+        params = llm._build_params(
+            stream=False,
+            tools=[
+                {
+                    "type": "function",
+                    "name": "get_weather",
+                    "description": "Get weather.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"location": {"type": "string"}},
+                        "required": ["location"],
+                    },
+                }
+            ],
+        )
+        resp_params = llm._prepare_responses_params(params)
+        tool = resp_params["tools"][0]
+        assert tool["name"] == "get_weather"
+        assert "function" not in tool
+
+
+# ── AIMessage.id set from response ID ───────────────────────────────
+
+
+class TestResponseIdOnMessage:
+    """response.id must be set on AIMessage.id for LangGraph compat."""
+
+    def test_invoke_sets_message_id(self) -> None:
+        llm = _make_llm()
+        mock_resp = _mock_responses_response(resp_id="resp_abc123")
+        llm._sync_client.responses.create = MagicMock(return_value=mock_resp)
+
+        result = llm._generate([HumanMessage(content="hi")])
+        msg = result.generations[0].message
+        assert msg.id == "resp_abc123"
+        assert msg.response_metadata["id"] == "resp_abc123"
+
+    def test_stream_completed_sets_message_id(self) -> None:
+        llm = _make_llm()
+        completed = MagicMock()
+        completed.type = "response.completed"
+        completed.response.id = "resp_stream_456"
+        completed.response.model = "test"
+        completed.response.usage.input_tokens = 5
+        completed.response.usage.output_tokens = 3
+        completed.response.usage.total_tokens = 8
+
+        llm._sync_client.responses.create = MagicMock(return_value=iter([completed]))
+
+        chunks = list(llm._stream([HumanMessage(content="hi")]))
+        assert chunks[-1].message.id == "resp_stream_456"
+
+
+# ── Streaming tool-call events ──────────────────────────────────────
+
+
+class TestStreamingToolCalls:
+    """Responses API streaming must emit tool-call chunks."""
+
+    def test_function_call_added_emits_tool_chunk(self) -> None:
+        llm = _make_llm()
+
+        added = MagicMock()
+        added.type = "response.output_item.added"
+        added.item.type = "function_call"
+        added.item.name = "get_weather"
+        added.item.call_id = "call_abc"
+        added.output_index = 0
+
+        delta = MagicMock()
+        delta.type = "response.function_call_arguments.delta"
+        delta.delta = '{"location":'
+        delta.output_index = 0
+
+        delta2 = MagicMock()
+        delta2.type = "response.function_call_arguments.delta"
+        delta2.delta = '"Seattle"}'
+        delta2.output_index = 0
+
+        completed = MagicMock()
+        completed.type = "response.completed"
+        completed.response.id = "resp_tc"
+        completed.response.model = "test"
+        completed.response.usage.input_tokens = 10
+        completed.response.usage.output_tokens = 5
+        completed.response.usage.total_tokens = 15
+
+        llm._sync_client.responses.create = MagicMock(
+            return_value=iter([added, delta, delta2, completed])
+        )
+
+        chunks = list(llm._stream([HumanMessage(content="weather?")]))
+
+        # First chunk should have tool name and id
+        assert isinstance(chunks[0].message, AIMessageChunk)
+        tc_chunks = chunks[0].message.tool_call_chunks
+        assert len(tc_chunks) == 1
+        assert tc_chunks[0]["name"] == "get_weather"
+        assert tc_chunks[0]["id"] == "call_abc"
+
+        # Subsequent chunks carry argument fragments
+        all_args = ""
+        for c in chunks[1:-1]:  # skip first (name) and last (completed)
+            assert isinstance(c.message, AIMessageChunk)
+            if c.message.tool_call_chunks:
+                args = c.message.tool_call_chunks[0]["args"]
+                if args:
+                    all_args += args
+        assert all_args == '{"location":"Seattle"}'
+
+
+# ── stream_usage toggle ─────────────────────────────────────────────
+
+
+class TestStreamUsage:
+    def test_default_includes_usage(self) -> None:
+        params = _make_llm()._build_params(stream=True)
+        assert params["stream_options"] == {"include_usage": True}
+
+    def test_explicit_true(self) -> None:
+        params = _make_llm(stream_usage=True)._build_params(stream=True)
+        assert params["stream_options"] == {"include_usage": True}
+
+    def test_explicit_false_omits_stream_options(self) -> None:
+        params = _make_llm(stream_usage=False)._build_params(stream=True)
+        assert "stream_options" not in params
+
+
+# ── use_previous_response_id ────────────────────────────────────────
+
+
+class TestUsePreviousResponseId:
+    def test_extracts_id_from_message_history(self) -> None:
+        llm = _make_llm(use_previous_response_id=True)
+        mock_resp = _mock_responses_response(text="followup", resp_id="resp_f1")
+        llm._sync_client.responses.create = MagicMock(return_value=mock_resp)
+
+        messages = [
+            HumanMessage(content="Hello"),
+            AIMessage(content="Hi!", id="resp_first_123"),
+            HumanMessage(content="How are you?"),
+        ]
+        result = llm._generate(messages)
+        assert result.generations[0].message.content == "followup"
+
+        # Verify previous_response_id was passed to the API
+        call_kwargs = llm._sync_client.responses.create.call_args[1]
+        assert call_kwargs["previous_response_id"] == "resp_first_123"
+
+    def test_no_response_id_sends_all_messages(self) -> None:
+        llm = _make_llm(use_previous_response_id=True)
+        mock_resp = _mock_responses_response()
+        llm._sync_client.responses.create = MagicMock(return_value=mock_resp)
+
+        messages: list[BaseMessage] = [
+            HumanMessage(content="Hello"),
+            HumanMessage(content="How are you?"),
+        ]
+        llm._generate(messages)
+
+        call_kwargs = llm._sync_client.responses.create.call_args[1]
+        assert call_kwargs.get("previous_response_id") is None
+
+    def test_disabled_by_default(self) -> None:
+        llm = _make_llm()
+        assert llm.use_previous_response_id is False
+
+
+# ── tool_choice validation ──────────────────────────────────────────
+
+
+class TestToolChoiceValidation:
+    def test_auto_passes_without_warning(self) -> None:
+        llm = _make_llm()
+        params = llm._build_params(stream=False, tool_choice="auto")
+        with patch("langchain_aws.chat_models.bedrock_mantle.logger") as mock_log:
+            llm._prepare_responses_params(params)
+            mock_log.warning.assert_not_called()
+
+    def test_none_passes_without_warning(self) -> None:
+        llm = _make_llm()
+        params = llm._build_params(stream=False, tool_choice="none")
+        with patch("langchain_aws.chat_models.bedrock_mantle.logger") as mock_log:
+            llm._prepare_responses_params(params)
+            mock_log.warning.assert_not_called()
+
+    def test_required_logs_warning(self) -> None:
+        llm = _make_llm()
+        params = llm._build_params(stream=False, tool_choice="required")
+        with patch("langchain_aws.chat_models.bedrock_mantle.logger") as mock_log:
+            llm._prepare_responses_params(params)
+            mock_log.warning.assert_called_once()
+            assert "tool_choice" in mock_log.warning.call_args[0][0]
+
+
+# ── _use_responses_api routing with text param ──────────────────────
+
+
+class TestRoutingWithTextParam:
+    def test_text_param_forces_responses_api(self) -> None:
+        llm = _make_llm()
+        params = {"model": "test", "text": {"format": {"type": "json_object"}}}
+        assert llm._use_responses_api(params) is True
+
+    def test_text_overrides_response_format(self) -> None:
+        """If both text and response_format are present, text wins."""
+        llm = _make_llm()
+        params = {
+            "model": "test",
+            "text": {"format": {"type": "json_object"}},
+            "response_format": {"type": "json_object"},
+        }
+        assert llm._use_responses_api(params) is True
+
+
+# ── with_structured_output json_schema ──────────────────────────────
+
+
+class TestWithStructuredOutputJsonSchema:
+    """with_structured_output(method='json_schema') must bind the text param
+    so the Responses API receives the json_schema format."""
+
+    def test_json_schema_binds_text_param(self) -> None:
+        llm = _make_llm()
+        mock_resp = _mock_responses_response(
+            text='{"name": "Alice", "age": 30}', resp_id="resp_js1"
+        )
+        llm._sync_client.responses.create = MagicMock(return_value=mock_resp)
+
+        schema = {
+            "type": "object",
+            "title": "Person",
+            "properties": {
+                "name": {"type": "string"},
+                "age": {"type": "integer"},
+            },
+            "required": ["name", "age"],
+        }
+        structured = llm.with_structured_output(schema, method="json_schema")
+
+        # Invoke to trigger the bound params
+        structured.invoke("Give me a person")
+
+        # Verify the text param was passed to the Responses API
+        call_kwargs = llm._sync_client.responses.create.call_args[1]
+        assert "text" in call_kwargs
+        text_format = call_kwargs["text"]["format"]
+        assert text_format["type"] == "json_schema"
+        assert text_format["name"] == "Person"
+        assert text_format["schema"] == schema
+        assert text_format["strict"] is True

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_mantle.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_mantle.py
@@ -1,5 +1,12 @@
-"""Unit tests for ChatBedrockMantle."""
+"""Unit tests for ChatBedrockMantle.
 
+The standard LangChain interface tests (``ChatModelUnitTests``) for this
+model live in ``tests/unit_tests/test_standard.py`` alongside the other
+Bedrock chat model conformance suites.
+"""
+
+import sys
+from typing import AsyncGenerator, Generator, Optional, cast
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
@@ -13,17 +20,40 @@ from langchain_core.messages import (
     ToolMessage,
     convert_to_openai_messages,
 )
+from langchain_core.outputs import ChatGenerationChunk
 from pydantic import SecretStr
 
 # We need to mock openai and aws_bedrock_token_generator before importing
 # ChatBedrockMantle since they are optional deps.
 
 
+def _make_mock_module(name: str) -> MagicMock:
+    """Build a MagicMock that satisfies ``importlib.util.find_spec``.
+
+    ``find_spec`` reads ``module.__spec__``; a bare ``MagicMock`` auto-
+    creates one but it isn't a valid ``ModuleSpec``, which raises when
+    the caller code uses ``find_spec`` to feature-detect the module.
+    """
+    from importlib.machinery import ModuleSpec
+
+    mod = MagicMock()
+    mod.__spec__ = ModuleSpec(name, loader=None)
+    mod.__name__ = name
+    return mod
+
+
+_mock_openai_mod = _make_mock_module("openai")
+_mock_token_gen_mod = _make_mock_module("aws_bedrock_token_generator")
+_mock_token_gen_mod.provide_token.return_value = "bedrock-api-key-dGVzdA==&Version=1"
+sys.modules.setdefault("openai", _mock_openai_mod)
+sys.modules.setdefault("aws_bedrock_token_generator", _mock_token_gen_mod)
+
+
 @pytest.fixture(autouse=True)
 def _mock_optional_deps(monkeypatch: pytest.MonkeyPatch) -> None:
     """Mock the optional dependencies so tests run without installing them."""
-    mock_openai_mod = MagicMock()
-    mock_token_mod = MagicMock()
+    mock_openai_mod = _make_mock_module("openai")
+    mock_token_mod = _make_mock_module("aws_bedrock_token_generator")
     mock_token_mod.provide_token.return_value = "bedrock-api-key-dGVzdA==&Version=1"
     monkeypatch.setitem(__import__("sys").modules, "openai", mock_openai_mod)
     monkeypatch.setitem(
@@ -77,6 +107,54 @@ def _mock_responses_response(
     mock_response.usage.output_tokens = 5
     mock_response.usage.total_tokens = 15
     return mock_response
+
+
+class _MockSyncStream:
+    """Mimic an ``openai.Stream``: both an iterator and a context manager."""
+
+    def __init__(self, events: list) -> None:
+        self._events = list(events)
+        self._i = 0
+
+    def __enter__(self) -> "_MockSyncStream":
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+        pass
+
+    def __iter__(self) -> "_MockSyncStream":
+        return self
+
+    def __next__(self) -> object:
+        if self._i >= len(self._events):
+            raise StopIteration
+        event = self._events[self._i]
+        self._i += 1
+        return event
+
+
+class _MockAsyncStream:
+    """Mimic an ``openai.AsyncStream``: supports ``async with`` and ``async for``."""
+
+    def __init__(self, events: list) -> None:
+        self._events = list(events)
+        self._i = 0
+
+    async def __aenter__(self) -> "_MockAsyncStream":
+        return self
+
+    async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+        pass
+
+    def __aiter__(self) -> "_MockAsyncStream":
+        return self
+
+    async def __anext__(self) -> object:
+        if self._i >= len(self._events):
+            raise StopAsyncIteration
+        event = self._events[self._i]
+        self._i += 1
+        return event
 
 
 # ── OpenAI response conversion ──────────────────────────────────────
@@ -136,6 +214,97 @@ class TestOpenAIResponseConversion:
 
         msg = _openai_response_to_ai_message(choice)
         assert msg.tool_calls[0]["args"] == {"raw": "not valid json"}
+
+
+# ── Responses API output extraction ─────────────────────────────────
+
+
+class TestExtractResponsesOutput:
+    """Tests for ``_extract_responses_output``.
+
+    Guards against known heterogeneous output items in the Responses API
+    (text, tool call, reasoning). Reasoning items expose a ``content``
+    attribute that is ``None`` on gpt-5.x; iterating it must not raise.
+    """
+
+    @staticmethod
+    def _extract(response: object) -> tuple:
+        from langchain_aws.chat_models.bedrock_mantle import (
+            _extract_responses_output,
+        )
+
+        return _extract_responses_output(response)
+
+    def _text_item(self, text: str) -> MagicMock:
+        block = MagicMock()
+        block.text = text
+        item = MagicMock()
+        item.content = [block]
+        # Ensure hasattr(item, "name") is False so it's treated as a text item.
+        del item.name
+        return item
+
+    def _tool_call_item(
+        self, name: str, args: str, call_id: str = "call_1"
+    ) -> MagicMock:
+        item = MagicMock()
+        item.content = None  # tool calls do not carry text content
+        item.name = name
+        item.arguments = args
+        item.call_id = call_id
+        return item
+
+    def _reasoning_item(self) -> MagicMock:
+        """Reasoning items on gpt-5.x expose ``content=None``."""
+        item = MagicMock()
+        item.content = None
+        # No `name` attribute → not a tool call either.
+        del item.name
+        return item
+
+    def _response(self, output_items: list) -> MagicMock:
+        r = MagicMock()
+        r.output = output_items
+        return r
+
+    def test_text_only(self) -> None:
+        response = self._response([self._text_item("hello")])
+        content, tool_calls = self._extract(response)
+        assert content == "hello"
+        assert tool_calls == []
+
+    def test_reasoning_item_with_none_content_skipped(self) -> None:
+        response = self._response([self._reasoning_item(), self._text_item("hi")])
+        content, tool_calls = self._extract(response)
+        assert content == "hi"
+        assert tool_calls == []
+
+    def test_reasoning_and_tool_call_no_text(self) -> None:
+        response = self._response(
+            [
+                self._reasoning_item(),
+                self._tool_call_item("get_weather", '{"city": "SEA"}'),
+            ]
+        )
+        content, tool_calls = self._extract(response)
+        assert content == ""
+        assert len(tool_calls) == 1
+        assert tool_calls[0]["name"] == "get_weather"
+        assert tool_calls[0]["args"] == {"city": "SEA"}
+        assert tool_calls[0]["id"] == "call_1"
+
+    def test_empty_output(self) -> None:
+        response = self._response([])
+        content, tool_calls = self._extract(response)
+        assert content == ""
+        assert tool_calls == []
+
+    def test_none_output(self) -> None:
+        r = MagicMock()
+        r.output = None
+        content, tool_calls = self._extract(r)
+        assert content == ""
+        assert tool_calls == []
 
 
 # ── Responses API tool-arg parsing ──────────────────────────────────
@@ -274,7 +443,7 @@ class TestBedrockApiKeyProvider:
     def test_no_token_refresh_fails_raises(self) -> None:
         """First call with no cached token — refresh failure must raise."""
         provider = _BedrockApiKeyProvider("us-east-1")
-        assert provider._token is None
+        assert not provider._token
 
         with patch(
             "langchain_aws.utils._BedrockApiKeyProvider._do_refresh"
@@ -282,6 +451,284 @@ class TestBedrockApiKeyProvider:
             mock_refresh.side_effect = RuntimeError("no creds")
             with pytest.raises(RuntimeError, match="no creds"):
                 provider()
+
+    def test_async_call_returns_same_token(self) -> None:
+        """``async_call`` delegates to ``__call__`` via ``asyncio.to_thread``
+        and returns the same cached token as the sync path.
+        """
+        import asyncio
+        import time as _time
+
+        provider = _BedrockApiKeyProvider("us-east-1")
+
+        def _set_token() -> None:
+            provider._token = "async-test-token"
+            provider._expires_at = _time.monotonic() + 43200
+
+        with patch.object(provider, "_do_refresh", side_effect=_set_token):
+            sync_result = provider()
+            async_result = asyncio.run(provider.async_call())
+
+        assert sync_result == "async-test-token"
+        assert async_result == "async-test-token"
+
+
+# ── Token provider _do_refresh credential-expiry awareness ──────────
+
+
+class TestBedrockApiKeyProviderDoRefresh:
+    """Tests for _do_refresh respecting underlying credential expiry."""
+
+    def test_static_credentials_use_full_ttl(self) -> None:
+        """Static (non-refreshable) creds → use full 12h TTL."""
+        import time
+
+        provider = _BedrockApiKeyProvider("us-east-1")
+
+        mock_static_creds = MagicMock()
+        mock_session = MagicMock()
+        mock_session.get_credentials.return_value = mock_static_creds
+
+        with (
+            patch("botocore.session.Session", return_value=mock_session),
+            patch(
+                "aws_bedrock_token_generator.provide_token",
+                return_value="bedrock-api-key-abc123",
+            ) as mock_provide,
+        ):
+            provider._do_refresh()
+
+        assert provider._token == "bedrock-api-key-abc123"
+        # Should use full 12h TTL since creds are not RefreshableCredentials
+        expected_expiry = time.monotonic() + 43200
+        assert abs(provider._expires_at - expected_expiry) < 2
+        mock_provide.assert_called_once()
+        call_kwargs = mock_provide.call_args
+        assert call_kwargs[1]["expiry"].total_seconds() == 43200
+
+    def test_refreshable_credentials_uses_remaining_time(self) -> None:
+        """RefreshableCredentials with 2h remaining → TTL capped at 2h."""
+        import time
+
+        from botocore.credentials import RefreshableCredentials
+
+        provider = _BedrockApiKeyProvider("us-east-1")
+
+        mock_creds = MagicMock(spec=RefreshableCredentials)
+        mock_creds._seconds_remaining.return_value = 7200.0  # 2 hours
+
+        mock_session = MagicMock()
+        mock_session.get_credentials.return_value = mock_creds
+
+        with (
+            patch("botocore.session.Session", return_value=mock_session),
+            patch(
+                "aws_bedrock_token_generator.provide_token",
+                return_value="bedrock-api-key-short",
+            ) as mock_provide,
+        ):
+            provider._do_refresh()
+
+        assert provider._token == "bedrock-api-key-short"
+        expected_expiry = time.monotonic() + 7200
+        assert abs(provider._expires_at - expected_expiry) < 2
+        call_kwargs = mock_provide.call_args
+        assert call_kwargs[1]["expiry"].total_seconds() == 7200
+
+    def test_refreshable_credentials_longer_than_12h_capped(self) -> None:
+        """RefreshableCredentials with 24h remaining → still capped at 12h."""
+        import time
+
+        from botocore.credentials import RefreshableCredentials
+
+        provider = _BedrockApiKeyProvider("us-east-1")
+
+        mock_creds = MagicMock(spec=RefreshableCredentials)
+        mock_creds._seconds_remaining.return_value = 86400.0  # 24 hours
+
+        mock_session = MagicMock()
+        mock_session.get_credentials.return_value = mock_creds
+
+        with (
+            patch("botocore.session.Session", return_value=mock_session),
+            patch(
+                "aws_bedrock_token_generator.provide_token",
+                return_value="bedrock-api-key-long",
+            ) as mock_provide,
+        ):
+            provider._do_refresh()
+
+        assert provider._token == "bedrock-api-key-long"
+        expected_expiry = time.monotonic() + 43200
+        assert abs(provider._expires_at - expected_expiry) < 2
+        call_kwargs = mock_provide.call_args
+        assert call_kwargs[1]["expiry"].total_seconds() == 43200
+
+    def test_session_error_falls_back_to_default_ttl(self) -> None:
+        """If credential introspection fails, fall back to 12h."""
+        import time
+
+        provider = _BedrockApiKeyProvider("us-east-1")
+
+        with (
+            patch(
+                "botocore.session.Session",
+                side_effect=RuntimeError("session broken"),
+            ),
+            patch(
+                "aws_bedrock_token_generator.provide_token",
+                return_value="bedrock-api-key-fallback",
+            ),
+        ):
+            provider._do_refresh()
+
+        assert provider._token == "bedrock-api-key-fallback"
+        expected_expiry = time.monotonic() + 43200
+        assert abs(provider._expires_at - expected_expiry) < 2
+
+    def test_refreshable_credentials_5min_remaining(self) -> None:
+        """Creds with only 5 min left → token TTL is 5 min, refresh
+        triggers quickly."""
+        import time
+
+        from botocore.credentials import RefreshableCredentials
+
+        provider = _BedrockApiKeyProvider("us-east-1")
+
+        mock_creds = MagicMock(spec=RefreshableCredentials)
+        mock_creds._seconds_remaining.return_value = 300.0  # 5 minutes
+
+        mock_session = MagicMock()
+        mock_session.get_credentials.return_value = mock_creds
+
+        with (
+            patch("botocore.session.Session", return_value=mock_session),
+            patch(
+                "aws_bedrock_token_generator.provide_token",
+                return_value="bedrock-api-key-5min",
+            ) as mock_provide,
+        ):
+            provider._do_refresh()
+
+        assert provider._token == "bedrock-api-key-5min"
+        expected_expiry = time.monotonic() + 300
+        assert abs(provider._expires_at - expected_expiry) < 2
+        call_kwargs = mock_provide.call_args
+        assert call_kwargs[1]["expiry"].total_seconds() == 300
+
+
+# ── Token provider thread safety ────────────────────────────────────
+
+
+class TestBedrockApiKeyProviderThreadSafety:
+    """Verify thread contention scenarios for _BedrockApiKeyProvider."""
+
+    def test_concurrent_calls_only_refresh_once(self) -> None:
+        """Multiple threads hitting advisory window simultaneously should
+        result in only one refresh call (others return cached token)."""
+        import threading
+        import time
+
+        provider = _BedrockApiKeyProvider("us-east-1")
+        provider._token = "old-token"
+        # Put in advisory window (12 min remaining)
+        provider._expires_at = time.monotonic() + 720
+
+        refresh_count = 0
+        refresh_lock = threading.Lock()
+
+        def _slow_refresh() -> None:
+            nonlocal refresh_count
+            # Simulate a slow refresh (e.g., network call)
+            time.sleep(0.1)
+            with refresh_lock:
+                refresh_count += 1
+            provider._token = "new-token"
+            provider._expires_at = time.monotonic() + 43200
+
+        results: list = []
+
+        def _call_provider() -> None:
+            token = provider()
+            results.append(token)
+
+        with patch.object(provider, "_do_refresh", side_effect=_slow_refresh):
+            threads = [threading.Thread(target=_call_provider) for _ in range(10)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+        # All threads should get a token (either old or new)
+        assert len(results) == 10
+        assert all(t in ("old-token", "new-token") for t in results)
+        # Only one thread should have performed the refresh
+        # (others either got the lock and saw no refresh needed,
+        # or returned the old token during advisory window)
+        assert refresh_count == 1
+
+    def test_mandatory_window_blocks_all_threads(self) -> None:
+        """When in mandatory window, all threads block until refresh
+        completes — none return a stale token."""
+        import threading
+        import time
+
+        provider = _BedrockApiKeyProvider("us-east-1")
+        provider._token = "expiring-token"
+        # Put in mandatory window (5 min remaining)
+        provider._expires_at = time.monotonic() + 300
+
+        def _refresh() -> None:
+            time.sleep(0.05)
+            provider._token = "fresh-token"
+            provider._expires_at = time.monotonic() + 43200
+
+        results: list = []
+
+        def _call_provider() -> None:
+            token = provider()
+            results.append(token)
+
+        with patch.object(provider, "_do_refresh", side_effect=_refresh):
+            threads = [threading.Thread(target=_call_provider) for _ in range(5)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+        # All threads must get the fresh token (mandatory = block until done)
+        assert all(t == "fresh-token" for t in results)
+
+    def test_no_token_all_threads_block(self) -> None:
+        """First call with no cached token — all threads must block
+        until the first refresh completes."""
+        import threading
+        import time
+
+        provider = _BedrockApiKeyProvider("us-east-1")
+        assert not provider._token
+
+        def _refresh() -> None:
+            time.sleep(0.05)
+            provider._token = "first-token"
+            provider._expires_at = time.monotonic() + 43200
+
+        results: list = []
+
+        def _call_provider() -> None:
+            token = provider()
+            results.append(token)
+
+        with patch.object(provider, "_do_refresh", side_effect=_refresh):
+            threads = [threading.Thread(target=_call_provider) for _ in range(5)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+        # All threads must get the token (none should get None)
+        assert len(results) == 5
+        assert all(t == "first-token" for t in results)
 
 
 # ── Init ────────────────────────────────────────────────────────────
@@ -317,6 +764,366 @@ class TestChatBedrockMantleInit:
 
     def test_timeout_custom(self) -> None:
         assert _make_llm(timeout=30.0).timeout == 30.0
+
+
+# ── Explicit AWS credentials & configurable TTL ─────────────────────
+
+
+_AWS_ENV_KEYS = (
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+    "AWS_PROFILE",
+)
+
+
+def _clear_aws_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remove ambient AWS env vars so ``secret_from_env`` fields default to None."""
+    for key in _AWS_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+
+class TestChatBedrockMantleCredentialFields:
+    """Field wiring for the credential kwargs added in this revision.
+
+    Mirrors ``ChatBedrockConverse``'s inline field pattern and adds
+    ``bedrock_api_key_ttl_seconds`` for configurable auto-refresh TTL.
+    """
+
+    # ── Defaults ───────────────────────────────────────────────
+
+    def test_default_ttl_is_12h(self) -> None:
+        assert _make_llm().bedrock_api_key_ttl_seconds == 43200
+
+    def test_custom_ttl_field(self) -> None:
+        llm = _make_llm(bedrock_api_key_ttl_seconds=3600)
+        assert llm.bedrock_api_key_ttl_seconds == 3600
+
+    def test_creds_default_to_none_when_no_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _clear_aws_env(monkeypatch)
+        llm = _make_llm()
+        assert llm.aws_access_key_id is None
+        assert llm.aws_secret_access_key is None
+        assert llm.aws_session_token is None
+        assert llm.credentials_profile_name is None
+
+    def test_creds_pick_up_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _clear_aws_env(monkeypatch)
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIA-env")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secret-env")
+        monkeypatch.setenv("AWS_SESSION_TOKEN", "token-env")
+        llm = _make_llm()
+        assert llm.aws_access_key_id is not None
+        assert llm.aws_access_key_id.get_secret_value() == "AKIA-env"
+        assert llm.aws_secret_access_key is not None
+        assert llm.aws_secret_access_key.get_secret_value() == "secret-env"
+        assert llm.aws_session_token is not None
+        assert llm.aws_session_token.get_secret_value() == "token-env"
+
+    # ── Validation ─────────────────────────────────────────────
+
+    def test_paired_creds_only_access_key_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _clear_aws_env(monkeypatch)
+        with pytest.raises(ValueError, match="both be provided"):
+            _make_llm(aws_access_key_id=SecretStr("AKIA..."))
+
+    def test_paired_creds_only_secret_key_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _clear_aws_env(monkeypatch)
+        with pytest.raises(ValueError, match="both be provided"):
+            _make_llm(aws_secret_access_key=SecretStr("secret..."))
+
+    def test_paired_creds_both_ok(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _clear_aws_env(monkeypatch)
+        llm = _make_llm(
+            aws_access_key_id=SecretStr("AKIA..."),
+            aws_secret_access_key=SecretStr("secret..."),
+        )
+        assert llm.aws_access_key_id is not None
+        assert llm.aws_secret_access_key is not None
+
+    @pytest.mark.parametrize("bad_ttl", [0, -1, -43200, 43201, 86400])
+    def test_ttl_out_of_range_rejected(self, bad_ttl: int) -> None:
+        with pytest.raises(ValueError, match="between 1 and 43200"):
+            _make_llm(bedrock_api_key_ttl_seconds=bad_ttl)
+
+    @pytest.mark.parametrize("good_ttl", [1, 60, 3600, 43200])
+    def test_ttl_in_range_accepted(self, good_ttl: int) -> None:
+        llm = _make_llm(bedrock_api_key_ttl_seconds=good_ttl)
+        assert llm.bedrock_api_key_ttl_seconds == good_ttl
+
+    # ── Propagation to _BedrockApiKeyProvider ──────────────────
+
+    def test_explicit_creds_propagate_to_provider(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Field values propagate through _validate_environment into the
+        provider's internal state."""
+        _clear_aws_env(monkeypatch)
+        # Force auto-refresh path (no static api_key).
+        ChatBedrockMantle(
+            model="test",
+            region_name="us-east-1",
+            aws_access_key_id=SecretStr("AKIA-explicit"),
+            aws_secret_access_key=SecretStr("secret-explicit"),
+            aws_session_token=SecretStr("session-explicit"),
+        )
+        # openai.OpenAI is a MagicMock; retrieve api_key from last call kwargs.
+        openai_ctor = sys.modules["openai"].OpenAI
+        provider = openai_ctor.call_args.kwargs["api_key"]
+        assert isinstance(provider, _BedrockApiKeyProvider)
+        assert provider._aws_access_key_id == "AKIA-explicit"
+        assert provider._aws_secret_access_key == "secret-explicit"
+        assert provider._aws_session_token == "session-explicit"
+
+    def test_profile_name_propagates_to_provider(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _clear_aws_env(monkeypatch)
+        ChatBedrockMantle(
+            model="test",
+            region_name="us-east-1",
+            credentials_profile_name="my-profile",
+        )
+        openai_ctor = sys.modules["openai"].OpenAI
+        provider = openai_ctor.call_args.kwargs["api_key"]
+        assert isinstance(provider, _BedrockApiKeyProvider)
+        assert provider._credentials_profile_name == "my-profile"
+
+    def test_custom_ttl_propagates_to_provider(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _clear_aws_env(monkeypatch)
+        ChatBedrockMantle(
+            model="test",
+            region_name="us-east-1",
+            bedrock_api_key_ttl_seconds=1800,
+        )
+        openai_ctor = sys.modules["openai"].OpenAI
+        provider = openai_ctor.call_args.kwargs["api_key"]
+        assert isinstance(provider, _BedrockApiKeyProvider)
+        assert provider._ttl_seconds == 1800
+
+    def test_default_ttl_propagates_to_provider(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _clear_aws_env(monkeypatch)
+        ChatBedrockMantle(model="test", region_name="us-east-1")
+        openai_ctor = sys.modules["openai"].OpenAI
+        provider = openai_ctor.call_args.kwargs["api_key"]
+        assert isinstance(provider, _BedrockApiKeyProvider)
+        assert provider._ttl_seconds == 43200
+
+    def test_static_api_key_bypasses_provider(self) -> None:
+        """When ``bedrock_api_key`` is set, no _BedrockApiKeyProvider is built."""
+        llm = _make_llm(api_key=SecretStr("static-key"))
+        openai_ctor = sys.modules["openai"].OpenAI
+        provider = openai_ctor.call_args.kwargs["api_key"]
+        # Should be the raw string, not a provider.
+        assert provider == "static-key"
+        assert llm.bedrock_api_key is not None
+
+
+class TestBedrockApiKeyProviderCredentialResolution:
+    """Verify _do_refresh picks up explicit creds / profile / default chain
+    with the correct precedence and passes them to provide_token.
+    """
+
+    def _patch_provide_token(self, monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+        """Patch provide_token in the utils module; return the mock."""
+        mock_pt = MagicMock(return_value="bedrock-api-key-fake&Version=1")
+        # Provide a mock module for aws_bedrock_token_generator
+        mock_mod = MagicMock()
+        mock_mod.provide_token = mock_pt
+        monkeypatch.setitem(
+            __import__("sys").modules, "aws_bedrock_token_generator", mock_mod
+        )
+        return mock_pt
+
+    def test_explicit_creds_used_by_provide_token(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Explicit access_key + secret_key + session_token produce a
+        credential provider whose .load() returns matching Credentials."""
+        from botocore.credentials import Credentials
+
+        from langchain_aws.utils import _BedrockApiKeyProvider
+
+        mock_pt = self._patch_provide_token(monkeypatch)
+
+        p = _BedrockApiKeyProvider(
+            "us-east-1",
+            aws_access_key_id="AKIA-abc",
+            aws_secret_access_key="secret-def",
+            aws_session_token="session-ghi",
+        )
+        p._do_refresh()
+
+        assert mock_pt.called
+        call_kwargs = mock_pt.call_args[1]
+        assert call_kwargs["region"] == "us-east-1"
+        provider_arg = call_kwargs["aws_credentials_provider"]
+        assert provider_arg is not None
+        loaded = provider_arg.load()
+        assert isinstance(loaded, Credentials)
+        assert loaded.access_key == "AKIA-abc"
+        assert loaded.secret_key == "secret-def"
+        assert loaded.token == "session-ghi"
+
+    def test_no_explicit_creds_uses_default_chain(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No explicit creds & no profile → default botocore chain."""
+        from langchain_aws.utils import _BedrockApiKeyProvider
+
+        mock_pt = self._patch_provide_token(monkeypatch)
+
+        # Mock botocore session to return a benign Credentials-like object.
+        from botocore.credentials import Credentials
+
+        default_creds = Credentials(
+            access_key="default-key",
+            secret_key="default-secret",
+            token=None,
+        )
+        mock_session = MagicMock()
+        mock_session.get_credentials.return_value = default_creds
+
+        with patch("botocore.session.Session", return_value=mock_session):
+            p = _BedrockApiKeyProvider("us-east-1")
+            p._do_refresh()
+
+        provider_arg = mock_pt.call_args[1]["aws_credentials_provider"]
+        assert provider_arg is not None
+        loaded = provider_arg.load()
+        assert loaded.access_key == "default-key"
+
+    def test_profile_only_uses_profile_session(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Only credentials_profile_name set → BotocoreSession(profile=...)."""
+        from botocore.credentials import Credentials
+
+        from langchain_aws.utils import _BedrockApiKeyProvider
+
+        mock_pt = self._patch_provide_token(monkeypatch)
+
+        profile_creds = Credentials(
+            access_key="profile-key",
+            secret_key="profile-secret",
+            token=None,
+        )
+        mock_session = MagicMock()
+        mock_session.get_credentials.return_value = profile_creds
+        session_cls = MagicMock(return_value=mock_session)
+
+        with patch("botocore.session.Session", session_cls):
+            p = _BedrockApiKeyProvider(
+                "us-east-1",
+                credentials_profile_name="foo-profile",
+            )
+            p._do_refresh()
+
+        # Session was constructed with the profile kwarg (not the default).
+        session_cls.assert_called_once_with(profile="foo-profile")
+        loaded = mock_pt.call_args[1]["aws_credentials_provider"].load()
+        assert loaded.access_key == "profile-key"
+
+    def test_session_failure_falls_back_to_provide_token_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When BotocoreSession raises, aws_credentials_provider=None so
+        provide_token uses its own internal default resolution."""
+        from langchain_aws.utils import _BedrockApiKeyProvider
+
+        mock_pt = self._patch_provide_token(monkeypatch)
+
+        # Session construction raises (e.g., malformed ~/.aws/config).
+        session_cls = MagicMock(side_effect=OSError("profile not found"))
+
+        with patch("botocore.session.Session", session_cls):
+            p = _BedrockApiKeyProvider(
+                "us-east-1", credentials_profile_name="missing-profile"
+            )
+            p._do_refresh()
+
+        # provide_token still called, but with aws_credentials_provider=None.
+        assert mock_pt.called
+        assert mock_pt.call_args[1]["aws_credentials_provider"] is None
+
+    def test_explicit_wins_over_profile(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When BOTH explicit creds AND profile are set, explicit wins."""
+        from botocore.credentials import Credentials
+
+        from langchain_aws.utils import _BedrockApiKeyProvider
+
+        mock_pt = self._patch_provide_token(monkeypatch)
+
+        p = _BedrockApiKeyProvider(
+            "us-east-1",
+            aws_access_key_id="EXPLICIT-key",
+            aws_secret_access_key="EXPLICIT-secret",
+            credentials_profile_name="some-profile",
+        )
+        p._do_refresh()
+
+        loaded = mock_pt.call_args[1]["aws_credentials_provider"].load()
+        assert isinstance(loaded, Credentials)
+        assert loaded.access_key == "EXPLICIT-key"
+
+    def test_custom_ttl_used_in_provide_token_call(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """ttl_seconds propagates into the expiry= arg of provide_token."""
+        import datetime as _dt
+
+        from langchain_aws.utils import _BedrockApiKeyProvider
+
+        mock_pt = self._patch_provide_token(monkeypatch)
+
+        p = _BedrockApiKeyProvider(
+            "us-east-1",
+            ttl_seconds=1800,
+            aws_access_key_id="AKIA-x",
+            aws_secret_access_key="secret-x",
+        )
+        p._do_refresh()
+
+        expiry_arg = mock_pt.call_args[1]["expiry"]
+        assert isinstance(expiry_arg, _dt.timedelta)
+        assert expiry_arg.total_seconds() == 1800
+
+    def test_ttl_capped_by_refreshable_credentials(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When default-chain creds are RefreshableCredentials with less
+        remaining lifetime than ttl_seconds, effective TTL is capped."""
+        import datetime as _dt
+
+        from botocore.credentials import RefreshableCredentials
+
+        from langchain_aws.utils import _BedrockApiKeyProvider
+
+        mock_pt = self._patch_provide_token(monkeypatch)
+
+        # RefreshableCredentials with 900s remaining, TTL request 12h.
+        mock_refreshable = MagicMock(spec=RefreshableCredentials)
+        mock_refreshable._seconds_remaining.return_value = 900
+        mock_session = MagicMock()
+        mock_session.get_credentials.return_value = mock_refreshable
+
+        with patch("botocore.session.Session", return_value=mock_session):
+            p = _BedrockApiKeyProvider("us-east-1", ttl_seconds=43200)
+            p._do_refresh()
+
+        expiry_arg = mock_pt.call_args[1]["expiry"]
+        assert isinstance(expiry_arg, _dt.timedelta)
+        assert expiry_arg.total_seconds() == 900
 
 
 # ── _build_params ───────────────────────────────────────────────────
@@ -429,28 +1236,55 @@ class TestErrorHandling:
             setattr(mock_mod, name, cls)
         return mock_mod
 
-    def test_authentication_error(self) -> None:
+    def test_authentication_error_reraised(self) -> None:
+        """AuthenticationError is re-raised unchanged (not wrapped)."""
         mock_mod = self._make_mock_openai()
         error = mock_mod.AuthenticationError("invalid key")
         with patch.dict(__import__("sys").modules, {"openai": mock_mod}):
-            with pytest.raises(ValueError, match="authentication failed"):
+            with pytest.raises(mock_mod.AuthenticationError, match="invalid key"):
                 _handle_openai_error(error)
 
-    def test_rate_limit_error(self) -> None:
+    def test_berm_error_logs_hint_and_reraises(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A 401 with 'Berm is not enabled' logs a routing hint and re-raises.
+
+        Mantle returns this string when a model that requires the
+        ``/openai/v1`` base path is called on ``/v1`` (e.g. gpt-5.x,
+        gemma-4-*, grok-4.3). The exception type is preserved so callers
+        can still ``except openai.AuthenticationError``; the hint is
+        emitted as a WARNING for discoverability.
+        """
+        mock_mod = self._make_mock_openai()
+        error = mock_mod.AuthenticationError("Berm is not enabled for this account")
+        with patch.dict(__import__("sys").modules, {"openai": mock_mod}):
+            with caplog.at_level(
+                "WARNING", logger="langchain_aws.chat_models.bedrock_mantle"
+            ):
+                with pytest.raises(mock_mod.AuthenticationError, match="Berm"):
+                    _handle_openai_error(error)
+        assert any(
+            "'/openai/v1' base path" in rec.getMessage() for rec in caplog.records
+        ), f"Expected /openai/v1 hint in log records, got: {caplog.records!r}"
+
+    def test_rate_limit_error_reraised(self) -> None:
+        """RateLimitError is re-raised unchanged (not wrapped)."""
         mock_mod = self._make_mock_openai()
         error = mock_mod.RateLimitError("rate limited")
         with patch.dict(__import__("sys").modules, {"openai": mock_mod}):
-            with pytest.raises(ValueError, match="rate limit"):
+            with pytest.raises(mock_mod.RateLimitError, match="rate limited"):
                 _handle_openai_error(error)
 
-    def test_not_found_error(self) -> None:
+    def test_not_found_error_reraised(self) -> None:
+        """NotFoundError is re-raised unchanged (not wrapped)."""
         mock_mod = self._make_mock_openai()
         error = mock_mod.NotFoundError("model not found")
         with patch.dict(__import__("sys").modules, {"openai": mock_mod}):
-            with pytest.raises(ValueError, match="model not found"):
+            with pytest.raises(mock_mod.NotFoundError, match="model not found"):
                 _handle_openai_error(error)
 
     def test_bad_request_tool_choice(self) -> None:
+        """BadRequestError with tool_choice context is wrapped in ValueError."""
         mock_mod = self._make_mock_openai()
         error = mock_mod.BadRequestError("Invalid 'tool_choice': value did not match")
         with patch.dict(__import__("sys").modules, {"openai": mock_mod}):
@@ -458,6 +1292,7 @@ class TestErrorHandling:
                 _handle_openai_error(error)
 
     def test_bad_request_not_supported(self) -> None:
+        """BadRequestError with 'does not support' is wrapped in ValueError."""
         mock_mod = self._make_mock_openai()
         error = mock_mod.BadRequestError("model does not support /v1/responses")
         with patch.dict(__import__("sys").modules, {"openai": mock_mod}):
@@ -465,17 +1300,21 @@ class TestErrorHandling:
                 _handle_openai_error(error)
 
     def test_unknown_error_reraised(self) -> None:
+        """Non-OpenAI errors are re-raised unchanged."""
         mock_mod = self._make_mock_openai()
         error = RuntimeError("something else")
         with patch.dict(__import__("sys").modules, {"openai": mock_mod}):
             with pytest.raises(RuntimeError, match="something else"):
                 _handle_openai_error(error)
 
-    def test_bad_request_generic(self) -> None:
+    def test_bad_request_generic_reraised(self) -> None:
+        """Generic BadRequestError is re-raised unchanged (not wrapped)."""
         mock_mod = self._make_mock_openai()
         error = mock_mod.BadRequestError("some other bad request")
         with patch.dict(__import__("sys").modules, {"openai": mock_mod}):
-            with pytest.raises(ValueError, match="bad request"):
+            with pytest.raises(
+                mock_mod.BadRequestError, match="some other bad request"
+            ):
                 _handle_openai_error(error)
 
 
@@ -562,7 +1401,9 @@ class TestResponsesApiStreaming:
             self._make_text_delta_event("lo"),
             self._make_completed_event(),
         ]
-        llm._sync_client.responses.create = MagicMock(return_value=iter(events))
+        llm._sync_client.responses.create = MagicMock(
+            return_value=_MockSyncStream(events)
+        )
 
         chunks = list(llm._stream([HumanMessage(content="hi")]))
         text = "".join(
@@ -578,7 +1419,9 @@ class TestResponsesApiStreaming:
             self._make_text_delta_event("ok"),
             self._make_completed_event(),
         ]
-        llm._sync_client.responses.create = MagicMock(return_value=iter(events))
+        llm._sync_client.responses.create = MagicMock(
+            return_value=_MockSyncStream(events)
+        )
 
         chunks = list(llm._stream([HumanMessage(content="hi")]))
         last = chunks[-1]
@@ -596,7 +1439,9 @@ class TestResponsesApiStreaming:
             self._make_text_delta_event("hi"),
             self._make_completed_event(),
         ]
-        llm._sync_client.responses.create = MagicMock(return_value=iter(events))
+        llm._sync_client.responses.create = MagicMock(
+            return_value=_MockSyncStream(events)
+        )
 
         chunks = list(llm._stream([HumanMessage(content="hi")]))
         text = "".join(
@@ -616,12 +1461,8 @@ class TestResponsesApiStreaming:
             self._make_completed_event(),
         ]
 
-        async def _async_iter():  # type: ignore[no-untyped-def]
-            for e in events:
-                yield e
-
-        async def _mock_create(**kwargs):  # type: ignore[no-untyped-def]
-            return _async_iter()
+        async def _mock_create(**kwargs: object) -> _MockAsyncStream:
+            return _MockAsyncStream(events)
 
         llm._async_client.responses.create = _mock_create
 
@@ -635,6 +1476,136 @@ class TestResponsesApiStreaming:
             if isinstance(c.message.content, str) and c.message.content
         )
         assert text == "async stream"
+
+    def test_stream_responses_closes_context_manager(self) -> None:
+        """``_stream_responses`` must consume the SDK stream via ``with``.
+
+        The mock helpers implement both ``__iter__`` and ``__enter__``, so
+        naive iteration would silently pass even if the production code
+        stopped using ``with``. A tracking subclass surfaces that
+        regression by asserting ``__enter__`` / ``__exit__`` actually
+        fire — both on happy-path exhaustion and on early exit.
+
+        Tests ``_stream_responses`` directly (rather than the ``_stream``
+        router) so ``generator.close()`` propagates synchronously through
+        the ``async with`` we care about.
+        """
+
+        class _TrackingSyncStream(_MockSyncStream):
+            entered: bool = False
+            exited: bool = False
+
+            def __enter__(self) -> "_TrackingSyncStream":
+                type(self).entered = True
+                return self
+
+            def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+                type(self).exited = True
+
+        events = [
+            self._make_text_delta_event("ok"),
+            self._make_completed_event(),
+        ]
+        llm = _make_llm()
+        params = llm._build_params(stream=True)
+
+        # Happy path: exhaust the iterator.
+        _TrackingSyncStream.entered = False
+        _TrackingSyncStream.exited = False
+        llm._sync_client.responses.create = MagicMock(
+            return_value=_TrackingSyncStream(events)
+        )
+        list(llm._stream_responses([HumanMessage(content="hi")], params))
+        assert _TrackingSyncStream.entered, "expected __enter__ on happy path"
+        assert _TrackingSyncStream.exited, "expected __exit__ on happy path"
+
+        # Early exit: break, then close the generator explicitly. Python's
+        # generator + ``break`` alone defers cleanup to GC; well-behaved
+        # consumers close the generator to signal early termination.
+        _TrackingSyncStream.entered = False
+        _TrackingSyncStream.exited = False
+        llm._sync_client.responses.create = MagicMock(
+            return_value=_TrackingSyncStream(events)
+        )
+        gen = cast(
+            Generator[ChatGenerationChunk, None, None],
+            llm._stream_responses([HumanMessage(content="hi")], params),
+        )
+        for _ in gen:
+            break
+        gen.close()
+        assert _TrackingSyncStream.entered, "expected __enter__ on early exit"
+        assert _TrackingSyncStream.exited, "expected __exit__ on early exit"
+
+    def test_astream_responses_closes_context_manager(self) -> None:
+        """Async counterpart of ``test_stream_responses_closes_context_manager``.
+
+        Verifies that ``_astream_responses`` consumes the SDK stream via
+        ``async with``, firing ``__aenter__`` / ``__aexit__`` on both
+        happy-path exhaustion and early exit + ``aclose()``.
+
+        Targets ``_astream_responses`` directly rather than the
+        ``_astream`` router. Calling ``aclose()`` on an outer async
+        generator that wraps an inner one defers the inner ``__aexit__``
+        to garbage collection via ``CancelledError`` propagation, which
+        cannot be observed synchronously. Testing the inner method
+        directly makes cleanup synchronous.
+        """
+        import asyncio
+
+        class _TrackingAsyncStream(_MockAsyncStream):
+            entered: bool = False
+            exited: bool = False
+
+            async def __aenter__(self) -> "_TrackingAsyncStream":
+                type(self).entered = True
+                return self
+
+            async def __aexit__(
+                self, exc_type: object, exc: object, tb: object
+            ) -> None:
+                type(self).exited = True
+
+        events = [
+            self._make_text_delta_event("ok"),
+            self._make_completed_event(),
+        ]
+        llm = _make_llm()
+        params = llm._build_params(stream=True)
+
+        async def _run_full() -> None:
+            _TrackingAsyncStream.entered = False
+            _TrackingAsyncStream.exited = False
+
+            async def _mock_create(**kwargs: object) -> _TrackingAsyncStream:
+                return _TrackingAsyncStream(events)
+
+            llm._async_client.responses.create = _mock_create
+            async for _ in llm._astream_responses([HumanMessage(content="hi")], params):
+                pass
+            assert _TrackingAsyncStream.entered, "expected __aenter__ on happy path"
+            assert _TrackingAsyncStream.exited, "expected __aexit__ on happy path"
+
+        async def _run_early_break() -> None:
+            _TrackingAsyncStream.entered = False
+            _TrackingAsyncStream.exited = False
+
+            async def _mock_create(**kwargs: object) -> _TrackingAsyncStream:
+                return _TrackingAsyncStream(events)
+
+            llm._async_client.responses.create = _mock_create
+            gen = cast(
+                AsyncGenerator[ChatGenerationChunk, None],
+                llm._astream_responses([HumanMessage(content="hi")], params),
+            )
+            async for _ in gen:
+                break
+            await gen.aclose()
+            assert _TrackingAsyncStream.entered, "expected __aenter__ on early exit"
+            assert _TrackingAsyncStream.exited, "expected __aexit__ on early exit"
+
+        asyncio.run(_run_full())
+        asyncio.run(_run_early_break())
 
 
 # ── Tool format conversion ──────────────────────────────────────────
@@ -720,7 +1691,9 @@ class TestResponseIdOnMessage:
         completed.response.usage.output_tokens = 3
         completed.response.usage.total_tokens = 8
 
-        llm._sync_client.responses.create = MagicMock(return_value=iter([completed]))
+        llm._sync_client.responses.create = MagicMock(
+            return_value=_MockSyncStream([completed])
+        )
 
         chunks = list(llm._stream([HumanMessage(content="hi")]))
         assert chunks[-1].message.id == "resp_stream_456"
@@ -761,7 +1734,7 @@ class TestStreamingToolCalls:
         completed.response.usage.total_tokens = 15
 
         llm._sync_client.responses.create = MagicMock(
-            return_value=iter([added, delta, delta2, completed])
+            return_value=_MockSyncStream([added, delta, delta2, completed])
         )
 
         chunks = list(llm._stream([HumanMessage(content="weather?")]))
@@ -800,6 +1773,141 @@ class TestStreamUsage:
         params = _make_llm(stream_usage=False)._build_params(stream=True)
         assert "stream_options" not in params
 
+    def test_chat_completions_final_usage_only_chunk_surfaced(self) -> None:
+        """OpenAI ``include_usage=True`` emits a terminal chunk with
+        ``choices=[]`` and populated ``usage``. That chunk must reach the
+        caller as an ``AIMessageChunk`` carrying ``usage_metadata`` — the
+        previous implementation dropped it via an early ``not chunk.choices``
+        return and silently lost token counts on every Chat Completions
+        stream.
+        """
+        llm = _make_llm(use_responses_api=False)
+
+        content_chunk = MagicMock()
+        content_chunk.id = "chatcmpl-abc"
+        content_chunk.model = "test-model"
+        content_chunk.choices = [MagicMock()]
+        content_chunk.choices[0].delta.content = "Hi"
+        content_chunk.choices[0].delta.tool_calls = None
+        content_chunk.choices[0].finish_reason = "stop"
+        content_chunk.usage = None
+
+        usage_chunk = MagicMock()
+        usage_chunk.id = "chatcmpl-abc"
+        usage_chunk.model = "test-model"
+        usage_chunk.choices = []
+        usage_chunk.usage = MagicMock()
+        usage_chunk.usage.prompt_tokens = 15
+        usage_chunk.usage.completion_tokens = 12
+        usage_chunk.usage.total_tokens = 27
+
+        llm._sync_client.chat.completions.create = MagicMock(
+            return_value=_MockSyncStream([content_chunk, usage_chunk])
+        )
+
+        chunks = list(llm._stream([HumanMessage(content="hi")]))
+        last = chunks[-1]
+        assert isinstance(last.message, AIMessageChunk)
+        assert last.message.usage_metadata is not None
+        assert last.message.usage_metadata["input_tokens"] == 15
+        assert last.message.usage_metadata["output_tokens"] == 12
+        assert last.message.usage_metadata["total_tokens"] == 27
+
+    @staticmethod
+    def _make_cc_delta(
+        content: Optional[str] = None,
+        finish_reason: Optional[str] = None,
+        tool_calls: Optional[list] = None,
+    ) -> MagicMock:
+        """Build a mock ChatCompletionChunk with a single delta choice."""
+        chunk = MagicMock()
+        chunk.choices = [MagicMock()]
+        chunk.choices[0].delta.content = content
+        chunk.choices[0].delta.tool_calls = tool_calls
+        chunk.choices[0].finish_reason = finish_reason
+        chunk.usage = None
+        return chunk
+
+    def test_chat_completions_stream_text_accumulates(self) -> None:
+        """Multiple content deltas are each surfaced as AIMessageChunks; the
+        caller can concatenate them to reconstruct the full text.
+        """
+        llm = _make_llm(use_responses_api=False)
+        chunks_in = [
+            self._make_cc_delta(content="Hel"),
+            self._make_cc_delta(content="lo"),
+            self._make_cc_delta(content="", finish_reason="stop"),
+        ]
+        llm._sync_client.chat.completions.create = MagicMock(
+            return_value=_MockSyncStream(chunks_in)
+        )
+
+        chunks = list(llm._stream([HumanMessage(content="hi")]))
+        text = "".join(
+            c.message.content for c in chunks if isinstance(c.message.content, str)
+        )
+        assert text == "Hello"
+
+    def test_chat_completions_stream_finish_reason_surfaced(self) -> None:
+        """``finish_reason`` on the terminating chunk lands in
+        ``response_metadata``.
+        """
+        llm = _make_llm(use_responses_api=False)
+        chunks_in = [self._make_cc_delta(content="done", finish_reason="stop")]
+        llm._sync_client.chat.completions.create = MagicMock(
+            return_value=_MockSyncStream(chunks_in)
+        )
+
+        chunks = list(llm._stream([HumanMessage(content="hi")]))
+        assert chunks[-1].message.response_metadata.get("finish_reason") == "stop"
+
+    def test_chat_completions_stream_tool_call_chunks(self) -> None:
+        """Streaming tool_calls emit tool_call_chunks with the fields the
+        SDK provides on each incremental delta (name on the first chunk,
+        args on subsequent chunks, shared index).
+        """
+        llm = _make_llm(use_responses_api=False)
+
+        def _tc(
+            name: Optional[str],
+            args: Optional[str],
+            id_: Optional[str],
+        ) -> MagicMock:
+            tc = MagicMock()
+            tc.function = MagicMock()
+            tc.function.name = name
+            tc.function.arguments = args
+            tc.id = id_
+            tc.index = 0
+            return tc
+
+        chunks_in = [
+            self._make_cc_delta(tool_calls=[_tc("get_weather", "", "call_1")]),
+            self._make_cc_delta(tool_calls=[_tc(None, '{"location":', None)]),
+            self._make_cc_delta(tool_calls=[_tc(None, '"Seattle"}', None)]),
+        ]
+        llm._sync_client.chat.completions.create = MagicMock(
+            return_value=_MockSyncStream(chunks_in)
+        )
+
+        chunks = list(llm._stream([HumanMessage(content="weather?")]))
+        # Runtime types are AIMessageChunk; narrow so mypy sees .tool_call_chunks.
+        first_msg = chunks[0].message
+        second_msg = chunks[1].message
+        third_msg = chunks[2].message
+        assert isinstance(first_msg, AIMessageChunk)
+        assert isinstance(second_msg, AIMessageChunk)
+        assert isinstance(third_msg, AIMessageChunk)
+        # First chunk carries the name and id.
+        first_tc_chunks = first_msg.tool_call_chunks
+        assert len(first_tc_chunks) == 1
+        assert first_tc_chunks[0]["name"] == "get_weather"
+        assert first_tc_chunks[0]["id"] == "call_1"
+        assert first_tc_chunks[0]["index"] == 0
+        # Subsequent chunks carry args deltas at the same index.
+        assert second_msg.tool_call_chunks[0]["args"] == '{"location":'
+        assert third_msg.tool_call_chunks[0]["args"] == '"Seattle"}'
+
 
 # ── use_previous_response_id ────────────────────────────────────────
 
@@ -812,7 +1920,12 @@ class TestUsePreviousResponseId:
 
         messages = [
             HumanMessage(content="Hello"),
-            AIMessage(content="Hi!", id="resp_first_123"),
+            # Mirrors the shape produced by ``_build_responses_result`` — the
+            # response id lives in ``response_metadata["id"]``.
+            AIMessage(
+                content="Hi!",
+                response_metadata={"id": "resp_first_123"},
+            ),
             HumanMessage(content="How are you?"),
         ]
         result = llm._generate(messages)
@@ -845,27 +1958,37 @@ class TestUsePreviousResponseId:
 
 
 class TestToolChoiceValidation:
-    def test_auto_passes_without_warning(self) -> None:
+    def test_auto_passes_through(self) -> None:
         llm = _make_llm()
         params = llm._build_params(stream=False, tool_choice="auto")
-        with patch("langchain_aws.chat_models.bedrock_mantle.logger") as mock_log:
-            llm._prepare_responses_params(params)
-            mock_log.warning.assert_not_called()
+        resp_params = llm._prepare_responses_params(params)
+        assert resp_params["tool_choice"] == "auto"
 
-    def test_none_passes_without_warning(self) -> None:
+    def test_none_passes_through(self) -> None:
         llm = _make_llm()
         params = llm._build_params(stream=False, tool_choice="none")
-        with patch("langchain_aws.chat_models.bedrock_mantle.logger") as mock_log:
-            llm._prepare_responses_params(params)
-            mock_log.warning.assert_not_called()
+        resp_params = llm._prepare_responses_params(params)
+        assert resp_params["tool_choice"] == "none"
 
-    def test_required_logs_warning(self) -> None:
+    def test_required_passes_through(self) -> None:
+        """'required' is a valid Responses API value — no warning."""
         llm = _make_llm()
         params = llm._build_params(stream=False, tool_choice="required")
-        with patch("langchain_aws.chat_models.bedrock_mantle.logger") as mock_log:
-            llm._prepare_responses_params(params)
-            mock_log.warning.assert_called_once()
-            assert "tool_choice" in mock_log.warning.call_args[0][0]
+        resp_params = llm._prepare_responses_params(params)
+        assert resp_params["tool_choice"] == "required"
+
+    def test_dict_format_converted(self) -> None:
+        """Chat Completions dict format is converted to Responses API format."""
+        llm = _make_llm()
+        params = llm._build_params(
+            stream=False,
+            tool_choice={"type": "function", "function": {"name": "get_weather"}},
+        )
+        resp_params = llm._prepare_responses_params(params)
+        assert resp_params["tool_choice"] == {
+            "type": "function",
+            "name": "get_weather",
+        }
 
 
 # ── _use_responses_api routing with text param ──────────────────────
@@ -888,17 +2011,142 @@ class TestRoutingWithTextParam:
         assert llm._use_responses_api(params) is True
 
 
+# ── disabled_params ─────────────────────────────────────────────────
+
+
+class TestDisabledParams:
+    """_filter_disabled_params silently drops params based on config."""
+
+    def test_no_disabled_params(self) -> None:
+        """When disabled_params is None, nothing is filtered."""
+        llm = _make_llm()
+        result = llm._filter_disabled_params(
+            tool_choice="required", parallel_tool_calls=False
+        )
+        assert result == {"tool_choice": "required", "parallel_tool_calls": False}
+
+    def test_drop_param_entirely(self) -> None:
+        """disabled_params={"parallel_tool_calls": None} drops it always."""
+        llm = _make_llm(disabled_params={"parallel_tool_calls": None})
+        result = llm._filter_disabled_params(
+            tool_choice="required", parallel_tool_calls=False
+        )
+        assert result == {"tool_choice": "required"}
+        assert "parallel_tool_calls" not in result
+
+    def test_drop_param_specific_value(self) -> None:
+        """disabled_params={"tool_choice": ["required"]} drops only that value."""
+        llm = _make_llm(disabled_params={"tool_choice": ["required"]})
+
+        # "required" is disabled — should be dropped
+        result = llm._filter_disabled_params(
+            tool_choice="required", parallel_tool_calls=False
+        )
+        assert "tool_choice" not in result
+        assert result["parallel_tool_calls"] is False
+
+        # "auto" is not disabled — should pass through
+        result2 = llm._filter_disabled_params(
+            tool_choice="auto", parallel_tool_calls=False
+        )
+        assert result2["tool_choice"] == "auto"
+
+    def test_structured_output_respects_disabled_params(self) -> None:
+        """with_structured_output drops parallel_tool_calls if disabled."""
+        llm = _make_llm(
+            disabled_params={"parallel_tool_calls": None},
+            use_responses_api=False,
+        )
+
+        mock_choice = MagicMock()
+        mock_choice.message.content = ""
+        mock_choice.message.tool_calls = [MagicMock()]
+        mock_choice.message.tool_calls[0].function.name = "Person"
+        mock_choice.message.tool_calls[
+            0
+        ].function.arguments = '{"name": "Alice", "age": 30}'
+        mock_choice.message.tool_calls[0].id = "call_1"
+        mock_choice.finish_reason = "tool_calls"
+        mock_resp = MagicMock()
+        mock_resp.choices = [mock_choice]
+        mock_resp.usage = None
+        mock_resp.model = "test"
+        mock_resp.id = "chatcmpl_dp1"
+        llm._sync_client.chat.completions.create = MagicMock(return_value=mock_resp)
+
+        from pydantic import BaseModel
+
+        class Person(BaseModel):
+            name: str
+            age: int
+
+        structured = llm.with_structured_output(Person, method="function_calling")
+        structured.invoke("Give me a person")
+
+        # Verify parallel_tool_calls was NOT passed to the API
+        call_kwargs = llm._sync_client.chat.completions.create.call_args[1]
+        assert "parallel_tool_calls" not in call_kwargs
+
+
 # ── with_structured_output json_schema ──────────────────────────────
 
 
 class TestWithStructuredOutputJsonSchema:
-    """with_structured_output(method='json_schema') must bind the text param
-    so the Responses API receives the json_schema format."""
+    """with_structured_output(method='json_schema') binds response_format.
 
-    def test_json_schema_binds_text_param(self) -> None:
+    ``response_format`` is a Chat-Completions-only key so requests route to
+    Chat Completions by default. If the request also has Responses-API-only
+    keys, ``_prepare_responses_params`` remaps ``response_format`` to
+    ``text``.
+    """
+
+    def test_json_schema_routes_to_chat_completions(self) -> None:
+        """Default: response_format routes to Chat Completions."""
         llm = _make_llm()
+
+        mock_choice = MagicMock()
+        mock_choice.message.content = '{"name": "Alice", "age": 30}'
+        mock_choice.message.tool_calls = None
+        mock_choice.finish_reason = "stop"
+        mock_resp = MagicMock()
+        mock_resp.choices = [mock_choice]
+        mock_resp.usage = None
+        mock_resp.model = "test"
+        mock_resp.id = "chatcmpl_js1"
+        llm._sync_client.chat.completions.create = MagicMock(return_value=mock_resp)
+        llm._sync_client.responses.create = MagicMock(
+            side_effect=AssertionError("should not call Responses API")
+        )
+
+        schema = {
+            "type": "object",
+            "title": "Person",
+            "properties": {
+                "name": {"type": "string"},
+                "age": {"type": "integer"},
+            },
+            "required": ["name", "age"],
+        }
+        structured = llm.with_structured_output(schema, method="json_schema")
+        result = structured.invoke("Give me a person")
+
+        # Verify response_format was passed to Chat Completions
+        call_kwargs = llm._sync_client.chat.completions.create.call_args[1]
+        assert "response_format" in call_kwargs
+        rf = call_kwargs["response_format"]
+        assert rf["type"] == "json_schema"
+        assert rf["json_schema"]["name"] == "Person"
+        assert rf["json_schema"]["strict"] is True
+        assert "text" not in call_kwargs
+
+        # Verify the output was parsed
+        assert result == {"name": "Alice", "age": 30}
+
+    def test_json_schema_remapped_when_forced_to_responses_api(self) -> None:
+        """When use_responses_api=True, response_format is remapped to text."""
+        llm = _make_llm(use_responses_api=True)
         mock_resp = _mock_responses_response(
-            text='{"name": "Alice", "age": 30}', resp_id="resp_js1"
+            text='{"name": "Bob", "age": 25}', resp_id="resp_js2"
         )
         llm._sync_client.responses.create = MagicMock(return_value=mock_resp)
 
@@ -912,15 +2160,47 @@ class TestWithStructuredOutputJsonSchema:
             "required": ["name", "age"],
         }
         structured = llm.with_structured_output(schema, method="json_schema")
+        result = structured.invoke("Give me a person")
 
-        # Invoke to trigger the bound params
-        structured.invoke("Give me a person")
-
-        # Verify the text param was passed to the Responses API
+        # Verify response_format was remapped to text for Responses API
         call_kwargs = llm._sync_client.responses.create.call_args[1]
         assert "text" in call_kwargs
         text_format = call_kwargs["text"]["format"]
         assert text_format["type"] == "json_schema"
         assert text_format["name"] == "Person"
-        assert text_format["schema"] == schema
         assert text_format["strict"] is True
+        assert "response_format" not in call_kwargs
+
+        # Verify the output was parsed
+        assert result == {"name": "Bob", "age": 25}
+
+    def test_json_schema_with_explicit_false(self) -> None:
+        """use_responses_api=False also routes to Chat Completions."""
+        llm = _make_llm(use_responses_api=False)
+
+        mock_choice = MagicMock()
+        mock_choice.message.content = '{"name": "Carol", "age": 40}'
+        mock_choice.message.tool_calls = None
+        mock_choice.finish_reason = "stop"
+        mock_resp = MagicMock()
+        mock_resp.choices = [mock_choice]
+        mock_resp.usage = None
+        mock_resp.model = "test"
+        mock_resp.id = "chatcmpl_js3"
+        llm._sync_client.chat.completions.create = MagicMock(return_value=mock_resp)
+
+        schema = {
+            "type": "object",
+            "title": "Person",
+            "properties": {
+                "name": {"type": "string"},
+                "age": {"type": "integer"},
+            },
+            "required": ["name", "age"],
+        }
+        structured = llm.with_structured_output(schema, method="json_schema")
+        result = structured.invoke("Give me a person")
+
+        call_kwargs = llm._sync_client.chat.completions.create.call_args[1]
+        assert "response_format" in call_kwargs
+        assert result == {"name": "Carol", "age": 40}

--- a/libs/aws/tests/unit_tests/test_standard.py
+++ b/libs/aws/tests/unit_tests/test_standard.py
@@ -1,6 +1,8 @@
 """Standard LangChain interface tests"""
 
+import sys
 from typing import Dict, Tuple, Type
+from unittest.mock import MagicMock
 
 from langchain_core.language_models import BaseChatModel
 from langchain_tests.unit_tests import ChatModelUnitTests
@@ -95,4 +97,47 @@ class TestBedrockAsConverseStandard(ChatModelUnitTests):
                 "aws_secret_access_key": "secret_key",
                 "aws_session_token": "token",
             },
+        )
+
+
+# Mock openai and aws_bedrock_token_generator before importing ChatBedrockMantle
+_mock_openai = MagicMock()
+_mock_token_gen = MagicMock()
+_mock_token_gen.provide_token.return_value = "bedrock-api-key-dGVzdA=="
+sys.modules.setdefault("openai", _mock_openai)
+sys.modules.setdefault("aws_bedrock_token_generator", _mock_token_gen)
+
+from langchain_aws.chat_models.bedrock_mantle import ChatBedrockMantle  # noqa: E402
+
+
+class TestBedrockMantleStandard(ChatModelUnitTests):
+    @property
+    def chat_model_class(self) -> Type[BaseChatModel]:
+        return ChatBedrockMantle
+
+    @property
+    def chat_model_params(self) -> dict:
+        return {
+            "model": "openai.gpt-oss-20b",
+            "region_name": "us-east-1",
+            "api_key": "test-static-key",
+        }
+
+    @property
+    def standard_chat_model_params(self) -> dict:
+        return {"max_tokens": 100}
+
+    @property
+    def init_from_env_params(
+        self,
+    ) -> Tuple[Dict[str, str], Dict[str, str], Dict[str, str]]:
+        return (
+            {
+                "AWS_REGION": "us-east-1",
+            },
+            {
+                "model": "openai.gpt-oss-20b",
+                "api_key": "test-static-key",
+            },
+            {},
         )

--- a/libs/aws/uv.lock
+++ b/libs/aws/uv.lock
@@ -120,6 +120,18 @@ wheels = [
 ]
 
 [[package]]
+name = "aws-bedrock-token-generator"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/39/cf1c2e12bc5a84af0f96a546481213f81fa6e7927d2bbabd81758c6558ca/aws_bedrock_token_generator-1.1.0.tar.gz", hash = "sha256:95ccb07f63a91ac486561f6df05cc4e04784c8ff5086dc687ed9c5fd3ab1b5ba", size = 19123, upload-time = "2025-07-29T19:53:19.511Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/fd/745ece98870c3824d294bcdce5dc5e15381188a41bc80832c246b205e40e/aws_bedrock_token_generator-1.1.0-py3-none-any.whl", hash = "sha256:bd12854f7c7e52dde5d980d369379f12d0cc5f0855099d87f38688b0f9de5cd4", size = 10291, upload-time = "2025-07-29T19:53:18.704Z" },
+]
+
+[[package]]
 name = "aws-sdk-bedrock-runtime"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1031,6 +1043,10 @@ anthropic = [
     { name = "anthropic", extra = ["bedrock"] },
     { name = "langchain-anthropic" },
 ]
+mantle = [
+    { name = "aws-bedrock-token-generator" },
+    { name = "openai" },
+]
 nova-sonic = [
     { name = "aws-sdk-bedrock-runtime", marker = "python_full_version >= '3.12'" },
 ]
@@ -1070,8 +1086,10 @@ test = [
 ]
 test-integration = [
     { name = "anthropic", extra = ["bedrock"] },
+    { name = "aws-bedrock-token-generator" },
     { name = "aws-sdk-bedrock-runtime", marker = "python_full_version >= '3.12'" },
     { name = "langchain-anthropic" },
+    { name = "openai" },
 ]
 typing = [
     { name = "langchain-anthropic" },
@@ -1082,6 +1100,7 @@ typing = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic", extras = ["bedrock"], marker = "extra == 'anthropic'" },
+    { name = "aws-bedrock-token-generator", marker = "extra == 'mantle'", specifier = ">=1.1.0" },
     { name = "aws-sdk-bedrock-runtime", marker = "python_full_version >= '3.12' and extra == 'nova-sonic'" },
     { name = "beautifulsoup4", marker = "extra == 'tools'", specifier = ">=4.13.4" },
     { name = "bedrock-agentcore", marker = "python_full_version >= '3.10' and extra == 'tools'", specifier = ">=1.4.0" },
@@ -1089,11 +1108,12 @@ requires-dist = [
     { name = "langchain-anthropic", marker = "extra == 'anthropic'" },
     { name = "langchain-core", specifier = ">=1.4.7" },
     { name = "numpy", specifier = ">=1.0.0,<3" },
+    { name = "openai", marker = "extra == 'mantle'", specifier = ">=1.106.0" },
     { name = "playwright", marker = "extra == 'tools'", specifier = ">=1.53.0" },
     { name = "pydantic", specifier = ">=2.10.6,<3" },
     { name = "valkey-glide-sync", marker = "extra == 'valkey'", specifier = ">=2.0.0" },
 ]
-provides-extras = ["tools", "anthropic", "valkey", "nova-sonic"]
+provides-extras = ["tools", "anthropic", "valkey", "nova-sonic", "mantle"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1120,8 +1140,10 @@ test = [
 ]
 test-integration = [
     { name = "anthropic", extras = ["bedrock"] },
+    { name = "aws-bedrock-token-generator", specifier = ">=1.1.0" },
     { name = "aws-sdk-bedrock-runtime", marker = "python_full_version >= '3.12'" },
     { name = "langchain-anthropic" },
+    { name = "openai", specifier = ">=1.106.0" },
 ]
 typing = [
     { name = "langchain-anthropic" },
@@ -1659,6 +1681,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/94/a8/f98e50356cf167df656c526c2dfeec2d7dde182f2a3da4b458a5938e2776/numpy-2.5.1-cp314-cp314t-win32.whl", hash = "sha256:6eab239876581b2b3c5a242281b6007bbdbcd1c7085d7709bb57c5929b11e6bf", size = 6263298, upload-time = "2026-07-04T17:07:53.445Z" },
     { url = "https://files.pythonhosted.org/packages/72/ac/96ae880cdecad0b3275d9359fcec72667b49a4863c9f12942e43679dda02/numpy-2.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:83ce9c80d5b521b0d77ddcbe5447c218d247929b6cc056ca5351342accfff0af", size = 12748623, upload-time = "2026-07-04T17:07:55.384Z" },
     { url = "https://files.pythonhosted.org/packages/a1/5a/4d2b1601df3602dba7a14f3348ba9bfe94a18adb428e693df6154c293831/numpy-2.5.1-cp314-cp314t-win_arm64.whl", hash = "sha256:5a6db61f9aaa57e369905c67d852045d3c4f7126405b29d09b19dec118e9c9cb", size = 10697674, upload-time = "2026-07-04T17:07:58.506Z" },
+]
+
+[[package]]
+name = "openai"
+version = "2.30.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/15/52580c8fbc16d0675d516e8749806eda679b16de1e4434ea06fb6feaa610/openai-2.30.0.tar.gz", hash = "sha256:92f7661c990bda4b22a941806c83eabe4896c3094465030dd882a71abe80c885", size = 676084, upload-time = "2026-03-25T22:08:59.96Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/9e/5bfa2270f902d5b92ab7d41ce0475b8630572e71e349b2a4996d14bdda93/openai-2.30.0-py3-none-any.whl", hash = "sha256:9a5ae616888eb2748ec5e0c5b955a51592e0b201a11f4262db920f2a78c5231d", size = 1146656, upload-time = "2026-03-25T22:08:58.2Z" },
 ]
 
 [[package]]
@@ -2588,6 +2629,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds `ChatBedrockMantle`, a `BaseChatModel` wrapping the OpenAI Python SDK to talk to Bedrock Mantle's OpenAI-compatible endpoints (`bedrock-mantle.<region>.api.aws`). Supports Responses API (default), Chat Completions API (fallback), streaming, async, tool calling, structured output, and conversation state via `previous_response_id`.

Auth supports both static API keys and auto-refreshing short-term tokens from AWS credentials via `_BedrockApiKeyProvider`, which follows botocore's `RefreshableCredentials` pattern with advisory (15 min) and mandatory (10 min) refresh windows.

## Usage

```python
from langchain_aws import ChatBedrockMantle

llm = ChatBedrockMantle(model="deepseek.v3.2", region_name="us-east-1")
response = llm.invoke("What is 2+2?")

# Streaming
for chunk in llm.stream("Say hello"):
    print(chunk.content)

# Async
response = await llm.ainvoke("What is 2+2?")
```

Install: `pip install "langchain-aws[mantle]"`

## Files Changed

| File | Change |
|---|---|
| `langchain_aws/chat_models/bedrock_mantle.py` | NEW — `ChatBedrockMantle` implementation |
| `langchain_aws/utils.py` | MODIFIED — Added `_BedrockApiKeyProvider` |
| `langchain_aws/chat_models/__init__.py` | MODIFIED — Added to `__all__` and lazy imports |
| `langchain_aws/__init__.py` | MODIFIED — Added to exports |
| `pyproject.toml` | MODIFIED — Added `[mantle]` optional dep (`openai>=1.106.0`) |
| `tests/unit_tests/chat_models/test_bedrock_mantle.py` | NEW — 68 unit tests |
| `tests/integration_tests/chat_models/test_bedrock_mantle.py` | NEW — 22 integration tests |

## Testing

- 68 unit tests — all passing
- 22 integration tests — all passing (live Mantle, us-east-1)
- Verified against `openai==1.106.0` (declared floor) — all passing
- Full unit suite (884+) — 0 failures
- Lint clean (ruff)

## Areas requiring careful review

- `_BedrockApiKeyProvider` token refresh logic in `utils.py` — follows botocore's `RefreshableCredentials` pattern with non-blocking advisory and blocking mandatory windows
- API routing in `_use_responses_api` — auto-detects Responses vs Chat Completions based on parameter keys
- `openai>=1.106.0` version pin — minimum for callable `api_key` support (short-term token refresh)

## Note

AI agents were used to assist with code review and refactoring during development.
