### PR TITLE
test(aws): disable pytest-benchmark under xdist to silence `PytestBenchmarkWarning`

### DIFF
--- a/libs/agentcore-codeinterpreter/Makefile
+++ b/libs/agentcore-codeinterpreter/Makefile
@@ -30,10 +30,10 @@ test:  ## Run individual unit test: make test TEST_FILE=tests/unit_tests/test.py
 	env -u AWS_ACCESS_KEY_ID -u AWS_SECRET_ACCESS_KEY -u AWS_SESSION_TOKEN uv run --group test pytest --disable-socket --allow-unix-socket $(TEST_FILE)
 
 integration_tests: ## Run all integration tests
-	uv run --group test --group test_integration pytest -n auto $(TEST_FILE)
+	uv run --group test --group test_integration pytest -n auto --benchmark-disable $(TEST_FILE)
 
 integration_test: ## Run individual integration test: make integration_test TEST_FILE=tests/integration_tests/integ_test.py
-	uv run --group test --group test_integration pytest -n auto $(TEST_FILE)
+	uv run --group test --group test_integration pytest -n auto --benchmark-disable $(TEST_FILE)
 
 coverage_tests: ## Run unit tests with coverage
 	env -u AWS_ACCESS_KEY_ID -u AWS_SECRET_ACCESS_KEY -u AWS_SESSION_TOKEN uv run --group test pytest --cov=langchain_agentcore_codeinterpreter --cov-report=html --cov-report=term-missing --cov-branch tests/unit_tests/

--- a/libs/aws/Makefile
+++ b/libs/aws/Makefile
@@ -30,10 +30,10 @@ test:  ## Run individual unit test: make test TEST_FILE=tests/unit_test/test.py
 	env -u AWS_ACCESS_KEY_ID -u AWS_SECRET_ACCESS_KEY -u AWS_SESSION_TOKEN -u BEDROCK_AWS_ACCESS_KEY_ID -u BEDROCK_AWS_SECRET_ACCESS_KEY uv run --group test pytest --disable-socket --allow-unix-socket $(TEST_FILE)
 
 integration_tests: ## Run all integration tests
-	uv run --group test --group test_integration pytest -n auto $(TEST_FILE)
+	uv run --group test --group test_integration pytest -n auto --benchmark-disable $(TEST_FILE)
 
 integration_test: ## Run individual integration test: make integration_test TEST_FILE=tests/integration_tests/integ_test.py
-	uv run --group test --group test_integration pytest -n auto $(TEST_FILE)
+	uv run --group test --group test_integration pytest -n auto --benchmark-disable $(TEST_FILE)
 
 test_watch: ## Run and interactively watch unit tests
 	uv run --group test ptw --snapshot-update --now . -- -vv $(TEST_FILE)


### PR DESCRIPTION
Integration tests run with `-n auto`, which causes `pytest-benchmark` (pulled in transitively via `langchain-tests`) to auto-disable itself and emit a `PytestBenchmarkWarning` once per xdist worker — five lines of noise on every integration run. Passing `--benchmark-disable` turns the plugin off intentionally so it never hits the auto-disable warning path.

## Changes
- Add `--benchmark-disable` to the `-n auto` integration test targets (`integration_test` / `integration_tests`) in the `aws` and `agentcore-codeinterpreter` Makefiles.
- `langgraph-checkpoint-aws` is intentionally untouched — it has neither `pytest-benchmark` installed nor xdist, so the flag would error there.