### PR TITLE
feat(aws): Enable streaming for `prompt_prefill` structured output mode

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -1726,17 +1726,17 @@ class ChatBedrockConverse(BaseChatModel):
         if isinstance(schema, type) and is_basemodel_subclass(schema):
             from langchain_core.output_parsers import PydanticOutputParser
 
-            text_parser: OutputParserLike = PydanticOutputParser(pydantic_object=schema)
+            output_parser: OutputParserLike = PydanticOutputParser(
+                pydantic_object=schema
+            )
         else:
             from langchain_core.output_parsers import JsonOutputParser
 
-            text_parser = JsonOutputParser()
-
-        extract_then_parse = RunnableLambda(_extract_prompt_prefill_text) | text_parser
+            output_parser = JsonOutputParser()
 
         if include_raw:
             parser_assign = RunnablePassthrough.assign(
-                parsed=itemgetter("raw") | extract_then_parse,
+                parsed=itemgetter("raw") | output_parser,
                 parsing_error=lambda _: None,
             )
             parser_none = RunnablePassthrough.assign(parsed=lambda _: None)
@@ -1744,7 +1744,7 @@ class ChatBedrockConverse(BaseChatModel):
                 [parser_none], exception_key="parsing_error"
             )
             return prepare | RunnableMap(raw=llm) | parser_with_fallback
-        return prepare | llm | extract_then_parse
+        return prepare | llm | output_parser
 
     def _converse_params(
         self,
@@ -2006,26 +2006,6 @@ def _append_to_system_message(
             new_content[last_text_idx] = block
 
     return [SystemMessage(content=new_content), *messages[1:]]
-
-
-def _extract_prompt_prefill_text(message: AIMessage) -> str:
-    """Extract JSON text from a Nova prompt-prefill response."""
-    content = message.content
-    if isinstance(content, list):
-        text_parts = [
-            block.get("text", "")
-            for block in content
-            if isinstance(block, dict) and block.get("type") in (None, "text")
-        ]
-        text = "".join(text_parts)
-    else:
-        text = content or ""
-    return (
-        text.strip()
-        .removeprefix(_PROMPT_PREFILL_VALUE)
-        .removesuffix(_PROMPT_PREFILL_STOP)
-        .strip()
-    )
 
 
 def _handle_bedrock_error(error: ClientError) -> None:

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -5547,24 +5547,24 @@ def test_with_structured_output_prompt_prefill_dict_schema() -> None:
     assert "Response Schema" not in json.dumps(schema)
 
 
-def test_with_structured_output_prompt_prefill_extract_text() -> None:
-    """The text extractor strips fences and concatenates text blocks."""
-    from langchain_core.messages import AIMessage
+def test_with_structured_output_prompt_prefill_stop_sequence_merge() -> None:
+    """Stop sequences are merged, not replaced, when using prompt_prefill."""
+    from typing import cast
 
-    from langchain_aws.chat_models.bedrock_converse import (
-        _extract_prompt_prefill_text,
+    from langchain_core.runnables import RunnableBinding
+
+    from langchain_aws.chat_models.bedrock_converse import _PROMPT_PREFILL_STOP
+
+    chat_model = ChatBedrockConverse(
+        model="us.amazon.nova-pro-v1:0",
+        region_name="us-west-2",
+        stop_sequences=["END"],
     )
-
-    msg = AIMessage(content='\n{"location": "NYC"}\n```')
-    assert _extract_prompt_prefill_text(msg) == '{"location": "NYC"}'
-
-    msg2 = AIMessage(
-        content=[
-            {"text": '```json\n{"location": '},
-            {"text": '"NYC"}\n```'},
-        ]
-    )
-    assert _extract_prompt_prefill_text(msg2) == '{"location": "NYC"}'
+    structured = chat_model.with_structured_output(GetWeather, method="prompt_prefill")
+    bound = cast(RunnableBinding, structured.middle[0])
+    bound_stops = bound.kwargs.get("stop")
+    assert _PROMPT_PREFILL_STOP in bound_stops
+    assert "END" in bound_stops
 
 
 def test_with_structured_output_prompt_prefill_include_raw() -> None:

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -5549,20 +5549,17 @@ def test_with_structured_output_prompt_prefill_dict_schema() -> None:
 
 def test_with_structured_output_prompt_prefill_stop_sequence_merge() -> None:
     """Stop sequences are merged, not replaced, when using prompt_prefill."""
-    from typing import cast
-
-    from langchain_core.runnables import RunnableBinding
-
     from langchain_aws.chat_models.bedrock_converse import _PROMPT_PREFILL_STOP
 
     chat_model = ChatBedrockConverse(
         model="us.amazon.nova-pro-v1:0",
         region_name="us-west-2",
-        stop_sequences=["END"],
+        stop=["END"],
     )
     structured = chat_model.with_structured_output(GetWeather, method="prompt_prefill")
-    bound = cast(RunnableBinding, structured.middle[0])
-    bound_stops = bound.kwargs.get("stop")
+    bound = structured.middle[0]  # type: ignore[attr-defined]
+    bound_stops = bound.kwargs.get("stop")  # type: ignore[attr-defined]
+    assert bound_stops is not None
     assert _PROMPT_PREFILL_STOP in bound_stops
     assert "END" in bound_stops
 


### PR DESCRIPTION
Following up on #1026 - 

The `_extract_prompt_prefill_text` handler is redundant and can be removed:
1. For the list content conditional, ChatGeneration's [`set_text`](https://github.com/langchain-ai/langchain/blob/master/libs/core/langchain_core/outputs/chat_generation.py#L44-L84) validator already joins text blocks into `.text` before being read by the parse
2. JsonOutputParser (and PydanticOutputParser) strips both ` ```json` and the stop backticks internally [inside of `parse_json_markdown`](https://github.com/langchain-ai/langchain/blob/master/libs/core/langchain_core/utils/json.py#L154-L162).

With this part of the chain removed, streaming is unblocked, as we can now pass individual `AIMessageChunk`s directly to the output parser.