### PR TITLE
fix(langgraph-checkpoint-aws): run DynamoDBSaver.alist in thread-pool executor

### DIFF
--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/dynamodb/saver.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/dynamodb/saver.py
@@ -475,7 +475,11 @@ class DynamoDBSaver(BaseCheckpointSaver):
         Returns:
             AsyncIterator[CheckpointTuple]: An iterator of checkpoint tuples.
         """
-        for item in self.list(config, filter=filter, before=before, limit=limit):
+        items = await run_in_executor(
+            None,
+            lambda: list(self.list(config, filter=filter, before=before, limit=limit)),
+        )
+        for item in items:
             yield item
 
     def delete_thread(self, thread_id: str) -> None:

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/checkpoint/dynamodb/test_saver.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/checkpoint/dynamodb/test_saver.py
@@ -1,6 +1,6 @@
 """Comprehensive unit tests for DynamoDBSaver."""
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 from botocore.config import Config
@@ -393,3 +393,28 @@ class TestDynamoDBSaverAsyncList:
 
         assert len(result) == 1
         assert result[0].checkpoint["id"] == "cp1"
+
+    @pytest.mark.asyncio
+    async def test_alist_uses_run_in_executor(self, mock_saver_dependencies):
+        """Test that alist delegates blocking list() calls to a thread-pool executor."""
+        mock_repo = Mock()
+        mock_saver_dependencies["repo"].return_value = mock_repo
+        mock_repo.list_checkpoints.return_value = iter([])
+        mock_repo.get_pending_writes.return_value = []
+
+        saver = DynamoDBSaver(table_name=TEST_TABLE_NAME)
+        config = {
+            "configurable": {
+                "thread_id": TEST_THREAD_ID,
+                "checkpoint_ns": TEST_CHECKPOINT_NS,
+            }
+        }
+
+        with patch(
+            "langgraph_checkpoint_aws.checkpoint.dynamodb.saver.run_in_executor"
+        ) as mock_executor:
+            mock_executor.return_value = []
+            result = [item async for item in saver.alist(config)]
+
+        mock_executor.assert_awaited_once()
+        assert result == []


### PR DESCRIPTION
## Summary

- `DynamoDBSaver.alist()` was iterating `self.list()` directly on the event-loop thread, blocking every other coroutine for the duration of the DynamoDB scan.
- All other async methods (`aget_tuple`, `aput`, `aput_writes`, `adelete_thread`) already delegate blocking I/O to `run_in_executor`; `alist` is now consistent with that pattern.

Fixes #754

## Change

```python
# Before — blocks the event loop
async def alist(self, config, *, filter=None, before=None, limit=None):
    for item in self.list(config, filter=filter, before=before, limit=limit):
        yield item

# After — runs the blocking scan in a thread-pool executor
async def alist(self, config, *, filter=None, before=None, limit=None):
    items = await run_in_executor(
        None,
        lambda: list(self.list(config, filter=filter, before=before, limit=limit)),
    )
    for item in items:
        yield item
```

## Test plan

- [x] Existing `test_alist_checkpoints` continues to pass (functional correctness unchanged)
- [x] New `test_alist_uses_run_in_executor` asserts that `run_in_executor` is awaited, verifying the blocking work is offloaded
- [x] Full unit test suite passes (`398 passed`)
- [x] `ruff check` passes with no issues

## AI disclosure

This PR was authored with the assistance of an AI coding agent (Claude) as part of an automated OSS contribution workflow.

https://claude.ai/code/session_01151ff7yYLPq8NiVhjAYMay