### PR TITLE
fix(agentcore-codeinterpreter): fix write() path doubling and PermissionError when sandbox cwd != /

### DIFF
--- a/libs/agentcore-codeinterpreter/langchain_agentcore_codeinterpreter/sandbox.py
+++ b/libs/agentcore-codeinterpreter/langchain_agentcore_codeinterpreter/sandbox.py
@@ -289,12 +289,7 @@ class AgentCoreSandbox(BaseSandbox):
         if preflight_error is not None:
             return preflight_error
         responses = self.upload_files([(abs_path, content.encode("utf-8"))])
-        if not responses:
-            msg = (
-                f"Responses was expected to return 1 result, but it returned "
-                f"{len(responses)} with type {type(responses)}"
-            )
-            raise AssertionError(msg)
+        assert responses, "upload_files returned no responses"
         response = responses[0]
         if response.error:
             return WriteResult(

--- a/libs/agentcore-codeinterpreter/langchain_agentcore_codeinterpreter/sandbox.py
+++ b/libs/agentcore-codeinterpreter/langchain_agentcore_codeinterpreter/sandbox.py
@@ -167,6 +167,15 @@ class AgentCoreSandbox(BaseSandbox):
     The caller is responsible for managing the interpreter lifecycle
     (``start()`` / ``stop()``).
 
+    !!! note
+
+        When the sandbox working directory is not ``/`` (e.g.
+        ``/opt/amazon/genesis1p-tools/var/``), paths must be resolved
+        against the real cwd before shell preflight commands and stripped of
+        the cwd prefix before the AgentCore ``writeFiles``/``readFiles`` APIs.
+        Pass the known cwd via the ``cwd`` constructor argument, or let the
+        sandbox detect it automatically on the first ``write()`` call.
+
     Example:
         .. code-block:: python
 
@@ -185,25 +194,113 @@ class AgentCoreSandbox(BaseSandbox):
             interpreter.stop()
     """
 
-    def __init__(self, *, interpreter: CodeInterpreter) -> None:
+    def __init__(
+        self,
+        *,
+        interpreter: CodeInterpreter,
+        cwd: str | None = None,
+    ) -> None:
         """Create a backend wrapping an active CodeInterpreter session.
 
         Args:
             interpreter: A started :class:`CodeInterpreter` instance.
+            cwd: The sandbox working directory (e.g.
+                ``"/opt/amazon/genesis1p-tools/var"``). When provided,
+                ``write()`` uses it to resolve virtual paths to real absolute
+                paths and to strip the prefix before the AgentCore
+                ``writeFiles`` API. When omitted, the cwd is detected
+                automatically on the first ``write()`` call via ``pwd``.
         """
         self._interpreter = interpreter
+        self._cwd: str | None = cwd.rstrip("/") if cwd is not None else None
 
-    @staticmethod
-    def _to_relative_path(path: str) -> str:
-        """Strip leading slashes and ``./`` prefixes for AgentCore APIs.
+    def _get_cwd(self) -> str:
+        """Return the sandbox working directory, detecting it lazily if needed.
+
+        Returns:
+            The working directory with any trailing slash stripped.
+        """
+        if self._cwd is None:
+            result = self.execute("pwd")
+            self._cwd = result.output.strip().rstrip("/")
+        return self._cwd
+
+    def _to_relative_path(self, path: str) -> str:
+        """Strip the cwd prefix (or leading slashes) for AgentCore file APIs.
+
+        When the sandbox cwd is known and ``path`` starts with it, the cwd
+        prefix is removed so the AgentCore ``writeFiles``/``readFiles`` APIs
+        receive a cwd-relative path. For paths that do not start with the cwd,
+        the standard leading-slash stripping is applied.
 
         Args:
             path: File path (absolute or relative).
 
         Returns:
-            Relative path string.
+            Path relative to the sandbox cwd, with no leading ``/`` or ``./``.
         """
+        if self._cwd is not None:
+            cwd_prefix = self._cwd + "/"
+            if path.startswith(cwd_prefix):
+                return path[len(cwd_prefix) :]
         return _normalize_relative_path(path)
+
+    def _to_absolute_path(self, path: str) -> str:
+        """Resolve a path to a real absolute path under the sandbox cwd.
+
+        Paths already under the cwd are returned unchanged. Virtual paths
+        (e.g. ``/workspace/hello.py``) and relative paths are prepended with
+        the cwd so that shell commands (``makedirs``, etc.) operate on the
+        real filesystem location.
+
+        Args:
+            path: File path to resolve.
+
+        Returns:
+            Absolute path under the sandbox cwd.
+        """
+        cwd = self._get_cwd()
+        if not cwd:
+            return path
+        if path.startswith(cwd + "/") or path == cwd:
+            return path
+        return cwd + "/" + path.lstrip("/")
+
+    def write(self, file_path: str, content: str) -> WriteResult:
+        """Create a new file in the sandbox, failing if it already exists.
+
+        Normalizes ``file_path`` to a real absolute path under the sandbox cwd
+        before the preflight shell command (so ``makedirs`` operates on the
+        correct location) and before uploading (so the AgentCore ``writeFiles``
+        API receives a cwd-relative path rather than a doubled absolute path).
+
+        Args:
+            file_path: Destination path for the new file. May be a real
+                absolute path under the sandbox cwd, a virtual absolute path
+                (e.g. ``/workspace/hello.py``), or a relative path.
+            content: UTF-8 text content to write.
+
+        Returns:
+            ``WriteResult`` with ``path`` set to the resolved absolute path on
+            success, or ``error`` on failure.
+        """
+        abs_path = self._to_absolute_path(file_path)
+        preflight_error = self._write_preflight(abs_path)
+        if preflight_error is not None:
+            return preflight_error
+        responses = self.upload_files([(abs_path, content.encode("utf-8"))])
+        if not responses:
+            msg = (
+                f"Responses was expected to return 1 result, but it returned "
+                f"{len(responses)} with type {type(responses)}"
+            )
+            raise AssertionError(msg)
+        response = responses[0]
+        if response.error:
+            return WriteResult(
+                error=f"Failed to write file '{abs_path}': {response.error}"
+            )
+        return WriteResult(path=abs_path)
 
     def _invoke(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
         """Invoke the interpreter and eagerly consume the response stream.

--- a/libs/agentcore-codeinterpreter/langchain_agentcore_codeinterpreter/sandbox.py
+++ b/libs/agentcore-codeinterpreter/langchain_agentcore_codeinterpreter/sandbox.py
@@ -222,6 +222,11 @@ class AgentCoreSandbox(BaseSandbox):
         """
         if self._cwd is None:
             result = self.execute("pwd")
+            if result.exit_code != 0 or not result.output.strip():
+                raise RuntimeError(
+                    f"Failed to detect sandbox working directory: "
+                    f"exit_code={result.exit_code}, output={result.output!r}"
+                )
             self._cwd = result.output.strip().rstrip("/")
         return self._cwd
 

--- a/libs/agentcore-codeinterpreter/tests/unit_tests/test_sandbox.py
+++ b/libs/agentcore-codeinterpreter/tests/unit_tests/test_sandbox.py
@@ -24,12 +24,13 @@ from langchain_agentcore_codeinterpreter.sandbox import (
 def _make_sandbox(
     invoke_return: dict[str, Any] | None = None,
     session_id: str = "test-session-123",
+    cwd: str | None = None,
 ) -> tuple[AgentCoreSandbox, MagicMock]:
     """Create a sandbox with a mocked interpreter."""
     interpreter = MagicMock()
     interpreter.session_id = session_id
     interpreter.invoke.return_value = invoke_return or {"stream": []}
-    return AgentCoreSandbox(interpreter=interpreter), interpreter
+    return AgentCoreSandbox(interpreter=interpreter, cwd=cwd), interpreter
 
 
 def _make_expired_sandbox() -> tuple[AgentCoreSandbox, MagicMock]:
@@ -265,16 +266,32 @@ def test_download_files_dot_slash_path() -> None:
 
 def test_relative_path_stripping() -> None:
     """Leading slashes should be stripped; relative paths left as-is."""
-    assert AgentCoreSandbox._to_relative_path("/abs/path.txt") == "abs/path.txt"
-    assert AgentCoreSandbox._to_relative_path("rel/path.txt") == "rel/path.txt"
-    assert AgentCoreSandbox._to_relative_path("///triple.txt") == "triple.txt"
+    sandbox, _ = _make_sandbox()
+    assert sandbox._to_relative_path("/abs/path.txt") == "abs/path.txt"
+    assert sandbox._to_relative_path("rel/path.txt") == "rel/path.txt"
+    assert sandbox._to_relative_path("///triple.txt") == "triple.txt"
 
 
 def test_relative_path_strips_dot_slash() -> None:
     """./ and repeated ././ prefixes should be stripped."""
-    assert AgentCoreSandbox._to_relative_path("./data/foo.png") == "data/foo.png"
-    assert AgentCoreSandbox._to_relative_path("././foo.png") == "foo.png"
-    assert AgentCoreSandbox._to_relative_path("/./data/foo.png") == "data/foo.png"
+    sandbox, _ = _make_sandbox()
+    assert sandbox._to_relative_path("./data/foo.png") == "data/foo.png"
+    assert sandbox._to_relative_path("././foo.png") == "foo.png"
+    assert sandbox._to_relative_path("/./data/foo.png") == "data/foo.png"
+
+
+def test_relative_path_strips_cwd_prefix() -> None:
+    """When cwd is known, paths under cwd should have the prefix stripped."""
+    sandbox, _ = _make_sandbox(cwd="/opt/sandbox")
+    result = sandbox._to_relative_path("/opt/sandbox/workspace/hello.py")
+    assert result == "workspace/hello.py"
+    assert sandbox._to_relative_path("/opt/sandbox/hello.py") == "hello.py"
+
+
+def test_relative_path_virtual_path_falls_back_to_strip() -> None:
+    """Paths outside cwd should fall back to leading-slash stripping."""
+    sandbox, _ = _make_sandbox(cwd="/opt/sandbox")
+    assert sandbox._to_relative_path("/workspace/hello.py") == "workspace/hello.py"
 
 
 # ------------------------------------------------------------------
@@ -288,6 +305,138 @@ def test_keyword_only_init() -> None:
     interpreter.session_id = "s"
     sandbox = AgentCoreSandbox(interpreter=interpreter)
     assert sandbox.id == "s"
+
+
+def test_cwd_constructor_stores_stripped_cwd() -> None:
+    """cwd passed at construction should be stored with trailing slash removed."""
+    sandbox, _ = _make_sandbox(cwd="/opt/sandbox/")
+    assert sandbox._cwd == "/opt/sandbox"
+
+
+def test_cwd_defaults_to_none() -> None:
+    """When cwd is not passed, _cwd should start as None (lazy detection)."""
+    sandbox, _ = _make_sandbox()
+    assert sandbox._cwd is None
+
+
+# ------------------------------------------------------------------
+# _to_absolute_path()
+# ------------------------------------------------------------------
+
+
+def test_to_absolute_path_already_under_cwd() -> None:
+    """Paths already under the cwd should be returned unchanged."""
+    sandbox, _ = _make_sandbox(cwd="/opt/sandbox")
+    path = "/opt/sandbox/workspace/hello.py"
+    assert sandbox._to_absolute_path(path) == path
+
+
+def test_to_absolute_path_virtual_path_prepends_cwd() -> None:
+    """Virtual paths like /workspace/hello.py should be resolved under cwd."""
+    sandbox, _ = _make_sandbox(cwd="/opt/sandbox")
+    result = sandbox._to_absolute_path("/workspace/hello.py")
+    assert result == "/opt/sandbox/workspace/hello.py"
+
+
+def test_to_absolute_path_relative_path_prepends_cwd() -> None:
+    """Relative paths should be resolved under cwd."""
+    sandbox, _ = _make_sandbox(cwd="/opt/sandbox")
+    result = sandbox._to_absolute_path("workspace/hello.py")
+    assert result == "/opt/sandbox/workspace/hello.py"
+
+
+def test_to_absolute_path_root_cwd_returns_as_is() -> None:
+    """When cwd is / (stored as empty string), absolute paths are returned as-is."""
+    sandbox, _ = _make_sandbox(cwd="/")
+    assert sandbox._to_absolute_path("/workspace/hello.py") == "/workspace/hello.py"
+
+
+# ------------------------------------------------------------------
+# write() — path normalization (issue #1055)
+# ------------------------------------------------------------------
+
+
+def _make_successful_invoke(cwd: str = "") -> Any:
+    """Return an invoke side_effect that succeeds for all methods."""
+
+    def invoke(**kwargs: Any) -> dict[str, Any]:
+        if kwargs.get("method") == "executeCommand":
+            return {
+                "stream": [
+                    {
+                        "result": {
+                            "exitCode": 0,
+                            "content": [{"type": "text", "text": cwd}],
+                        }
+                    }
+                ]
+            }
+        return {"stream": []}
+
+    return invoke
+
+
+def test_write_strips_cwd_prefix_from_upload_path() -> None:
+    """upload path must be cwd-relative so writeFiles doesn't double the prefix."""
+    cwd = "/opt/amazon/genesis1p-tools/var"
+    sandbox, mock = _make_sandbox(cwd=cwd)
+    mock.invoke.side_effect = _make_successful_invoke(cwd)
+
+    abs_path = f"{cwd}/workspace/hello.py"
+    result = sandbox.write(abs_path, "hello")
+
+    write_files_calls = [
+        c for c in mock.invoke.call_args_list if c.kwargs.get("method") == "writeFiles"
+    ]
+    assert len(write_files_calls) == 1
+    uploaded_path = write_files_calls[0].kwargs["params"]["content"][0]["path"]
+    assert uploaded_path == "workspace/hello.py"
+    assert result.path == abs_path
+
+
+def test_write_resolves_virtual_path_for_preflight() -> None:
+    """Virtual paths must be resolved to real absolute paths before preflight."""
+    cwd = "/opt/sandbox"
+    sandbox, mock = _make_sandbox(cwd=cwd)
+    mock.invoke.side_effect = _make_successful_invoke(cwd)
+
+    result = sandbox.write("/workspace/hello.py", "hello")
+
+    # The resolved absolute path should be returned and used for the upload.
+    assert result.path == "/opt/sandbox/workspace/hello.py"
+    write_files_calls = [
+        c for c in mock.invoke.call_args_list if c.kwargs.get("method") == "writeFiles"
+    ]
+    assert len(write_files_calls) == 1
+    uploaded_path = write_files_calls[0].kwargs["params"]["content"][0]["path"]
+    assert uploaded_path == "workspace/hello.py"
+
+
+def test_write_lazy_cwd_detection() -> None:
+    """When cwd is not passed at construction, write() detects it via pwd."""
+    cwd = "/opt/sandbox"
+    sandbox, mock = _make_sandbox()
+    mock.invoke.side_effect = _make_successful_invoke(cwd)
+
+    result = sandbox.write("/workspace/hello.py", "hello")
+
+    assert sandbox._cwd == cwd
+    assert result.path == "/opt/sandbox/workspace/hello.py"
+
+
+def test_write_root_cwd_preserves_existing_behavior() -> None:
+    """When cwd is /, write() should behave as it did before the fix."""
+    sandbox, mock = _make_sandbox(cwd="/")
+    mock.invoke.side_effect = _make_successful_invoke("/")
+
+    result = sandbox.write("/hello.py", "hello")
+
+    assert result.path == "/hello.py"
+    write_files_calls = [
+        c for c in mock.invoke.call_args_list if c.kwargs.get("method") == "writeFiles"
+    ]
+    uploaded_path = write_files_calls[0].kwargs["params"]["content"][0]["path"]
+    assert uploaded_path == "hello.py"
 
 
 # ------------------------------------------------------------------

--- a/libs/agentcore-codeinterpreter/tests/unit_tests/test_sandbox.py
+++ b/libs/agentcore-codeinterpreter/tests/unit_tests/test_sandbox.py
@@ -425,7 +425,7 @@ def test_write_lazy_cwd_detection() -> None:
 
 
 def test_write_returns_resolved_path_not_virtual_path() -> None:
-    """WriteResult.path must be the resolved absolute path, not the caller-supplied virtual path.
+    """WriteResult.path must be the resolved absolute path, not the virtual path.
 
     Regression test for the execute()-after-write() mismatch: when the LLM writes
     to "/tmp/script.py" and then runs execute("python /tmp/script.py"), it must

--- a/libs/agentcore-codeinterpreter/tests/unit_tests/test_sandbox.py
+++ b/libs/agentcore-codeinterpreter/tests/unit_tests/test_sandbox.py
@@ -424,6 +424,30 @@ def test_write_lazy_cwd_detection() -> None:
     assert result.path == "/opt/sandbox/workspace/hello.py"
 
 
+def test_write_returns_resolved_path_not_virtual_path() -> None:
+    """WriteResult.path must be the resolved absolute path, not the caller-supplied virtual path.
+
+    Regression test for the execute()-after-write() mismatch: when the LLM writes
+    to "/tmp/script.py" and then runs execute("python /tmp/script.py"), it must
+    use the same path that was returned by write() — otherwise the shell cannot
+    find the file because AgentCore resolves uploads relative to cwd, not to "/".
+    """
+    cwd = "/opt/amazon/genesis1p-tools/var"
+    sandbox, mock = _make_sandbox(cwd=cwd)
+    mock.invoke.side_effect = _make_successful_invoke(cwd)
+
+    result = sandbox.write("/tmp/script.py", "print('hello')")
+
+    # The returned path must be the real location so execute() can find the file.
+    assert result.path == f"{cwd}/tmp/script.py"
+    write_files_calls = [
+        c for c in mock.invoke.call_args_list if c.kwargs.get("method") == "writeFiles"
+    ]
+    uploaded_path = write_files_calls[0].kwargs["params"]["content"][0]["path"]
+    # AgentCore receives a cwd-relative path, resolving to {cwd}/tmp/script.py.
+    assert uploaded_path == "tmp/script.py"
+
+
 def test_write_root_cwd_preserves_existing_behavior() -> None:
     """When cwd is /, write() should behave as it did before the fix."""
     sandbox, mock = _make_sandbox(cwd="/")


### PR DESCRIPTION
## Summary

Fixes #1055 — `AgentCoreSandbox.write()` produces a doubled file path (or a `PermissionError`) when the sandbox working directory is not `/`.

- **Root cause**: `write()` had two consumers with conflicting path requirements. The preflight shell command (`makedirs`) needs a real absolute path, while the AgentCore `writeFiles` API needs a path relative to the sandbox cwd. The previous `_to_relative_path` only stripped the leading `/`, which happens to work when `cwd == /` but breaks otherwise.
- **Case 1 (doubled path)**: passing the full real absolute path (e.g. `/opt/amazon/.../workspace/hello.py`) caused `writeFiles` to prepend cwd again → doubled path.
- **Case 2 (PermissionError)**: passing a virtual path (e.g. `/workspace/hello.py`) caused the preflight `makedirs('/workspace')` to fail with a permission error.

## Changes

- Add optional `cwd: str | None = None` keyword argument to `AgentCoreSandbox.__init__` (fully backward-compatible — defaults to lazy detection via `pwd` on the first `write()` call).
- `_get_cwd()`: lazily executes `pwd` and caches the result.
- `_to_absolute_path(path)`: resolves virtual/relative paths to their real absolute location under the sandbox cwd, used by `write()` before the preflight shell command.
- `_to_relative_path(path)`: promoted from `@staticmethod` to instance method; strips the cwd prefix when known (preventing path doubling), otherwise falls back to the original leading-slash stripping (no behavior change for callers that don't go through `write()`).
- `write()` override: normalizes the path via `_to_absolute_path` before both `_write_preflight` and `upload_files`, and returns the resolved absolute path.
- 11 new unit tests covering both bug cases, lazy cwd detection, constructor injection, and `cwd="/"` backward compatibility.

## Areas requiring careful review

- `_to_absolute_path` edge case: when `cwd` resolves to `""` (sandbox at `/`), the guard `if not cwd: return path` preserves the original behavior for all callers.
- `_to_relative_path` only strips the cwd prefix when `self._cwd is not None`; direct calls to `upload_files`/`download_files` that bypass `write()` do not trigger lazy cwd detection, preserving the existing call semantics for those methods.

## Test plan

- [x] All 62 unit tests pass (`uv run --group test pytest tests/unit_tests/`)
- [x] `ruff check` and `ruff format --check` pass
- [x] Verify Case 1 (doubled path) is fixed: `test_write_strips_cwd_prefix_from_upload_path`
- [x] Verify Case 2 (PermissionError) is fixed: `test_write_resolves_virtual_path_for_preflight`
- [x] Verify lazy cwd detection: `test_write_lazy_cwd_detection`
- [x] Verify backward compatibility: `test_write_root_cwd_preserves_existing_behavior`

> This PR was implemented with the assistance of an AI agent (Claude Sonnet 4.6 via Claude Code).