### PR TITLE
feat: add CLIENT SETNAME for connection identification

### DIFF
--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/valkey/async_saver.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/valkey/async_saver.py
@@ -128,7 +128,12 @@ class AsyncValkeySaver(BaseValkeySaver):
             ...     # Use the memory instance
             ...     pass
         """
-        client = AsyncValkey.from_url(conn_string, max_connections=pool_size, client_name=DEFAULT_CLIENT_NAME, **kwargs)
+        client = AsyncValkey.from_url(
+            conn_string,
+            max_connections=pool_size,
+            client_name=DEFAULT_CLIENT_NAME,
+            **kwargs,
+        )
         try:
             # Set client info for library identification
             await aset_client_info(client)

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/valkey/async_saver.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/valkey/async_saver.py
@@ -19,6 +19,7 @@ from langgraph.checkpoint.base import (
 from langgraph.checkpoint.serde.base import SerializerProtocol
 
 from .base import BaseValkeySaver
+from .saver import DEFAULT_CLIENT_NAME
 from .utils import aset_client_info
 
 # Conditional imports for optional dependencies
@@ -127,7 +128,7 @@ class AsyncValkeySaver(BaseValkeySaver):
             ...     # Use the memory instance
             ...     pass
         """
-        client = AsyncValkey.from_url(conn_string, max_connections=pool_size, **kwargs)
+        client = AsyncValkey.from_url(conn_string, max_connections=pool_size, client_name=DEFAULT_CLIENT_NAME, **kwargs)
         try:
             # Set client info for library identification
             await aset_client_info(client)
@@ -162,7 +163,7 @@ class AsyncValkeySaver(BaseValkeySaver):
             ...     # Use the memory instance
             ...     pass
         """
-        client = AsyncValkey(connection_pool=pool)
+        client = AsyncValkey(connection_pool=pool, client_name=DEFAULT_CLIENT_NAME)
         try:
             # Set client info for library identification
             await aset_client_info(client)

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/valkey/saver.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/valkey/saver.py
@@ -42,6 +42,9 @@ except ImportError as e:
 
 logger = logging.getLogger(__name__)
 
+# Default client name for connection identification via CLIENT SETNAME
+DEFAULT_CLIENT_NAME = "langchain_aws_checkpoint_client"
+
 
 class ValkeySaver(BaseValkeySaver):
     """A checkpoint saver that stores checkpoints in Valkey (Redis-compatible).
@@ -119,7 +122,7 @@ class ValkeySaver(BaseValkeySaver):
         """
         # Create connection pool first, then client
         pool = ConnectionPool.from_url(conn_string, max_connections=pool_size)
-        client = Valkey(connection_pool=pool, **kwargs)
+        client = Valkey(connection_pool=pool, client_name=DEFAULT_CLIENT_NAME, **kwargs)
         try:
             yield cls(client, ttl=ttl_seconds)
         finally:

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/checkpoint/valkey/test_async_valkey_saver.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/checkpoint/valkey/test_async_valkey_saver.py
@@ -179,7 +179,10 @@ class TestAsyncValkeySaverInit:
             async with AsyncValkeySaver.from_pool(mock_pool, ttl_seconds=3600) as saver:
                 assert saver.client == mock_client
                 assert saver.ttl == 3600.0
-                mock_valkey_class.assert_called_once_with(connection_pool=mock_pool)
+                mock_valkey_class.assert_called_once_with(
+                    connection_pool=mock_pool,
+                    client_name="langchain_aws_checkpoint_client",
+                )
 
     @pytest.mark.asyncio
     @pytest.mark.timeout(10)


### PR DESCRIPTION
## Summary

Adds `client_name="langchain_aws_checkpoint_client"` to the Valkey client
creation in `ValkeySaver.from_conn_string()` and `AsyncValkeySaver` factory
methods. This sends a CLIENT SETNAME command on connection, making the
connection identifiable in CLIENT LIST and monitoring tools.

Fixes #1064

## Changes

- `saver.py`: Added `DEFAULT_CLIENT_NAME` constant, passed `client_name=DEFAULT_CLIENT_NAME` to `Valkey()` in `from_conn_string()`
- `async_saver.py`: Imported `DEFAULT_CLIENT_NAME`, passed it to `AsyncValkey.from_url()` in `from_conn_string()` and `AsyncValkey()` in `from_pool()`

## Motivation

The package already sets `CLIENT SETINFO LIB-NAME` to `langgraph_checkpoint_aws`, but does not set `CLIENT SETNAME`. While LIB-NAME identifies the library, CLIENT SETNAME identifies the connection/application and is visible in:
- `CLIENT LIST` output
- Monitoring dashboards (e.g., Valkey Admin)
- CloudWatch metrics (ElastiCache)

## Risk

Zero-risk — `client_name` is a metadata-only option passed to valkey-py. No behavioral changes.