### PR TITLE
test(aws): make `test_request_headers` robust to credential-resolution requests

### DIFF
--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
@@ -1068,7 +1068,15 @@ def test_request_headers(tmp_path: Any, streaming: bool) -> None:
         else:
             _ = model.invoke("hi")
 
-        headers = cassette.requests[0].headers
+        # Credential resolution (STS/SSO/IMDS) can produce VCR-captured
+        # requests that precede the Converse call; the custom-headers hook
+        # is only registered for bedrock-runtime Converse/ConverseStream,
+        # so pick the matching request rather than indexing position 0.
+        converse_requests = [
+            r for r in cassette.requests if "bedrock-runtime" in r.uri
+        ]
+        assert converse_requests, "no bedrock-runtime request captured"
+        headers = converse_requests[0].headers
 
     assert headers["X-Foo"] == "Bar"
 

--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
@@ -1072,9 +1072,7 @@ def test_request_headers(tmp_path: Any, streaming: bool) -> None:
         # requests that precede the Converse call; the custom-headers hook
         # is only registered for bedrock-runtime Converse/ConverseStream,
         # so pick the matching request rather than indexing position 0.
-        converse_requests = [
-            r for r in cassette.requests if "bedrock-runtime" in r.uri
-        ]
+        converse_requests = [r for r in cassette.requests if "bedrock-runtime" in r.uri]
         assert converse_requests, "no bedrock-runtime request captured"
         headers = converse_requests[0].headers
 


### PR DESCRIPTION
`test_request_headers` indexed `cassette.requests[0]`, but VCR's HTTPConnection patch captures every HTTP request inside the cassette block — including STS/SSO/IMDS calls made during AWS credential resolution. When those land first, the assertion blew up with `KeyError: 'x-foo'` because the `default_headers` hook is only registered for `bedrock-runtime.Converse`/`ConverseStream`.