### PR TITLE
test(aws): make `ChatAnthropicBedrock` region tests hermetic

### DIFF
--- a/libs/aws/tests/unit_tests/chat_models/test_anthropic.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_anthropic.py
@@ -236,6 +236,7 @@ def test_chat_anthropic_bedrock_get_ls_params() -> None:
 def test_chat_anthropic_bedrock_region_inference_from_env() -> None:
     """Test ChatAnthropicBedrock region inference from environment variables."""
     with MonkeyPatch().context() as m:
+        m.delenv("AWS_DEFAULT_REGION", raising=False)
         m.setenv("AWS_REGION", "us-west-2")
         model = ChatAnthropicBedrock(  # type: ignore[call-arg]
             model=BEDROCK_MODEL_NAME,
@@ -249,6 +250,7 @@ def test_chat_anthropic_bedrock_region_inference_from_env() -> None:
 def test_chat_anthropic_bedrock_region_inference_from_default_env() -> None:
     """Test ChatAnthropicBedrock region inference from AWS_DEFAULT_REGION."""
     with MonkeyPatch().context() as m:
+        m.delenv("AWS_REGION", raising=False)
         m.setenv("AWS_DEFAULT_REGION", "eu-west-1")
         model = ChatAnthropicBedrock(  # type: ignore[call-arg]
             model=BEDROCK_MODEL_NAME,


### PR DESCRIPTION
The region-inference tests only `setenv` the variable they care about, leaving the other AWS region env var inherited from the developer's shell. When `AWS_REGION` is set in the shell, it shadows the test's `AWS_DEFAULT_REGION` (boto3's resolution order), so `test_chat_anthropic_bedrock_region_inference_from_default_env` fails locally with the shell's region instead of `eu-west-1`.