### PR TITLE
test(aws): silence pending deprecation and PDF user warnings in test runs

### DIFF
--- a/libs/aws/pyproject.toml
+++ b/libs/aws/pyproject.toml
@@ -41,6 +41,7 @@ test = [
     "langchain-classic>=1.0.0",
     "langchain-tests>=1.1.3",
     "langchain>=1.0.0",
+    "langgraph-checkpoint>=4.1.0",
     "bedrock-agentcore>=1.4.0",
     "playwright>=1.53.0",
     "beautifulsoup4>=4.13.4",

--- a/libs/aws/tests/conftest.py
+++ b/libs/aws/tests/conftest.py
@@ -1,8 +1,7 @@
 from typing import Any
 
 import pytest
-from langchain_tests.conftest import CustomPersister, CustomSerializer
-from langchain_tests.conftest import _base_vcr_config as _base_vcr_config
+from langchain_tests.conftest import CustomPersister, CustomSerializer, base_vcr_config
 from vcr import VCR  # type: ignore[import-untyped]
 
 
@@ -19,9 +18,9 @@ def remove_response_headers(response: dict) -> dict:
 
 
 @pytest.fixture(scope="session")
-def vcr_config(_base_vcr_config: dict) -> dict:  # noqa: F811
+def vcr_config() -> dict:
     """Extend the default configuration coming from langchain_tests."""
-    config = _base_vcr_config.copy()
+    config = base_vcr_config().copy()
     config["before_record_request"] = remove_request_headers
     config["before_record_response"] = remove_response_headers
     config["serializer"] = "yaml.gz"

--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
@@ -2,6 +2,7 @@
 
 import base64
 import time
+import warnings
 from typing import Any, Literal, Optional, Type
 from uuid import uuid4
 
@@ -45,6 +46,18 @@ class TestBedrockStandard(ChatModelIntegrationTests):
     @property
     def supports_pdf_tool_message(self) -> bool:
         return True
+
+    def test_pdf_tool_message(self, model: BaseChatModel) -> None:
+        # The standard test sends a PDF without a filename, which intentionally
+        # triggers a UserWarning from `_format_data_content_block`. Suppress it
+        # so test output stays clean.
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="Bedrock Converse may require a filename for file inputs.*",
+                category=UserWarning,
+            )
+            super().test_pdf_tool_message(model)
 
 
 class TestBedrockMistralStandard(ChatModelIntegrationTests):

--- a/libs/aws/uv.lock
+++ b/libs/aws/uv.lock
@@ -1038,6 +1038,7 @@ test = [
     { name = "langchain-anthropic" },
     { name = "langchain-classic" },
     { name = "langchain-tests" },
+    { name = "langgraph-checkpoint" },
     { name = "playwright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -1087,6 +1088,7 @@ test = [
     { name = "langchain-anthropic" },
     { name = "langchain-classic", specifier = ">=1.0.0" },
     { name = "langchain-tests", specifier = ">=1.1.3" },
+    { name = "langgraph-checkpoint", specifier = ">=4.1.0" },
     { name = "playwright", specifier = ">=1.53.0" },
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "pytest-asyncio", specifier = ">=0.20,<2" },
@@ -1212,15 +1214,15 @@ wheels = [
 
 [[package]]
 name = "langgraph-checkpoint"
-version = "4.0.1"
+version = "4.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "ormsgpack" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/44/a8df45d1e8b4637e29789fa8bae1db022c953cc7ac80093cfc52e923547e/langgraph_checkpoint-4.0.1.tar.gz", hash = "sha256:b433123735df11ade28829e40ce25b9be614930cd50245ff2af60629234befd9", size = 158135, upload-time = "2026-02-27T21:06:16.092Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/47/886af6f886f0bff2273164a45f008694e48a96ff3cd25ff0228f2aa9480e/langgraph_checkpoint-4.1.1.tar.gz", hash = "sha256:6c2bdb530c91f91d7d9c1bd100925d0fc4f498d418c17f3587d1526279482a25", size = 184020, upload-time = "2026-05-22T16:57:38.503Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/4c/09a4a0c42f5d2fc38d6c4d67884788eff7fd2cfdf367fdf7033de908b4c0/langgraph_checkpoint-4.0.1-py3-none-any.whl", hash = "sha256:e3adcd7a0e0166f3b48b8cf508ce0ea366e7420b5a73aa81289888727769b034", size = 50453, upload-time = "2026-02-27T21:06:14.293Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/b4/71425e3e38be92611300b9cc5e46a5bf98ab23f5ea8a75b73d02a2f1413c/langgraph_checkpoint-4.1.1-py3-none-any.whl", hash = "sha256:25d29144b082827218e7bc3f1e9b0566a4bb007895cd6cc26f66a8428739f56e", size = 56212, upload-time = "2026-05-22T16:57:37.203Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Clean up two noisy warnings emitted during the `libs/aws` test session: the `LangChainPendingDeprecationWarning` about `allowed_objects` defaults (from `langgraph.checkpoint.serde.jsonplus`'s module-scope `Reviver()`), and the intentional `UserWarning` raised by `_format_data_content_block` when the standard PDF tool-message test sends a file without a name. Also migrates the VCR conftest off the deprecated `_base_vcr_config` fixture.