### PR TITLE
feat(aws): Set default Valkey client name if not provided by user

### DIFF
--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/agentcore/valkey/saver.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/agentcore/valkey/saver.py
@@ -31,7 +31,7 @@ from valkey.asyncio import Valkey as AsyncValkey
 from valkey.connection import ConnectionPool
 from valkey.exceptions import ConnectionError, TimeoutError, ValkeyError
 
-from ...checkpoint.valkey.utils import set_client_info
+from ...checkpoint.valkey.utils import set_client_info, set_client_name
 from ..constants import InvalidConfigError
 from ..helpers import EventSerializer
 from .models import (
@@ -101,6 +101,7 @@ class AgentCoreValkeySaver(BaseCheckpointSaver[str]):
         # Set client info for library identification
         if not self.is_async:
             set_client_info(client)
+            set_client_name(client)
 
         # Validate configuration
         if ttl is not None and ttl <= 0:

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/cache/valkey/cache.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/cache/valkey/cache.py
@@ -21,7 +21,7 @@ except ImportError as e:
         "Install it with: pip install 'langgraph-checkpoint-aws[valkey]'"
     ) from e
 
-from ...checkpoint.valkey.utils import set_client_info
+from ...checkpoint.valkey.utils import set_client_info, set_client_name
 
 if TYPE_CHECKING:
     pass
@@ -112,6 +112,7 @@ class ValkeyCache(BaseCache[ValueT]):
         self.prefix = prefix
         self.ttl = int(ttl) if ttl else None
         set_client_info(client)
+        set_client_name(client)
 
     @classmethod
     @contextmanager

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/valkey/async_saver.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/valkey/async_saver.py
@@ -19,7 +19,7 @@ from langgraph.checkpoint.base import (
 from langgraph.checkpoint.serde.base import SerializerProtocol
 
 from .base import BaseValkeySaver
-from .utils import aset_client_info
+from .utils import aset_client_info, aset_client_name
 
 # Conditional imports for optional dependencies
 try:
@@ -131,6 +131,7 @@ class AsyncValkeySaver(BaseValkeySaver):
         try:
             # Set client info for library identification
             await aset_client_info(client)
+            await aset_client_name(client)
             yield cls(client, ttl=ttl_seconds, serde=serde)
         finally:
             await client.aclose()
@@ -166,6 +167,7 @@ class AsyncValkeySaver(BaseValkeySaver):
         try:
             # Set client info for library identification
             await aset_client_info(client)
+            await aset_client_name(client)
             yield cls(client, ttl=ttl_seconds)
         finally:
             await client.aclose()

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/valkey/base.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/valkey/base.py
@@ -19,7 +19,7 @@ from langgraph.checkpoint.base import (
     get_checkpoint_metadata,
 )
 
-from .utils import set_client_info
+from .utils import set_client_info, set_client_name
 
 
 class BaseValkeySaver(BaseCheckpointSaver[str]):
@@ -56,6 +56,7 @@ class BaseValkeySaver(BaseCheckpointSaver[str]):
         else:
             # This is a sync client, safe to call set_client_info
             set_client_info(client)
+            set_client_name(client)
 
     def _make_checkpoint_key(
         self, thread_id: str, checkpoint_ns: str, checkpoint_id: str

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/valkey/utils.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/valkey/utils.py
@@ -37,6 +37,25 @@ def set_client_info(client: Any) -> None:
         logger.debug(f"Failed to set client info: {e}")
 
 
+def set_client_name(client: Any) -> None:
+    """Set a default CLIENT SETNAME if one has not already been set by the user.
+
+    This makes the connection identifiable in CLIENT LIST output and monitoring
+    tools. If the user already set a client_name on the Valkey client, this is
+    a no-op.
+
+    Args:
+        client: Valkey client instance (sync or async)
+    """
+    try:
+        current_name = client.execute_command("CLIENT", "GETNAME")
+        if not current_name:
+            client.execute_command("CLIENT", "SETNAME", LIBRARY_NAME)
+            logger.debug(f"Set client name: {LIBRARY_NAME}")
+    except Exception as e:
+        logger.debug(f"Failed to set client name: {e}")
+
+
 async def aset_client_info(client: Any) -> None:
     """Set CLIENT SETINFO for library name and version on an async Valkey client.
 
@@ -55,3 +74,22 @@ async def aset_client_info(client: Any) -> None:
     except Exception as e:
         # Don't fail if CLIENT SETINFO is not supported or fails
         logger.debug(f"Failed to set client info: {e}")
+
+
+async def aset_client_name(client: Any) -> None:
+    """Set a default CLIENT SETNAME if one has not already been set by the user.
+
+    This makes the connection identifiable in CLIENT LIST output and monitoring
+    tools. If the user already set a client_name on the Valkey client, this is
+    a no-op.
+
+    Args:
+        client: Async Valkey client instance
+    """
+    try:
+        current_name = await client.execute_command("CLIENT", "GETNAME")
+        if not current_name:
+            await client.execute_command("CLIENT", "SETNAME", LIBRARY_NAME)
+            logger.debug(f"Set client name: {LIBRARY_NAME}")
+    except Exception as e:
+        logger.debug(f"Failed to set client name: {e}")

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/store/valkey/async_store.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/store/valkey/async_store.py
@@ -27,7 +27,7 @@ from langgraph.store.base.embed import get_text_at_path
 from valkey import Valkey
 from valkey.connection import ConnectionPool
 
-from ...checkpoint.valkey.utils import aset_client_info
+from ...checkpoint.valkey.utils import aset_client_info, aset_client_name
 from .base import BaseValkeyStore, ValkeyIndexConfig
 from .document_utils import DocumentProcessor, FilterProcessor, ScoreCalculator
 from .exceptions import EmbeddingGenerationError
@@ -302,6 +302,7 @@ class AsyncValkeyStore(BaseValkeyStore):
                 client = Valkey.from_url(conn_string)
 
             await aset_client_info(client)
+            await aset_client_name(client)
             store = cls(client, index=index, ttl=ttl)
             yield store
         finally:
@@ -326,6 +327,7 @@ class AsyncValkeyStore(BaseValkeyStore):
         try:
             client = Valkey.from_pool(connection_pool=pool)
             await aset_client_info(client)
+            await aset_client_name(client)
             store = cls(client, index=index, ttl=ttl)
             yield store
         finally:

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/store/valkey/base.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/store/valkey/base.py
@@ -24,7 +24,7 @@ from langgraph.store.base.embed import ensure_embeddings
 from valkey import Valkey
 from valkey.connection import ConnectionPool
 
-from ...checkpoint.valkey.utils import aset_client_info, set_client_info
+from ...checkpoint.valkey.utils import aset_client_info, set_client_info, set_client_name
 from .constants import (
     DEFAULT_COLLECTION_NAME,
     DEFAULT_DISTANCE_METRIC,
@@ -146,6 +146,7 @@ class BaseValkeyStore(BaseStore):
             # This is a sync client, safe to call set_client_info
             try:
                 set_client_info(client)
+                set_client_name(client)
             except Exception as e:
                 raise ValkeyConnectionError(f"Failed to set client info: {e}") from e
 

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/store/valkey/base.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/store/valkey/base.py
@@ -24,7 +24,11 @@ from langgraph.store.base.embed import ensure_embeddings
 from valkey import Valkey
 from valkey.connection import ConnectionPool
 
-from ...checkpoint.valkey.utils import aset_client_info, set_client_info, set_client_name
+from ...checkpoint.valkey.utils import (
+    aset_client_info,
+    set_client_info,
+    set_client_name,
+)
 from .constants import (
     DEFAULT_COLLECTION_NAME,
     DEFAULT_DISTANCE_METRIC,

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/store/valkey/store.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/store/valkey/store.py
@@ -262,9 +262,10 @@ class ValkeyStore(BaseValkeyStore):
                 client = Valkey.from_url(conn_string)
 
             # Set client info for library identification
-            from ...checkpoint.valkey.utils import set_client_info
+            from ...checkpoint.valkey.utils import set_client_info, set_client_name
 
             set_client_info(client)
+            set_client_name(client)
 
             store = cls(client, index=index, ttl=ttl)
             yield store
@@ -338,9 +339,10 @@ class ValkeyStore(BaseValkeyStore):
         try:
             client = Valkey.from_pool(connection_pool=pool)
             # Set client info for library identification
-            from ...checkpoint.valkey.utils import set_client_info
+            from ...checkpoint.valkey.utils import set_client_info, set_client_name
 
             set_client_info(client)
+            set_client_name(client)
 
             store = cls(client, index=index, ttl=ttl)
             yield store

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/store/valkey/test_valkey_client_setinfo_unit.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/store/valkey/test_valkey_client_setinfo_unit.py
@@ -24,7 +24,9 @@ from langgraph_checkpoint_aws.checkpoint.valkey.utils import (
     LIBRARY_NAME,
     LIBRARY_VERSION,
     aset_client_info,
+    aset_client_name,
     set_client_info,
+    set_client_name,
 )
 
 
@@ -130,36 +132,116 @@ class TestClientSetInfoUtils:
         )
 
 
-class TestSaverClientSetInfo:
-    """Test CLIENT SETINFO is called in checkpoint savers."""
+class TestClientSetName:
+    """Test the CLIENT SETNAME utility functions."""
 
+    def test_set_client_name_when_no_name_set(self, mock_valkey_client: Mock):
+        """Test that set_client_name sets the name when none is set."""
+        mock_valkey_client.execute_command.return_value = None
+
+        set_client_name(mock_valkey_client)
+
+        expected_calls = [
+            call("CLIENT", "GETNAME"),
+            call("CLIENT", "SETNAME", LIBRARY_NAME),
+        ]
+        mock_valkey_client.execute_command.assert_has_calls(expected_calls)
+
+    def test_set_client_name_preserves_existing_name(self, mock_valkey_client: Mock):
+        """Test that set_client_name does not overwrite a user-set name."""
+        mock_valkey_client.execute_command.return_value = "my-app"
+
+        set_client_name(mock_valkey_client)
+
+        mock_valkey_client.execute_command.assert_called_once_with(
+            "CLIENT", "GETNAME"
+        )
+
+    def test_set_client_name_failure_handling(self, mock_valkey_client: Mock):
+        """Test that set_client_name handles failures gracefully."""
+        mock_valkey_client.execute_command.side_effect = Exception("Command failed")
+
+        # Should not raise an exception
+        set_client_name(mock_valkey_client)
+
+    @pytest.mark.asyncio
+    async def test_aset_client_name_when_no_name_set(
+        self, mock_async_valkey_client: AsyncMock
+    ):
+        """Test that aset_client_name sets the name when none is set."""
+        mock_async_valkey_client.execute_command.return_value = None
+
+        await aset_client_name(mock_async_valkey_client)
+
+        expected_calls = [
+            call("CLIENT", "GETNAME"),
+            call("CLIENT", "SETNAME", LIBRARY_NAME),
+        ]
+        mock_async_valkey_client.execute_command.assert_has_calls(expected_calls)
+
+    @pytest.mark.asyncio
+    async def test_aset_client_name_preserves_existing_name(
+        self, mock_async_valkey_client: AsyncMock
+    ):
+        """Test that aset_client_name does not overwrite a user-set name."""
+        mock_async_valkey_client.execute_command.return_value = "my-app"
+
+        await aset_client_name(mock_async_valkey_client)
+
+        mock_async_valkey_client.execute_command.assert_called_once_with(
+            "CLIENT", "GETNAME"
+        )
+
+    @pytest.mark.asyncio
+    async def test_aset_client_name_failure_handling(
+        self, mock_async_valkey_client: AsyncMock
+    ):
+        """Test that aset_client_name handles failures gracefully."""
+
+        async def failing_command(*args, **kwargs):
+            raise Exception("Command failed")
+
+        mock_async_valkey_client.execute_command.side_effect = failing_command
+
+        # Should not raise an exception
+        await aset_client_name(mock_async_valkey_client)
+
+
+class TestSaverClientSetInfo:
+    """Test CLIENT SETINFO and SETNAME are called in checkpoint savers."""
+
+    @patch("langgraph_checkpoint_aws.checkpoint.valkey.base.set_client_name")
     @patch("langgraph_checkpoint_aws.checkpoint.valkey.base.set_client_info")
     def test_sync_saver_direct_init(
-        self, mock_set_client_info: Mock, mock_valkey_client: Mock
+        self, mock_set_client_info: Mock, mock_set_client_name: Mock,
+        mock_valkey_client: Mock
     ):
-        """Test CLIENT SETINFO is called when directly initializing
+        """Test CLIENT SETINFO and SETNAME are called when directly initializing
         ValkeySaver."""
         ValkeySaver(mock_valkey_client)
         mock_set_client_info.assert_called_once_with(mock_valkey_client)
+        mock_set_client_name.assert_called_once_with(mock_valkey_client)
 
+    @patch("langgraph_checkpoint_aws.checkpoint.valkey.base.set_client_name")
     @patch("langgraph_checkpoint_aws.checkpoint.valkey.base.set_client_info")
     def test_async_saver_direct_init(
-        self, mock_set_client_info: Mock, mock_async_valkey_client: Mock
+        self, mock_set_client_info: Mock, mock_set_client_name: Mock,
+        mock_async_valkey_client: Mock
     ):
-        """Test CLIENT SETINFO is NOT called when directly initializing
+        """Test CLIENT SETINFO/SETNAME are NOT called when directly initializing
         AsyncValkeySaver with async client."""
         AsyncValkeySaver(mock_async_valkey_client)
 
-        # set_client_info should NOT be called for async clients to avoid
-        # unawaited coroutines
-        # The base class should detect the async client and skip the sync
-        # set_client_info call
+        # Should NOT be called for async clients to avoid unawaited coroutines
         mock_set_client_info.assert_not_called()
+        mock_set_client_name.assert_not_called()
 
     @patch("valkey.connection.ConnectionPool.from_url")
+    @patch("langgraph_checkpoint_aws.checkpoint.valkey.base.set_client_name")
     @patch("langgraph_checkpoint_aws.checkpoint.valkey.base.set_client_info")
     def test_sync_saver_from_conn_string(
-        self, mock_set_client_info: Mock, mock_pool_from_url: Mock, valkey_url: str
+        self, mock_set_client_info: Mock, mock_set_client_name: Mock,
+        mock_pool_from_url: Mock, valkey_url: str
     ):
         # Set up mock pool with required attributes
         mock_pool = Mock(spec=ConnectionPool)
@@ -174,67 +256,78 @@ class TestSaverClientSetInfo:
 
             with ValkeySaver.from_conn_string(valkey_url) as saver:
                 # Should be called once: only in __init__ (base class)
-                # The actual client passed will be the real Valkey instance,
-                # not our mock
                 mock_set_client_info.assert_called_once()
+                mock_set_client_name.assert_called_once()
                 assert saver is not None
 
     @patch("valkey.asyncio.Valkey.from_url")
+    @patch("langgraph_checkpoint_aws.checkpoint.valkey.async_saver.aset_client_name")
     @patch("langgraph_checkpoint_aws.checkpoint.valkey.async_saver.aset_client_info")
+    @patch("langgraph_checkpoint_aws.checkpoint.valkey.base.set_client_name")
     @patch("langgraph_checkpoint_aws.checkpoint.valkey.base.set_client_info")
     @pytest.mark.asyncio
     async def test_async_saver_from_conn_string(
         self,
         mock_set_client_info: Mock,
+        mock_set_client_name: Mock,
         mock_aset_client_info: AsyncMock,
+        mock_aset_client_name: AsyncMock,
         mock_from_url: Mock,
         valkey_url: str,
     ):
-        """Test CLIENT SETINFO is called when using async from_conn_string."""
+        """Test CLIENT SETINFO and SETNAME are called when using async
+        from_conn_string."""
         mock_client = AsyncMock(spec=AsyncValkey)
         mock_client.aclose = AsyncMock()
         mock_from_url.return_value = mock_client
 
         async with AsyncValkeySaver.from_conn_string(valkey_url):
             # Should be called in from_conn_string but NOT in __init__
-            # (async client detection)
             mock_aset_client_info.assert_called_once_with(mock_client)
-            # set_client_info should NOT be called for async clients to avoid
-            # unawaited coroutines
+            mock_aset_client_name.assert_called_once_with(mock_client)
+            # Sync versions should NOT be called for async clients
             mock_set_client_info.assert_not_called()
+            mock_set_client_name.assert_not_called()
 
 
 class TestStoreClientSetInfo:
-    """Test CLIENT SETINFO is called in store implementations."""
+    """Test CLIENT SETINFO and SETNAME are called in store implementations."""
 
+    @patch("langgraph_checkpoint_aws.store.valkey.base.set_client_name")
     @patch("langgraph_checkpoint_aws.store.valkey.base.set_client_info")
     def test_sync_store_direct_init(
-        self, mock_set_client_info: Mock, mock_valkey_client: Mock
+        self, mock_set_client_info: Mock, mock_set_client_name: Mock,
+        mock_valkey_client: Mock
     ):
-        """Test CLIENT SETINFO is called when directly initializing ValkeyStore."""
+        """Test CLIENT SETINFO and SETNAME are called when directly initializing
+        ValkeyStore."""
         ValkeyStore(mock_valkey_client)
         mock_set_client_info.assert_called_once_with(mock_valkey_client)
+        mock_set_client_name.assert_called_once_with(mock_valkey_client)
 
+    @patch("langgraph_checkpoint_aws.store.valkey.base.set_client_name")
     @patch("langgraph_checkpoint_aws.store.valkey.base.set_client_info")
     def test_async_store_direct_init(
-        self, mock_set_client_info: Mock, mock_async_valkey_client: Mock
+        self, mock_set_client_info: Mock, mock_set_client_name: Mock,
+        mock_async_valkey_client: Mock
     ):
-        """Test CLIENT SETINFO is NOT called when directly initializing
+        """Test CLIENT SETINFO/SETNAME are NOT called when directly initializing
         AsyncValkeyStore with async client."""
         AsyncValkeyStore(mock_async_valkey_client)
 
-        # set_client_info should NOT be called for async clients to avoid
-        # unawaited coroutines
-        # The base class should detect the async client and skip the sync
-        # set_client_info call
+        # Should NOT be called for async clients
         mock_set_client_info.assert_not_called()
+        mock_set_client_name.assert_not_called()
 
     @patch("valkey.Valkey.from_url")
+    @patch("langgraph_checkpoint_aws.store.valkey.base.set_client_name")
     @patch("langgraph_checkpoint_aws.store.valkey.base.set_client_info")
     def test_sync_store_from_conn_string(
-        self, mock_set_client_info: Mock, mock_from_url: Mock, valkey_url: str
+        self, mock_set_client_info: Mock, mock_set_client_name: Mock,
+        mock_from_url: Mock, valkey_url: str
     ):
-        """Test CLIENT SETINFO is called when using store from_conn_string."""
+        """Test CLIENT SETINFO and SETNAME are called when using store
+        from_conn_string."""
         mock_client = Mock(spec=Valkey)
         mock_client.__enter__ = Mock(return_value=mock_client)
         mock_client.__exit__ = Mock(return_value=None)
@@ -243,6 +336,7 @@ class TestStoreClientSetInfo:
         with ValkeyStore.from_conn_string(valkey_url) as store:
             # Should be called once: only in __init__ (base class)
             mock_set_client_info.assert_called_once_with(mock_client)
+            mock_set_client_name.assert_called_once_with(mock_client)
             assert store is not None
 
 

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/store/valkey/test_valkey_client_setinfo_unit.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/store/valkey/test_valkey_client_setinfo_unit.py
@@ -153,9 +153,7 @@ class TestClientSetName:
 
         set_client_name(mock_valkey_client)
 
-        mock_valkey_client.execute_command.assert_called_once_with(
-            "CLIENT", "GETNAME"
-        )
+        mock_valkey_client.execute_command.assert_called_once_with("CLIENT", "GETNAME")
 
     def test_set_client_name_failure_handling(self, mock_valkey_client: Mock):
         """Test that set_client_name handles failures gracefully."""
@@ -213,8 +211,10 @@ class TestSaverClientSetInfo:
     @patch("langgraph_checkpoint_aws.checkpoint.valkey.base.set_client_name")
     @patch("langgraph_checkpoint_aws.checkpoint.valkey.base.set_client_info")
     def test_sync_saver_direct_init(
-        self, mock_set_client_info: Mock, mock_set_client_name: Mock,
-        mock_valkey_client: Mock
+        self,
+        mock_set_client_info: Mock,
+        mock_set_client_name: Mock,
+        mock_valkey_client: Mock,
     ):
         """Test CLIENT SETINFO and SETNAME are called when directly initializing
         ValkeySaver."""
@@ -225,8 +225,10 @@ class TestSaverClientSetInfo:
     @patch("langgraph_checkpoint_aws.checkpoint.valkey.base.set_client_name")
     @patch("langgraph_checkpoint_aws.checkpoint.valkey.base.set_client_info")
     def test_async_saver_direct_init(
-        self, mock_set_client_info: Mock, mock_set_client_name: Mock,
-        mock_async_valkey_client: Mock
+        self,
+        mock_set_client_info: Mock,
+        mock_set_client_name: Mock,
+        mock_async_valkey_client: Mock,
     ):
         """Test CLIENT SETINFO/SETNAME are NOT called when directly initializing
         AsyncValkeySaver with async client."""
@@ -240,8 +242,11 @@ class TestSaverClientSetInfo:
     @patch("langgraph_checkpoint_aws.checkpoint.valkey.base.set_client_name")
     @patch("langgraph_checkpoint_aws.checkpoint.valkey.base.set_client_info")
     def test_sync_saver_from_conn_string(
-        self, mock_set_client_info: Mock, mock_set_client_name: Mock,
-        mock_pool_from_url: Mock, valkey_url: str
+        self,
+        mock_set_client_info: Mock,
+        mock_set_client_name: Mock,
+        mock_pool_from_url: Mock,
+        valkey_url: str,
     ):
         # Set up mock pool with required attributes
         mock_pool = Mock(spec=ConnectionPool)
@@ -296,8 +301,10 @@ class TestStoreClientSetInfo:
     @patch("langgraph_checkpoint_aws.store.valkey.base.set_client_name")
     @patch("langgraph_checkpoint_aws.store.valkey.base.set_client_info")
     def test_sync_store_direct_init(
-        self, mock_set_client_info: Mock, mock_set_client_name: Mock,
-        mock_valkey_client: Mock
+        self,
+        mock_set_client_info: Mock,
+        mock_set_client_name: Mock,
+        mock_valkey_client: Mock,
     ):
         """Test CLIENT SETINFO and SETNAME are called when directly initializing
         ValkeyStore."""
@@ -308,8 +315,10 @@ class TestStoreClientSetInfo:
     @patch("langgraph_checkpoint_aws.store.valkey.base.set_client_name")
     @patch("langgraph_checkpoint_aws.store.valkey.base.set_client_info")
     def test_async_store_direct_init(
-        self, mock_set_client_info: Mock, mock_set_client_name: Mock,
-        mock_async_valkey_client: Mock
+        self,
+        mock_set_client_info: Mock,
+        mock_set_client_name: Mock,
+        mock_async_valkey_client: Mock,
     ):
         """Test CLIENT SETINFO/SETNAME are NOT called when directly initializing
         AsyncValkeyStore with async client."""
@@ -323,8 +332,11 @@ class TestStoreClientSetInfo:
     @patch("langgraph_checkpoint_aws.store.valkey.base.set_client_name")
     @patch("langgraph_checkpoint_aws.store.valkey.base.set_client_info")
     def test_sync_store_from_conn_string(
-        self, mock_set_client_info: Mock, mock_set_client_name: Mock,
-        mock_from_url: Mock, valkey_url: str
+        self,
+        mock_set_client_info: Mock,
+        mock_set_client_name: Mock,
+        mock_from_url: Mock,
+        valkey_url: str,
     ):
         """Test CLIENT SETINFO and SETNAME are called when using store
         from_conn_string."""


### PR DESCRIPTION
Closes: #1064

Updates `ValkeyCache`/`ValkeyStore`/`ValkeySaver`/`AgentCoreValkeySaver` to set a default client name (`langgraph_checkpoint_aws`) for Valkey connections, if one has not already been provided by the user.

Note that this is primarily relevant for our `from_conn_string` and `from_pool` factory methods which create a Valkey client  internally, and don't give users an opportunity to pass the client name at construction time. For other cases where users provide their own Valkey client, and set a custom `client_name`, we will catch this with a `CLIENT GETNAME` call and preserve the existing client name.
