### PR TITLE
test(aws): scope PDF filename warning filter via pytestmark

### DIFF
--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
@@ -2,7 +2,6 @@
 
 import base64
 import time
-import warnings
 from typing import Any, Literal, Optional, Type
 from uuid import uuid4
 
@@ -27,6 +26,13 @@ from langchain_aws import ChatBedrockConverse
 
 
 class TestBedrockStandard(ChatModelIntegrationTests):
+    # `_format_data_content_block` intentionally warns when a PDF is sent
+    # without a filename; the standard `test_pdf_tool_message` does exactly
+    # that, so suppress it to keep test output clean.
+    pytestmark = pytest.mark.filterwarnings(
+        "ignore:Bedrock Converse may require a filename for file inputs.*:UserWarning"
+    )
+
     @property
     def chat_model_class(self) -> Type[BaseChatModel]:
         return ChatBedrockConverse
@@ -46,18 +52,6 @@ class TestBedrockStandard(ChatModelIntegrationTests):
     @property
     def supports_pdf_tool_message(self) -> bool:
         return True
-
-    def test_pdf_tool_message(self, model: BaseChatModel) -> None:
-        # The standard test sends a PDF without a filename, which intentionally
-        # triggers a UserWarning from `_format_data_content_block`. Suppress it
-        # so test output stays clean.
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                message="Bedrock Converse may require a filename for file inputs.*",
-                category=UserWarning,
-            )
-            super().test_pdf_tool_message(model)
 
 
 class TestBedrockMistralStandard(ChatModelIntegrationTests):


### PR DESCRIPTION
The standard `test_no_overrides_DO_NOT_OVERRIDE` check from `langchain-tests` flagged the previous `test_pdf_tool_message` override (added in #1063 to silence the intentional `UserWarning`) since it carried no `xfail` marker. Replace the override with a class-scoped `pytestmark = pytest.mark.filterwarnings(...)` on `TestBedrockStandard`, keeping the warning suppressed without redefining the inherited test.