### PR TITLE
feat: Add new method for structured output - "prompt_prefill"

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -1707,9 +1707,13 @@ class ChatBedrockConverse(BaseChatModel):
 
         prepare = RunnableLambda(_prepare)
 
+        user_stops = kwargs.pop("stop", None) or []
+        existing_stops = self.stop_sequences or []
+        merged_stops = list(set(existing_stops + user_stops + [_PROMPT_PREFILL_STOP]))
+
         try:
             llm = self.bind(
-                stop=[_PROMPT_PREFILL_STOP],
+                stop=merged_stops,
                 ls_structured_output_format={
                     "kwargs": {"method": "prompt_prefill"},
                     "schema": json_schema,
@@ -1717,7 +1721,7 @@ class ChatBedrockConverse(BaseChatModel):
                 **kwargs,
             )
         except Exception:
-            llm = self.bind(stop=[_PROMPT_PREFILL_STOP], **kwargs)
+            llm = self.bind(stop=merged_stops, **kwargs)
 
         if isinstance(schema, type) and is_basemodel_subclass(schema):
             from langchain_core.output_parsers import PydanticOutputParser

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -1946,7 +1946,7 @@ _method_doc = """\
         - ``"prompt_prefill"``: Augments the system message with the JSON
           schema, prefills an assistant turn with a ``\\`\\`\\`json`` fence
           and stops generation at the closing fence. Useful for models
-          without native JSON-schema (Amazon Nova)).
+          without native JSON-schema (Amazon Nova).
 
 """
 ChatBedrockConverse.with_structured_output.__doc__ = _base_wso_doc.replace(

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -1680,8 +1680,9 @@ class ChatBedrockConverse(BaseChatModel):
     ) -> Runnable[LanguageModelInput, Union[Dict, BaseModel]]:
         """Structured output via assistant-message prefill and a stop sequence.
 
-        Targets models that lack native JSON-schema or adequate performance in forced tool-calling mode
-        (notably Amazon Nova). The system message is augmented with the JSON schema,
+        Targets models that lack native JSON-schema support or adequate
+        performance in forced tool-calling mode (notably Amazon Nova). The
+        system message is augmented with the JSON schema,
         an assistant turn is prefilled with ``\\`\\`\\`json`` to force the model to
         start a JSON code block, and ``stop=["\\`\\`\\`"]`` halts generation at the
         closing fence. The resulting text is parsed against ``schema``.

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -53,7 +53,12 @@ from langchain_core.messages.tool import tool_call_chunk
 from langchain_core.output_parsers import JsonOutputKeyToolsParser, PydanticToolsParser
 from langchain_core.output_parsers.base import OutputParserLike
 from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
-from langchain_core.runnables import Runnable, RunnableMap, RunnablePassthrough
+from langchain_core.runnables import (
+    Runnable,
+    RunnableLambda,
+    RunnableMap,
+    RunnablePassthrough,
+)
 from langchain_core.tools import BaseTool
 from langchain_core.utils import get_pydantic_field_names, secret_from_env
 from langchain_core.utils.function_calling import (
@@ -1503,11 +1508,17 @@ class ChatBedrockConverse(BaseChatModel):
         schema: _DictOrPydanticClass,
         *,
         include_raw: bool = False,
-        method: Literal["function_calling", "json_schema"] = "function_calling",
+        method: Literal[
+            "function_calling", "json_schema", "prompt_prefill"
+        ] = "function_calling",
         **kwargs: Any,
     ) -> Runnable[LanguageModelInput, Union[Dict, BaseModel]]:
         if method == "json_schema":
             return self._with_structured_output_json_schema(
+                schema, include_raw=include_raw, **kwargs
+            )
+        if method == "prompt_prefill":
+            return self._with_structured_output_prompt_prefill(
                 schema, include_raw=include_raw, **kwargs
             )
         return self._with_structured_output_function_calling(
@@ -1659,6 +1670,76 @@ class ChatBedrockConverse(BaseChatModel):
             return RunnableMap(raw=llm) | parser_with_fallback
         else:
             return llm | output_parser
+
+    def _with_structured_output_prompt_prefill(
+        self,
+        schema: _DictOrPydanticClass,
+        *,
+        include_raw: bool = False,
+        **kwargs: Any,
+    ) -> Runnable[LanguageModelInput, Union[Dict, BaseModel]]:
+        """Structured output via assistant-message prefill and a stop sequence.
+
+        Targets models that lack native JSON-schema or adequate performance in forced tool-calling mode
+        (notably Amazon Nova). The system message is augmented with the JSON schema,
+        an assistant turn is prefilled with ``\\`\\`\\`json`` to force the model to
+        start a JSON code block, and ``stop=["\\`\\`\\`"]`` halts generation at the
+        closing fence. The resulting text is parsed against ``schema``.
+        """
+        if isinstance(schema, type) and is_basemodel_subclass(schema):
+            json_schema = schema.model_json_schema()
+        elif isinstance(schema, dict):
+            json_schema = copy.deepcopy(schema)
+        else:
+            msg = (
+                f"Unsupported schema type: {type(schema)}. "
+                "Expected a Pydantic model class or a dict."
+            )
+            raise ValueError(msg)
+
+        instructions = _prompt_prefill_instructions(json_schema)
+
+        def _prepare(inp: LanguageModelInput) -> List[BaseMessage]:
+            messages = self._convert_input(inp).to_messages()
+            messages = _append_to_system_message(messages, instructions)
+            return [*messages, AIMessage(content=_PROMPT_PREFILL_VALUE)]
+
+        prepare = RunnableLambda(_prepare)
+
+        try:
+            llm = self.bind(
+                stop=[_PROMPT_PREFILL_STOP],
+                ls_structured_output_format={
+                    "kwargs": {"method": "prompt_prefill"},
+                    "schema": json_schema,
+                },
+                **kwargs,
+            )
+        except Exception:
+            llm = self.bind(stop=[_PROMPT_PREFILL_STOP], **kwargs)
+
+        if isinstance(schema, type) and is_basemodel_subclass(schema):
+            from langchain_core.output_parsers import PydanticOutputParser
+
+            text_parser: OutputParserLike = PydanticOutputParser(pydantic_object=schema)
+        else:
+            from langchain_core.output_parsers import JsonOutputParser
+
+            text_parser = JsonOutputParser()
+
+        extract_then_parse = RunnableLambda(_extract_prompt_prefill_text) | text_parser
+
+        if include_raw:
+            parser_assign = RunnablePassthrough.assign(
+                parsed=itemgetter("raw") | extract_then_parse,
+                parsing_error=lambda _: None,
+            )
+            parser_none = RunnablePassthrough.assign(parsed=lambda _: None)
+            parser_with_fallback = parser_assign.with_fallbacks(
+                [parser_none], exception_key="parsing_error"
+            )
+            return prepare | RunnableMap(raw=llm) | parser_with_fallback
+        return prepare | llm | extract_then_parse
 
     def _converse_params(
         self,
@@ -1849,7 +1930,8 @@ class ChatBedrockConverse(BaseChatModel):
 _base_wso_doc = BaseChatModel.with_structured_output.__doc__ or ""
 _method_doc = """\
     method: The method for structured output generation. Supported
-        options are ``"function_calling"`` and ``"json_schema"``.
+        options are ``"function_calling"``, ``"json_schema"``, and
+        ``"prompt_prefill"``.
 
         - ``"function_calling"`` (default): Uses forced tool calling to
           generate structured output.
@@ -1860,11 +1942,85 @@ _method_doc = """\
           documentation
           <https://docs.aws.amazon.com/bedrock/latest/userguide/structured-output.html>`_
           for the latest supported models.
+        - ``"prompt_prefill"``: Augments the system message with the JSON
+          schema, prefills an assistant turn with a ``\\`\\`\\`json`` fence
+          and stops generation at the closing fence. Useful for models
+          without native JSON-schema (Amazon Nova)).
 
 """
 ChatBedrockConverse.with_structured_output.__doc__ = _base_wso_doc.replace(
     "Raises:", _method_doc + "Raises:", 1
 )
+
+
+_PROMPT_PREFILL_VALUE = "```json"
+_PROMPT_PREFILL_STOP = "```"
+
+
+def _prompt_prefill_instructions(json_schema: dict) -> str:
+    return (
+        "You MUST respond with a single JSON object matching the schema below. "
+        "Do not include any preamble, explanation, or text outside the JSON. "
+        "Wrap the JSON in a ```json ... ``` fenced code block.\n\n"
+        "## Response Schema:\n"
+        f"```json\n{json.dumps(json_schema, indent=2)}\n```"
+    )
+
+
+def _append_to_system_message(
+    messages: List[BaseMessage], text: str
+) -> List[BaseMessage]:
+    """Append ``text`` to the existing leading SystemMessage, or prepend one.
+
+    For block-style content, appends to the *last* text block (rather than as a
+    new trailing block) so any subsequent cache-point blocks continue to cover
+    the appended text.
+    """
+    if not messages or not isinstance(messages[0], SystemMessage):
+        return [SystemMessage(content=text), *messages]
+
+    system_message = messages[0]
+    existing = system_message.content
+    if isinstance(existing, str):
+        new_content: Any = existing + "\n\n" + text
+    else:
+        new_content = list(existing)
+        last_text_idx = next(
+            (
+                i
+                for i in range(len(new_content) - 1, -1, -1)
+                if isinstance(new_content[i], dict) and "text" in new_content[i]
+            ),
+            None,
+        )
+        if last_text_idx is None:
+            new_content.append({"text": text})
+        else:
+            block = dict(new_content[last_text_idx])
+            block["text"] = block["text"] + "\n\n" + text
+            new_content[last_text_idx] = block
+
+    return [SystemMessage(content=new_content), *messages[1:]]
+
+
+def _extract_prompt_prefill_text(message: AIMessage) -> str:
+    """Extract JSON text from a Nova prompt-prefill response."""
+    content = message.content
+    if isinstance(content, list):
+        text_parts = [
+            block.get("text", "")
+            for block in content
+            if isinstance(block, dict) and block.get("type") in (None, "text")
+        ]
+        text = "".join(text_parts)
+    else:
+        text = content or ""
+    return (
+        text.strip()
+        .removeprefix(_PROMPT_PREFILL_VALUE)
+        .removesuffix(_PROMPT_PREFILL_STOP)
+        .strip()
+    )
 
 
 def _handle_bedrock_error(error: ClientError) -> None:

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -5429,3 +5429,160 @@ def test_structured_output_tool_choice_not_supported(thinking_model: str) -> Non
     tool_spec = tool_config["tools"][0]["toolSpec"]
     assert tool_spec["name"] == "ClassifyQuery"
     assert call_kwargs["additionalModelRequestFields"]["thinking"]["type"] == "enabled"
+
+
+def test_with_structured_output_prompt_prefill_pydantic() -> None:
+    """method='prompt_prefill' wraps the LLM with prep + stop binding + parser."""
+    from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+    from langchain_core.runnables import RunnableLambda
+
+    from langchain_aws.chat_models.bedrock_converse import (
+        _PROMPT_PREFILL_STOP,
+        _PROMPT_PREFILL_VALUE,
+    )
+
+    chat_model = ChatBedrockConverse(
+        model="us.amazon.nova-pro-v1:0",
+        region_name="us-west-2",
+    )
+    structured = chat_model.with_structured_output(GetWeather, method="prompt_prefill")
+
+    # Pipeline: prepare(RunnableLambda) | bound_llm | extract+parse
+    first_step = structured.first  # type: ignore[attr-defined]
+    assert isinstance(first_step, RunnableLambda)
+
+    bound = structured.middle[0]  # type: ignore[attr-defined]
+    bound_kwargs = cast(RunnableBinding, bound).kwargs
+    assert bound_kwargs.get("stop") == [_PROMPT_PREFILL_STOP]
+    assert bound_kwargs["ls_structured_output_format"]["kwargs"]["method"] == (
+        "prompt_prefill"
+    )
+
+    # Prep prepends a SystemMessage with schema, leaves user input alone, and
+    # appends an AIMessage prefill.
+    prepared = first_step.invoke([HumanMessage(content="What's the weather?")])
+    assert len(prepared) == 3
+    assert isinstance(prepared[0], SystemMessage)
+    assert "Response Schema" in prepared[0].content
+    assert "location" in prepared[0].content
+    assert isinstance(prepared[1], HumanMessage)
+    assert prepared[1].content == "What's the weather?"
+    assert isinstance(prepared[-1], AIMessage)
+    assert prepared[-1].content == _PROMPT_PREFILL_VALUE
+
+
+def test_with_structured_output_prompt_prefill_accepts_string_input() -> None:
+    """A bare string input is coerced via _convert_input — no SystemMessage needed."""
+    chat_model = ChatBedrockConverse(
+        model="us.amazon.nova-pro-v1:0",
+        region_name="us-west-2",
+    )
+    structured = chat_model.with_structured_output(GetWeather, method="prompt_prefill")
+    prepared = structured.first.invoke("What's the weather?")  # type: ignore[attr-defined]
+    assert len(prepared) == 3
+    assert "Response Schema" in prepared[0].content
+
+
+def test_with_structured_output_prompt_prefill_appends_to_existing_system() -> None:
+    """Schema is appended to an existing string-content SystemMessage."""
+    from langchain_core.messages import HumanMessage, SystemMessage
+
+    chat_model = ChatBedrockConverse(
+        model="us.amazon.nova-pro-v1:0",
+        region_name="us-west-2",
+    )
+    structured = chat_model.with_structured_output(GetWeather, method="prompt_prefill")
+    prepared = structured.first.invoke(  # type: ignore[attr-defined]
+        [
+            SystemMessage(content="You are a weather bot."),
+            HumanMessage(content="hi"),
+        ]
+    )
+    assert len(prepared) == 3
+    assert isinstance(prepared[0], SystemMessage)
+    assert prepared[0].content.startswith("You are a weather bot.")
+    assert "Response Schema" in prepared[0].content
+
+
+def test_with_structured_output_prompt_prefill_appends_inside_last_text_block() -> None:
+    """For block-style system content, schema is merged into the last text block.
+
+    This keeps any trailing cachePoint block covering the appended schema text.
+    """
+    from langchain_core.messages import HumanMessage, SystemMessage
+
+    chat_model = ChatBedrockConverse(
+        model="us.amazon.nova-pro-v1:0",
+        region_name="us-west-2",
+    )
+    structured = chat_model.with_structured_output(GetWeather, method="prompt_prefill")
+    cache_point = ChatBedrockConverse.create_cache_point()
+    prepared = structured.first.invoke(  # type: ignore[attr-defined]
+        [
+            SystemMessage(content=[{"text": "You are a weather bot."}, cache_point]),
+            HumanMessage(content="hi"),
+        ]
+    )
+    sys_blocks = prepared[0].content
+    assert isinstance(sys_blocks, list)
+    assert len(sys_blocks) == 2
+    # Schema text merged into the existing text block.
+    assert sys_blocks[0]["text"].startswith("You are a weather bot.")
+    assert "Response Schema" in sys_blocks[0]["text"]
+    # Cache-point block remains last so it covers the appended schema.
+    assert sys_blocks[1] == cache_point
+
+
+def test_with_structured_output_prompt_prefill_dict_schema() -> None:
+    """method='prompt_prefill' accepts a dict JSON-schema."""
+    schema = {
+        "title": "Joke",
+        "type": "object",
+        "properties": {"setup": {"type": "string"}},
+        "required": ["setup"],
+    }
+    chat_model = ChatBedrockConverse(
+        model="us.amazon.nova-pro-v1:0",
+        region_name="us-west-2",
+    )
+    structured = chat_model.with_structured_output(schema, method="prompt_prefill")
+    prepared = structured.first.invoke("hi")  # type: ignore[attr-defined]
+    assert "setup" in prepared[0].content
+    # Original dict not mutated.
+    assert "Response Schema" not in json.dumps(schema)
+
+
+def test_with_structured_output_prompt_prefill_extract_text() -> None:
+    """The text extractor strips fences and concatenates text blocks."""
+    from langchain_core.messages import AIMessage
+
+    from langchain_aws.chat_models.bedrock_converse import (
+        _extract_prompt_prefill_text,
+    )
+
+    msg = AIMessage(content='\n{"location": "NYC"}\n```')
+    assert _extract_prompt_prefill_text(msg) == '{"location": "NYC"}'
+
+    msg2 = AIMessage(
+        content=[
+            {"text": '```json\n{"location": '},
+            {"text": '"NYC"}\n```'},
+        ]
+    )
+    assert _extract_prompt_prefill_text(msg2) == '{"location": "NYC"}'
+
+
+def test_with_structured_output_prompt_prefill_include_raw() -> None:
+    """include_raw=True wraps the LLM in a RunnableMap with raw + parsed keys."""
+    chat_model = ChatBedrockConverse(
+        model="us.amazon.nova-pro-v1:0",
+        region_name="us-west-2",
+    )
+    structured = chat_model.with_structured_output(
+        GetWeather, method="prompt_prefill", include_raw=True
+    )
+    # Pipeline shape: prepare | RunnableMap(raw=llm) | parser_with_fallback
+    assert structured.first is not None  # type: ignore[attr-defined]
+    last = structured.last  # type: ignore[attr-defined]
+    # Last step should reference the "parsed" / "parsing_error" keys via fallback.
+    assert "parsing_error" in repr(last) or "parsed" in repr(last)

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -5500,8 +5500,10 @@ def test_with_structured_output_prompt_prefill_appends_to_existing_system() -> N
     )
     assert len(prepared) == 3
     assert isinstance(prepared[0], SystemMessage)
-    assert prepared[0].content.startswith("You are a weather bot.")
-    assert "Response Schema" in prepared[0].content
+    sys_content = prepared[0].content
+    assert isinstance(sys_content, str)
+    assert sys_content.startswith("You are a weather bot.")
+    assert "Response Schema" in sys_content
 
 
 def test_with_structured_output_prompt_prefill_appends_inside_last_text_block() -> None:


### PR DESCRIPTION
Implements feature request #1025 

Allows for obtaining structured outputs programatically for nova models, following the AWS recommendations in [this guide](https://docs.aws.amazon.com/nova/latest/userguide/prompting-structured-output.html)

This is achieved through:
1. Injecting Pydantic model instructions into SystemMessage
2. Prefilling an AIMessage with the "```json" prefix
3. Adding a "```" stop sequence 


### Usage:

```
from langchain_aws import ChatBedrockConverse
from langchain_core.messages import HumanMessage, SystemMessage
from pydantic import BaseModel, Field


class Joke(BaseModel):
    setup: str = Field(description="The setup of the joke")
    punchline: str = Field(description="The punchline")
    rating: int = Field(description="How funny, 1-10", ge=1, le=10)


llm = ChatBedrockConverse(
    model="us.amazon.nova-2-lite-v1:0",
    region_name="us-east-1",
).with_structured_output(Joke, method="prompt_prefill")

result = llm.invoke([
    SystemMessage(content="You are a witty comedian."),
    HumanMessage(content="Tell me a short joke about cats."),
])

print(result)
# setup='Why did the cat bring a ladder to the library?' punchline='It heard the shelves were a little high-brow!' rating=8
```

### Known Limitations

Streaming - I haven't really figured out partial streaming for this one, any help would be appreciated