### PR TITLE
test(aws): silence third-party pydantic deprecation warning in pytest

### DIFF
--- a/libs/agentcore-codeinterpreter/pyproject.toml
+++ b/libs/agentcore-codeinterpreter/pyproject.toml
@@ -62,6 +62,12 @@ disallow_untyped_defs = "True"
 
 [tool.pytest.ini_options]
 addopts = "--strict-markers --strict-config --durations=5"
+filterwarnings = [
+    # `bedrock-agentcore` (third-party) still uses class-based pydantic `Config`
+    # in `bedrock_agentcore.runtime.context.RequestContext`. Remove once upstream
+    # migrates to `ConfigDict`.
+    "ignore:Support for class-based .config. is deprecated:DeprecationWarning",
+]
 markers = [
     "requires: mark tests as requiring a specific library",
     "asyncio: mark tests as requiring asyncio",

--- a/libs/aws/pyproject.toml
+++ b/libs/aws/pyproject.toml
@@ -121,6 +121,12 @@ directory = "htmlcov"
 # https://github.com/tophat/syrupy
 # --snapshot-warn-unused    Prints a warning on unused snapshots rather than fail the test suite.
 addopts = "--snapshot-warn-unused --strict-markers --strict-config --durations=5"
+filterwarnings = [
+    # `bedrock-agentcore` (third-party) still uses class-based pydantic `Config`
+    # in `bedrock_agentcore.runtime.context.RequestContext`. Remove once upstream
+    # migrates to `ConfigDict`.
+    "ignore:Support for class-based .config. is deprecated:DeprecationWarning",
+]
 # Registering custom markers.
 # https://docs.pytest.org/en/7.1.x/example/markers.html#registering-markers
 markers = [


### PR DESCRIPTION
The `bedrock-agentcore` SDK still defines `RequestContext` with pydantic's deprecated class-based `Config`, which floods test output with a `PydanticDeprecatedSince20` warning on every run that imports it. Since the warning originates upstream and can't be fixed locally, it's filtered at the pytest level instead.