### PR TITLE
fix(langgraph-checkpoint-aws): run DynamoDBSaver.alist off the event loop

### DIFF
--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/dynamodb/saver.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/dynamodb/saver.py
@@ -475,7 +475,15 @@ class DynamoDBSaver(BaseCheckpointSaver):
         Returns:
             AsyncIterator[CheckpointTuple]: An iterator of checkpoint tuples.
         """
-        for item in self.list(config, filter=filter, before=before, limit=limit):
+        # ``list`` is backed by blocking boto3 calls, so it is driven from a
+        # background thread one item at a time to avoid blocking the event loop
+        # while still yielding lazily (no need to materialize all results).
+        iterator = self.list(config, filter=filter, before=before, limit=limit)
+
+        def next_item() -> CheckpointTuple | None:
+            return next(iterator, None)
+
+        while (item := await run_in_executor(None, next_item)) is not None:
             yield item
 
     def delete_thread(self, thread_id: str) -> None:

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/checkpoint/dynamodb/test_saver.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/checkpoint/dynamodb/test_saver.py
@@ -393,3 +393,46 @@ class TestDynamoDBSaverAsyncList:
 
         assert len(result) == 1
         assert result[0].checkpoint["id"] == "cp1"
+
+    @pytest.mark.asyncio
+    async def test_alist_runs_blocking_work_off_event_loop(
+        self, mock_saver_dependencies
+    ):
+        """`alist` must not run blocking boto3 calls on the event loop thread."""
+        import threading
+
+        loop_thread_id = threading.get_ident()
+        observed_thread_ids = []
+
+        def list_checkpoints(*args, **kwargs):
+            # Record the thread each item is produced on. With a blocking
+            # implementation this would run on the event loop thread.
+            for checkpoint_id in ("cp1", "cp2"):
+                observed_thread_ids.append(threading.get_ident())
+                yield {
+                    "thread_id": TEST_THREAD_ID,
+                    "checkpoint_id": checkpoint_id,
+                    "checkpoint_ns": TEST_CHECKPOINT_NS,
+                    "checkpoint": {"id": checkpoint_id},
+                    "metadata": {},
+                    "parent_checkpoint_id": None,
+                }
+
+        mock_repo = Mock()
+        mock_saver_dependencies["repo"].return_value = mock_repo
+        mock_repo.list_checkpoints.side_effect = list_checkpoints
+        mock_repo.get_pending_writes.return_value = []
+
+        saver = DynamoDBSaver(table_name=TEST_TABLE_NAME)
+        config = {
+            "configurable": {
+                "thread_id": TEST_THREAD_ID,
+                "checkpoint_ns": TEST_CHECKPOINT_NS,
+            }
+        }
+
+        result = [item async for item in saver.alist(config)]
+
+        assert [item.checkpoint["id"] for item in result] == ["cp1", "cp2"]
+        assert observed_thread_ids, "list_checkpoints was never driven"
+        assert all(tid != loop_thread_id for tid in observed_thread_ids)


### PR DESCRIPTION
## TL;DR

`DynamoDBSaver.alist` looks async, but it secretly blocks the event loop. This PR makes it actually run its blocking AWS calls on a background thread, like every other async method in the class already does.

Closes #754

## The problem, in plain terms

`alist` is an `async` method, so callers reasonably assume it does its I/O without blocking the event loop. But the old implementation just looped over the **synchronous** `list` method and re-yielded its items:

```python
async def alist(self, config, *, filter=None, before=None, limit=None):
    for item in self.list(config, filter=filter, before=before, limit=limit):
        yield item
```

`list` is not cheap — under the hood it makes blocking boto3 DynamoDB calls (`repo.list_checkpoints(...)`, plus a pending-writes fetch for each checkpoint). Because all of that runs directly inside the `async` method, **the event loop is frozen during every network round-trip.** In an app serving multiple concurrent requests (e.g. a LangGraph server), one `alist` call stalls everything else. And as #754 notes, there's no warning — the method silently lies about being async.

The other async methods in this same class already do the right thing: they push the blocking work to a worker thread with `run_in_executor`. `alist` was simply the one that got missed.

## Before vs. after

| | Before | After |
|---|---|---|
| Declared as `async`? | Yes | Yes |
| Blocking boto3 calls run on… | ❌ the event loop thread | ✅ a background worker thread |
| Blocks other concurrent tasks? | ❌ Yes, during every fetch | ✅ No |
| Consistent with `aget_tuple` / `aput` / `aput_writes` / `adelete_thread`? | ❌ No | ✅ Yes |
| Streams results lazily (no full buffering)? | ✅ Yes | ✅ Yes (preserved) |
| Public API / arguments / ordering | — | ✅ Unchanged |

## The fix

Drive the underlying synchronous iterator **one item at a time** through `run_in_executor`. Each blocking fetch happens on a worker thread, but results are still yielded lazily — so we keep the original streaming and early-exit behavior (no buffering the whole result set into memory):

```python
iterator = self.list(config, filter=filter, before=before, limit=limit)

def next_item() -> CheckpointTuple | None:
    return next(iterator, None)

while (item := await run_in_executor(None, next_item)) is not None:
    yield item
```

That's the entire behavioral change. Same arguments, same result ordering, same lazy streaming — only the thread the blocking work runs on is different.

## Tests

I added a unit test that records which thread each checkpoint is produced on and asserts it is **not** the event loop thread. This test fails against the old code and passes with the fix, so it actually guards the regression.

**The new test against the OLD implementation — fails as expected:**

```text
>       assert all(tid != loop_thread_id for tid in observed_thread_ids)
E       assert False
tests/unit_tests/checkpoint/dynamodb/test_saver.py:438: AssertionError
=========================== short test summary info ============================
FAILED tests/.../test_saver.py::TestDynamoDBSaverAsyncList::test_alist_runs_blocking_work_off_event_loop
1 failed, 1 warning in 0.04s
```

**The new test against the fix — passes:**

```text
tests/.../test_saver.py::TestDynamoDBSaverAsyncList::test_alist_runs_blocking_work_off_event_loop .  [100%]
1 passed, 1 warning in 0.01s
```

**Full unit suite — green:**

```text
======================= 973 passed, 73 warnings in 2.82s =======================
```

`make lint` and `make format` also pass cleanly (including `mypy`).

## Review notes

- This is a behavior-preserving fix; the only observable difference is that the event loop is no longer blocked.
- A natural follow-up would be true native-async I/O via `aioboto3` (see #663), but that is a much larger change. This PR is the minimal, low-risk fix that resolves the reported issue and matches the existing convention in the file.

---

*Disclaimer: this contribution was prepared with the assistance of an AI agent (Claude Code). A human reviewed the change, the reasoning, and the test results before submitting.*