### PR TITLE
test(aws): make `test_tool_use_with_cache_point` deterministic

### DIFF
--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
@@ -355,6 +355,12 @@ def test_tool_use_with_cache_point() -> None:
     # Define a large number of tools to exceed 1024 tokens
     tool_classes = []
 
+    # Bedrock dedupes byte-identical cache prefixes across separate calls for the
+    # cache TTL (5m default), so a re-run within that window would return a cache
+    # read instead of a write and break the assertion below. Salt one tool's
+    # docstring with a per-run unique value so each run sends a fresh prefix.
+    session = uuid4().hex
+
     # Each tool is simple but we'll define many of them
     for i in range(1, 20):
         # Creating a unique class for each tool
@@ -369,7 +375,10 @@ def test_tool_use_with_cache_point() -> None:
                     description=f"Operation {i} to perform on the numbers"
                 )
 
-            ToolClass.__doc__ = f"A tool to calculate the {i}th mathematical operation"
+            ToolClass.__doc__ = (
+                f"A tool to calculate the {i}th mathematical operation "
+                f"(session {session})"
+            )
             return ToolClass
 
         tool_class = create_tool_class(i)


### PR DESCRIPTION
`test_tool_use_with_cache_point` in `ChatBedrockConverse`'s integration suite asserts `cache_creation > 0` on the first call. The Converse API dedupes byte-identical cache prefixes across separate calls in the same account/region for the cache TTL (5 minutes by default for Claude). When CI re-runs within that window, the "first call" comes back as a cache read (`cacheReadInputTokens > 0`, `cacheWriteInputTokens == 0`) and the assertion fails — confirmed by AWS: there is no `cachePoint` knob to force a write, the only options are waiting out the TTL or mutating the prefix.

Salt one of the cached tools' docstrings with a per-run `uuid4().hex`, mirroring the pattern already used by `_LONG_SYSTEM_PROMPT` for the same reason. Each run now sends a fresh prefix, so the cache write is deterministic without changing what the test exercises.