### PR TITLE
fix(agentcore-codeinterpreter): preserve binary blob bytes and normalize ./ paths in readFiles

### DIFF
--- a/libs/agentcore-codeinterpreter/langchain_agentcore_codeinterpreter/sandbox.py
+++ b/libs/agentcore-codeinterpreter/langchain_agentcore_codeinterpreter/sandbox.py
@@ -32,6 +32,21 @@ _AGENTCORE_EXECUTOR = ThreadPoolExecutor(
 )
 
 
+def _normalize_relative_path(path: str) -> str:
+    """Strip leading slashes and ``./`` prefixes to a canonical relative path.
+
+    Args:
+        path: File path (absolute or relative).
+
+    Returns:
+        Canonical relative path string with no leading ``/`` or ``./``.
+    """
+    path = path.lstrip("/")
+    while path.startswith("./"):
+        path = path[2:]
+    return path
+
+
 class SessionExpiredError(Exception):
     """Raised when the AgentCore session has expired or been terminated."""
 
@@ -104,8 +119,7 @@ def _extract_files_from_stream(
     """
     path_lookup: dict[str, str] = {}
     for path in requested_paths:
-        stripped = path.lstrip("/")
-        path_lookup[stripped] = path
+        path_lookup[_normalize_relative_path(path)] = path
 
     files: dict[str, bytes] = {}
 
@@ -117,13 +131,16 @@ def _extract_files_from_stream(
                 continue
             resource = item.get("resource", {})
             uri = resource.get("uri", "")
-            file_path = uri.replace("file://", "").lstrip("/")
+            file_path = _normalize_relative_path(uri.replace("file://", ""))
 
             content: bytes | None = None
             if "text" in resource:
                 content = resource["text"].encode("utf-8")
             elif "blob" in resource:
-                content = base64.b64decode(resource["blob"])
+                blob = resource["blob"]
+                # The AgentCore stream may deliver blob as already-decoded bytes.
+                # Only base64-decode when it arrives as encoded text.
+                content = blob if isinstance(blob, bytes) else base64.b64decode(blob)
 
             if content is not None:
                 original_path = path_lookup.get(file_path, file_path)
@@ -178,7 +195,7 @@ class AgentCoreSandbox(BaseSandbox):
 
     @staticmethod
     def _to_relative_path(path: str) -> str:
-        """Strip leading slashes so paths are relative for AgentCore APIs.
+        """Strip leading slashes and ``./`` prefixes for AgentCore APIs.
 
         Args:
             path: File path (absolute or relative).
@@ -186,7 +203,7 @@ class AgentCoreSandbox(BaseSandbox):
         Returns:
             Relative path string.
         """
-        return path.lstrip("/")
+        return _normalize_relative_path(path)
 
     def _invoke(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
         """Invoke the interpreter and eagerly consume the response stream.

--- a/libs/agentcore-codeinterpreter/tests/unit_tests/test_sandbox.py
+++ b/libs/agentcore-codeinterpreter/tests/unit_tests/test_sandbox.py
@@ -228,6 +228,36 @@ def test_download_files_handles_session_expiry() -> None:
     assert results[0].error == "permission_denied"
 
 
+def test_download_files_dot_slash_path() -> None:
+    """./-prefixed paths must round-trip through readFiles and lookup."""
+    fake_png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+    sandbox, mock = _make_sandbox(
+        {
+            "stream": [
+                {
+                    "result": {
+                        "content": [
+                            {
+                                "type": "resource",
+                                "resource": {
+                                    "uri": "file:///data/foo.png",
+                                    "blob": fake_png,
+                                },
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    )
+    results = sandbox.download_files(["./data/foo.png"])
+    mock.invoke.assert_called_once_with(
+        method="readFiles", params={"paths": ["data/foo.png"]}
+    )
+    assert results[0].error is None
+    assert results[0].content == fake_png
+
+
 # ------------------------------------------------------------------
 # _to_relative_path()
 # ------------------------------------------------------------------
@@ -238,6 +268,13 @@ def test_relative_path_stripping() -> None:
     assert AgentCoreSandbox._to_relative_path("/abs/path.txt") == "abs/path.txt"
     assert AgentCoreSandbox._to_relative_path("rel/path.txt") == "rel/path.txt"
     assert AgentCoreSandbox._to_relative_path("///triple.txt") == "triple.txt"
+
+
+def test_relative_path_strips_dot_slash() -> None:
+    """./ and repeated ././ prefixes should be stripped."""
+    assert AgentCoreSandbox._to_relative_path("./data/foo.png") == "data/foo.png"
+    assert AgentCoreSandbox._to_relative_path("././foo.png") == "foo.png"
+    assert AgentCoreSandbox._to_relative_path("/./data/foo.png") == "data/foo.png"
 
 
 # ------------------------------------------------------------------

--- a/libs/agentcore-codeinterpreter/tests/unit_tests/test_stream_parsing.py
+++ b/libs/agentcore-codeinterpreter/tests/unit_tests/test_stream_parsing.py
@@ -182,6 +182,54 @@ def test_extract_files_blob_resource() -> None:
     assert files["/data.bin"] == b"binary data"
 
 
+def test_extract_files_blob_already_bytes() -> None:
+    """Blob delivered as raw bytes must not be base64-decoded again."""
+    png_magic = b"\x89PNG\r\n\x1a\n"
+    fake_png = png_magic + b"\x00" * 100
+    response: dict[str, Any] = {
+        "stream": [
+            {
+                "result": {
+                    "content": [
+                        {
+                            "type": "resource",
+                            "resource": {
+                                "uri": "file:///test.png",
+                                "blob": fake_png,
+                            },
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+    files = _extract_files_from_stream(response, ["test.png"])
+    assert files["test.png"] == fake_png
+
+
+def test_extract_files_dot_slash_path() -> None:
+    """./-prefixed requested paths should match URIs without the prefix."""
+    response: dict[str, Any] = {
+        "stream": [
+            {
+                "result": {
+                    "content": [
+                        {
+                            "type": "resource",
+                            "resource": {
+                                "uri": "file:///data/foo.png",
+                                "text": "x",
+                            },
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+    files = _extract_files_from_stream(response, ["./data/foo.png"])
+    assert files["./data/foo.png"] == b"x"
+
+
 def test_extract_files_path_normalization() -> None:
     """Relative requested paths should still match file:/// URIs."""
     response: dict[str, Any] = {


### PR DESCRIPTION
## Summary

Fixes two bugs in `_extract_files_from_stream` / `_to_relative_path` that make `AgentCoreSandbox.download_files()` silently corrupt binary files and fail to find any path passed with a `./` prefix.

Related: langchain-ai/langchain-aws#1047

## Root cause

### Bug 1 — Double base64 decode of binary blobs

The AgentCore stream deserializes `resource["blob"]` as raw `bytes` before `_extract_files_from_stream` sees it. The code then unconditionally calls `base64.b64decode()`, treating valid binary content as base64-encoded text. With `validate=False` (the default), this silently drops non-base64 bytes and returns a small, corrupt result.

```python
# before
elif "blob" in resource:
    content = base64.b64decode(resource["blob"])  # blob is already bytes
```

Runtime evidence on a 26 KB PNG:

```
type(resource["blob"])       -> <class 'bytes'>
len(resource["blob"])        -> 26340
resource["blob"][:8].hex()  -> '89504e470d0a1a0a'   # valid PNG magic
len(base64.b64decode(resource["blob"])) -> 110      # corrupted output
```

### Bug 2 — `./` paths never match the URI-derived lookup key

`_to_relative_path` stripped leading `/` but not `./`. Worse, `_extract_files_from_stream` had its own inline `path.lstrip(\"/\")` when building `path_lookup`. The result: paths like `\"./data/foo.png\"` were stored in `path_lookup` with the `./` intact, while the URI returned by the API (`file:///data/foo.png`) normalized to `\"data/foo.png\"` — permanent key mismatch, permanent `file_not_found`.

## Fix

- Add a module-level `_normalize_relative_path` that strips both leading `/` and `./` prefixes.
- Use it in both `_to_relative_path` and `_extract_files_from_stream` (for `path_lookup` keys and the URI-derived `file_path`) so the two sides agree.
- In `_extract_files_from_stream`, only call `base64.b64decode` when the blob is not already `bytes`.

No public API changes.

## Tests

New unit tests (all 50 unit tests pass, `ruff check` and `ruff format --check` clean):

- `test_extract_files_blob_already_bytes` — raw-bytes blob is returned verbatim, not double-decoded.
- `test_extract_files_dot_slash_path` — `./`-prefixed requested path matches the URI-derived key.
- `test_download_files_dot_slash_path` — end-to-end: `download_files([\"./data/foo.png\"])` returns the original bytes with `error=None` and calls `readFiles` with the normalized `\"data/foo.png\"`.
- `test_relative_path_strips_dot_slash` — covers `./`, repeated `././`, and `/./` prefixes.

The existing `test_extract_files_blob_resource` (base64-encoded `str` path) still passes, confirming both blob shapes are handled.

## Checklist

- [x] Tests added for both bugs
- [x] `_extract_files_from_stream` handles both `bytes` and `str` blob
- [x] `_to_relative_path` handles `./`, `././`, and `/` prefixes
- [x] `path_lookup` and URI-derived path use the same normalization
- [x] No change to public API surface
- [x] `ruff check` / `ruff format --check` pass