### PR TITLE
chore: Update model profiles tests to Claude 4.6

### DIFF
--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
@@ -31,14 +31,7 @@ from langchain_aws.function_calling import convert_to_anthropic_tool
 
 def test_profile() -> None:
     model = ChatBedrock(
-        model_id="anthropic.claude-3-5-sonnet-20241022-v2:0",
-        region_name="us-west-2",
-    )
-    assert model.profile
-    assert not model.profile["reasoning_output"]
-
-    model = ChatBedrock(
-        model_id="anthropic.claude-sonnet-4-20250514-v1:0",
+        model_id="anthropic.claude-sonnet-4-6",
         region_name="us-west-2",
     )
     assert model.profile

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -108,14 +108,7 @@ class TestBedrockStandard(ChatModelUnitTests):
 
 def test_profile() -> None:
     model = ChatBedrockConverse(
-        model="anthropic.claude-3-5-sonnet-20241022-v2:0",
-        region_name="us-west-2",
-    )
-    assert model.profile
-    assert not model.profile["reasoning_output"]
-
-    model = ChatBedrockConverse(
-        model="anthropic.claude-sonnet-4-20250514-v1:0",
+        model="anthropic.claude-sonnet-4-6",
         region_name="us-west-2",
     )
     assert model.profile


### PR DESCRIPTION
Fixes [CI failures](https://github.com/langchain-ai/langchain-aws/actions/runs/25624200696/job/75216203447) in #1030

Updated the model profile unit tests to use Claude 4.6, as Claude 3.x/4.0 are both now deprecated. First assertion also isn't needed anymore since all active models have `reasoning_output=True`.