### PR TITLE
perf: Improve performance of put_writes/aput_writes with DynamoDB backend

### DIFF
--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/dynamodb/unified_repository.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/dynamodb/unified_repository.py
@@ -22,6 +22,11 @@ else:
 
 logger = logging.getLogger(__name__)
 
+# DynamoDB ``batch_write_item`` per-request item cap.
+_BATCH_WRITE_MAX_ITEMS = 25
+# Maximum retries for ``UnprocessedItems`` returned by ``batch_write_item``.
+_BATCH_WRITE_MAX_RETRIES = 5
+
 
 # ========== Key Generation Functions ==========
 
@@ -587,7 +592,14 @@ class UnifiedRepository:
         task_id: str,
         task_path: str = "",
     ) -> None:
-        """Store writes with intelligent offloading and parallel execution.
+        """Store writes with intelligent offloading and batched metadata writes.
+
+        Metadata items for all writes are committed in a single
+        ``batch_write_item`` request (chunked at 25 items, the DynamoDB
+        per-request limit). Payloads are then stored via the storage
+        strategy. This preserves the metadata-before-payload invariant
+        while collapsing N sequential ``put_item`` calls into
+        ``ceil(N / 25)`` batch requests.
 
         Args:
             thread_id: Thread identifier
@@ -606,7 +618,10 @@ class UnifiedRepository:
         # Check if all writes are special (can be overwritten)
         all_special = all(w[0] in WRITES_IDX_MAP for w in writes)
 
-        # Build all write items with payload storage
+        # Materialize the (metadata, payload) pairs so metadata can be
+        # batch-written before any payload is stored.
+        base_items: list[dict[str, Any]] = []
+        ref_items: list[dict[str, Any]] = []
         for base_item, ref_item in self._build_write_items(
             thread_id,
             checkpoint_ns,
@@ -616,12 +631,14 @@ class UnifiedRepository:
             task_path,
             allow_overwrites=all_special,
         ):
-            # Store metadata to base table
-            self.put_single_write_item(
-                checkpoint_id, base_item, allow_overwrites=all_special
-            )
+            base_items.append(base_item)
+            ref_items.append(ref_item)
 
-            # Store Chunks for the record
+        # Batch-write metadata to base table.
+        self._batch_put_write_items(checkpoint_id, base_items)
+
+        # Store payloads via the storage strategy (DynamoDB chunk table or S3).
+        for ref_item in ref_items:
             self.storage.store_data(
                 chunk_key=ref_item["chunk_key"],
                 s3_key=ref_item["s3_key"],
@@ -715,6 +732,91 @@ class UnifiedRepository:
                 base_item["ttl"] = {"N": str(int(time.time() + self.ttl_seconds))}
 
             yield base_item, ref_item
+
+    def _batch_put_write_items(
+        self,
+        checkpoint_id: str,
+        items: list[dict[str, Any]],
+    ) -> None:
+        """Batch-write metadata items to the base table via ``batch_write_item``.
+
+        DynamoDB caps each ``batch_write_item`` request at 25 items and may
+        return ``UnprocessedItems`` when a portion of the batch is throttled.
+        Items are chunked accordingly and any unprocessed items are retried
+        with exponential backoff.
+
+        Note:
+            ``batch_write_item`` does not support ``ConditionExpression``,
+            so existing items with the same primary key are overwritten.
+            For LangGraph writes this is safe because the sort key derives
+            from ``(task_id, idx)``, which deterministically maps to a
+            single payload — replays write identical data.
+
+        Args:
+            checkpoint_id: Checkpoint identifier (for log context).
+            items: Items to write to the base table.
+
+        Raises:
+            ClientError: If ``batch_write_item`` fails.
+            RuntimeError: If items remain unprocessed after the retry budget
+                is exhausted.
+        """
+        if not items:
+            return
+
+        for i in range(0, len(items), _BATCH_WRITE_MAX_ITEMS):
+            chunk = items[i : i + _BATCH_WRITE_MAX_ITEMS]
+
+            write_requests: list[WriteRequestTypeDef] = [
+                {"PutRequest": {"Item": item}} for item in chunk
+            ]
+            request_items: dict[str, list[WriteRequestTypeDef]] = {
+                self.table_name: write_requests
+            }
+
+            retries = 0
+            while request_items:
+                try:
+                    response = self.dynamodb_client.batch_write_item(
+                        RequestItems=request_items
+                    )
+                except ClientError as err:
+                    error_code = err.response["Error"]["Code"]
+                    logger.error(
+                        f"Batch write failed: checkpoint_id={checkpoint_id}, "
+                        f"error={error_code}, batch_size={len(chunk)}"
+                    )
+                    raise
+
+                unprocessed = response.get("UnprocessedItems") or {}
+                if not unprocessed:
+                    break
+
+                retries += 1
+                num_unprocessed = len(unprocessed.get(self.table_name, []))
+                if num_unprocessed == 0:
+                    break
+
+                if retries > _BATCH_WRITE_MAX_RETRIES:
+                    raise RuntimeError(
+                        f"batch_write_item failed to process "
+                        f"{num_unprocessed} items after "
+                        f"{_BATCH_WRITE_MAX_RETRIES} retries: "
+                        f"checkpoint_id={checkpoint_id}"
+                    )
+
+                # Exponential backoff capped at 5 seconds.
+                backoff_seconds = min(2 ** (retries - 1) * 0.1, 5.0)
+                logger.warning(
+                    f"Retrying {num_unprocessed} unprocessed write items "
+                    f"(attempt {retries}/{_BATCH_WRITE_MAX_RETRIES}, "
+                    f"backoff={backoff_seconds:.1f}s)"
+                )
+                time.sleep(backoff_seconds)
+                request_items = {
+                    k: cast("list[WriteRequestTypeDef]", list(v))
+                    for k, v in unprocessed.items()
+                }
 
     def put_single_write_item(
         self, checkpoint_id: str, item: dict[str, Any], allow_overwrites: bool = False

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/checkpoint/dynamodb/test_unified_repository.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/checkpoint/dynamodb/test_unified_repository.py
@@ -1,6 +1,6 @@
 """Comprehensive tests for UnifiedRepository."""
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 from botocore.exceptions import ClientError
@@ -471,6 +471,8 @@ class TestPendingWrites:
         mock_serializer = Mock()
         mock_storage = Mock()
 
+        mock_client.batch_write_item.return_value = {"UnprocessedItems": {}}
+
         repo = UnifiedRepository(
             dynamodb_client=mock_client,
             table_name=TEST_TABLE_NAME,
@@ -847,6 +849,8 @@ class TestMetadataBeforePayloadOrdering:
         # Setup storage to indicate small payload (DYNAMODB storage)
         mock_storage.should_offload_to_s3.return_value = False
 
+        mock_dynamodb.batch_write_item.return_value = {"UnprocessedItems": {}}
+
         return {
             "dynamodb": mock_dynamodb,
             "serializer": mock_serializer,
@@ -963,17 +967,22 @@ class TestMetadataBeforePayloadOrdering:
         # Track call order with details
         call_order = []
 
-        def track_put_item(**kwargs):
-            item = kwargs.get("Item", {})
-            channel = item.get("channel", {}).get("S", "unknown")
-            call_order.append(("put_item", channel))
+        def track_batch_write(**kwargs):
+            for reqs in kwargs.get("RequestItems", {}).values():
+                for req in reqs:
+                    item = req.get("PutRequest", {}).get("Item", {})
+                    channel = item.get("channel", {}).get("S", "unknown")
+                    call_order.append(("batch_write_item", channel))
+            return {"UnprocessedItems": {}}
 
         def track_store_data(*args, **kwargs):
             # Extract channel info from chunk_key
             chunk_key = kwargs.get("chunk_key", "")
             call_order.append(("store_data", chunk_key))
 
-        mock_repo_components["dynamodb"].put_item.side_effect = track_put_item
+        mock_repo_components[
+            "dynamodb"
+        ].batch_write_item.side_effect = track_batch_write
         mock_repo_components["storage"].store_data.side_effect = track_store_data
 
         # Act
@@ -988,22 +997,13 @@ class TestMetadataBeforePayloadOrdering:
         # Assert
         assert len(call_order) == 6, "Expected 3 metadata + 3 payload calls"
 
-        # Verify alternating pattern: metadata, payload, metadata, payload, ...
-        for i in range(0, len(call_order), 2):
-            assert call_order[i][0] == "put_item", (
-                f"Call {i} should be put_item (metadata)"
-            )
-            assert call_order[i + 1][0] == "store_data", (
-                f"Call {i + 1} should be store_data (payload)"
-            )
-
-        # Verify each write's metadata comes before its payload
-        assert call_order[0] == ("put_item", "channel1")
-        assert "CHUNK_" in call_order[1][1]  # store_data with chunk_key
-        assert call_order[2] == ("put_item", "channel2")
-        assert "CHUNK_" in call_order[3][1]
-        assert call_order[4] == ("put_item", "channel3")
-        assert "CHUNK_" in call_order[5][1]
+        # All metadata is committed (in a single batch) before any payload.
+        assert call_order[0] == ("batch_write_item", "channel1")
+        assert call_order[1] == ("batch_write_item", "channel2")
+        assert call_order[2] == ("batch_write_item", "channel3")
+        for i in range(3, 6):
+            assert call_order[i][0] == "store_data"
+            assert "CHUNK_" in call_order[i][1]
 
     def test_put_writes_sequential_not_parallel(self, repo, mock_repo_components):
         """Test that writes are processed sequentially, not in parallel."""
@@ -1013,15 +1013,20 @@ class TestMetadataBeforePayloadOrdering:
         # Track execution order with timestamps
         execution_log = []
 
-        def track_put_item(**kwargs):
-            item = kwargs.get("Item", {})
-            channel = item.get("channel", {}).get("S", "unknown")
-            execution_log.append(f"metadata_{channel}")
+        def track_batch_write(**kwargs):
+            for reqs in kwargs.get("RequestItems", {}).values():
+                for req in reqs:
+                    item = req.get("PutRequest", {}).get("Item", {})
+                    channel = item.get("channel", {}).get("S", "unknown")
+                    execution_log.append(f"metadata_{channel}")
+            return {"UnprocessedItems": {}}
 
         def track_store_data(*args, **kwargs):
             execution_log.append("payload")
 
-        mock_repo_components["dynamodb"].put_item.side_effect = track_put_item
+        mock_repo_components[
+            "dynamodb"
+        ].batch_write_item.side_effect = track_batch_write
         mock_repo_components["storage"].store_data.side_effect = track_store_data
 
         # Act
@@ -1033,11 +1038,11 @@ class TestMetadataBeforePayloadOrdering:
             task_id=TEST_TASK_ID,
         )
 
-        # Assert - verify sequential execution pattern
+        # Assert - all metadata is committed (in a single batch) before any payload
         expected_order = [
             "metadata_channel1",
-            "payload",
             "metadata_channel2",
+            "payload",
             "payload",
         ]
         assert execution_log == expected_order
@@ -1071,16 +1076,11 @@ class TestMetadataBeforePayloadOrdering:
         # Arrange
         writes = [("channel1", "value1"), ("channel2", "value2")]
 
-        # Make second put_item fail
+        # Make batch_write_item fail
         error_response = {"Error": {"Code": "InternalServerError", "Message": "Test"}}
-        call_count = [0]
-
-        def failing_put_item(**kwargs):
-            call_count[0] += 1
-            if call_count[0] == 2:  # Fail on second call
-                raise ClientError(error_response, "PutItem")
-
-        mock_repo_components["dynamodb"].put_item.side_effect = failing_put_item
+        mock_repo_components["dynamodb"].batch_write_item.side_effect = ClientError(
+            error_response, "BatchWriteItem"
+        )
 
         # Act & Assert
         with pytest.raises(ClientError):
@@ -1092,29 +1092,29 @@ class TestMetadataBeforePayloadOrdering:
                 task_id=TEST_TASK_ID,
             )
 
-        # Verify store_data was called only once (for first write)
-        assert mock_repo_components["storage"].store_data.call_count == 1
+        # Metadata batch failed before any payload — store_data must not run.
+        assert mock_repo_components["storage"].store_data.call_count == 0
 
     def test_put_single_write_item_called_before_storage(
         self, repo, mock_repo_components
     ):
-        """Test that put_single_write_item is called before storage.store_data."""
+        """Test that batch_write_item is called before storage.store_data."""
         # Arrange
         writes = [("channel1", "value1")]
 
         # Track method calls
         call_order = []
 
-        original_put_single = repo.put_single_write_item
-
-        def tracked_put_single(*args, **kwargs):
-            call_order.append("put_single_write_item")
-            return original_put_single(*args, **kwargs)
+        def tracked_batch_write(**kwargs):
+            call_order.append("batch_write_item")
+            return {"UnprocessedItems": {}}
 
         def tracked_store_data(*args, **kwargs):
             call_order.append("store_data")
 
-        repo.put_single_write_item = tracked_put_single
+        mock_repo_components[
+            "dynamodb"
+        ].batch_write_item.side_effect = tracked_batch_write
         mock_repo_components["storage"].store_data.side_effect = tracked_store_data
 
         # Act
@@ -1127,7 +1127,39 @@ class TestMetadataBeforePayloadOrdering:
         )
 
         # Assert
-        assert call_order == ["put_single_write_item", "store_data"]
+        assert call_order == ["batch_write_item", "store_data"]
+
+    def test_put_writes_retries_unprocessed_items(self, repo, mock_repo_components):
+        """UnprocessedItems returned by batch_write_item are re-submitted."""
+        # Arrange — first response holds one item back, second drains the batch.
+        writes = [("channel1", "value1"), ("channel2", "value2")]
+
+        mock_repo_components["dynamodb"].batch_write_item.side_effect = [
+            {
+                "UnprocessedItems": {
+                    TEST_TABLE_NAME: [
+                        {"PutRequest": {"Item": {"PK": {"S": "x"}, "SK": {"S": "y"}}}}
+                    ]
+                }
+            },
+            {"UnprocessedItems": {}},
+        ]
+
+        # Act — patch sleep so the backoff doesn't slow the test.
+        with patch(
+            "langgraph_checkpoint_aws.checkpoint.dynamodb.unified_repository.time.sleep"
+        ):
+            repo.put_writes(
+                thread_id=TEST_THREAD_ID,
+                checkpoint_ns=TEST_CHECKPOINT_NS,
+                checkpoint_id=TEST_CHECKPOINT_ID,
+                writes=writes,
+                task_id=TEST_TASK_ID,
+            )
+
+        # Assert — initial batch + 1 retry, all payloads stored exactly once.
+        assert mock_repo_components["dynamodb"].batch_write_item.call_count == 2
+        assert mock_repo_components["storage"].store_data.call_count == 2
 
 
 class TestDetermineStorageLocation:
@@ -1139,6 +1171,8 @@ class TestDetermineStorageLocation:
         mock_dynamodb = Mock()
         mock_serializer = Mock()
         mock_storage = Mock()
+
+        mock_dynamodb.batch_write_item.return_value = {"UnprocessedItems": {}}
 
         return UnifiedRepository(
             dynamodb_client=mock_dynamodb,
@@ -1232,7 +1266,8 @@ class TestDetermineStorageLocation:
         # Assert - verify should_offload_to_s3 was called
         repo.storage.should_offload_to_s3.assert_called_once()
 
-        # Verify put_item was called with DYNAMODB location
-        put_item_call = repo.dynamodb_client.put_item.call_args
-        item = put_item_call[1]["Item"]
+        # Verify batch_write_item was called with a DYNAMODB-located item
+        batch_call = repo.dynamodb_client.batch_write_item.call_args
+        write_requests = next(iter(batch_call[1]["RequestItems"].values()))
+        item = write_requests[0]["PutRequest"]["Item"]
         assert item["ref_loc"]["S"] == "DYNAMODB"


### PR DESCRIPTION
## Summary

Replaces the per-item `put_item` loop in `UnifiedRepository.put_writes` with a single chunked `batch_write_item` call for metadata writes, collapsing N sequential round-trips into `N / 25` batched requests.

Related issue: #766

## Why

`put_writes` is on the hot path for `aput_writes`, which `langgraph` invokes once per task. The old implementation issued N synchronous `put_item` calls inside an `asyncio` thread-pool, so `aput_writes` have to wait for the event loop for `O(N)` round-trips even though the writes are independent.

For the reproduction in #766 (6 channel writes), this is ~1 s of latency that ought to be a single network call.

## Out of scope

Payload writes via `storage.store_data` (S3 + DynamoDB chunk table) are still sequential. Batching them requires a separate refactor inside `StorageStrategy` and is left for a follow-up.