### PR TITLE
test(aws): fix yaml parse error in `test_request_headers`

### DIFF
--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
@@ -7,7 +7,6 @@ from uuid import uuid4
 
 import httpx
 import pytest
-import yaml  # type: ignore[import-untyped]
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import (
     AIMessage,
@@ -1059,7 +1058,7 @@ def test_request_headers(tmp_path: Any, streaming: bool) -> None:
     cassette_path = tmp_path / "headers.yaml"
 
     vcr = VCR(record_mode="all")
-    with vcr.use_cassette(str(cassette_path)):
+    with vcr.use_cassette(str(cassette_path)) as cassette:
         model = ChatBedrockConverse(
             model="us.anthropic.claude-haiku-4-5-20251001-v1:0",
             default_headers={"X-Foo": "Bar"},
@@ -1069,12 +1068,9 @@ def test_request_headers(tmp_path: Any, streaming: bool) -> None:
         else:
             _ = model.invoke("hi")
 
-    cassette = yaml.safe_load(cassette_path.read_text())
-    interactions = cassette["interactions"]
-    request = interactions[0]["request"]
-    headers = request["headers"]
+        headers = cassette.requests[0].headers
 
-    assert headers["X-Foo"] == ["Bar"]
+    assert headers["X-Foo"] == "Bar"
 
 
 # --- Native structured outputs integration tests ---


### PR DESCRIPTION
`test_request_headers` re-parsed its VCR cassette with `yaml.safe_load`, which fails when the recorded request body is a `_io.BytesIO` object (serialized with Python-specific YAML tags). Read headers directly from the in-memory `Cassette.requests` API instead.

## Changes
- Inspect `cassette.requests[0].headers` inside the `vcr.use_cassette(...) as cassette` block; drop the `yaml.safe_load` cassette re-parse and the now-unused `yaml` import.
- Update the assertion from `["Bar"]` to `"Bar"` — VCR's in-memory `Request.headers` is a `dict[str, str]`, not the list form the YAML serializer emits.