### PR TITLE
fix(agentcore-codeinterpreter): send binary uploads as raw blobs

### DIFF
--- a/libs/agentcore-codeinterpreter/langchain_agentcore_codeinterpreter/sandbox.py
+++ b/libs/agentcore-codeinterpreter/langchain_agentcore_codeinterpreter/sandbox.py
@@ -439,7 +439,7 @@ class AgentCoreSandbox(BaseSandbox):
     def upload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
         """Upload files to the AgentCore sandbox.
 
-        Text files are sent directly; binary files are base64-encoded.
+        Text files are sent directly; binary files are sent as raw blobs.
 
         Args:
             files: List of ``(path, content)`` tuples to upload.
@@ -448,7 +448,7 @@ class AgentCoreSandbox(BaseSandbox):
             List of :class:`FileUploadResponse` objects in the same order
             as the input files.
         """
-        file_list: list[dict[str, str]] = []
+        file_list: list[dict[str, str | bytes]] = []
 
         for path, content in files:
             rel_path = self._to_relative_path(path)
@@ -456,8 +456,7 @@ class AgentCoreSandbox(BaseSandbox):
                 text_content = content.decode("utf-8")
                 file_list.append({"path": rel_path, "text": text_content})
             except UnicodeDecodeError:
-                encoded = base64.b64encode(content).decode("ascii")
-                file_list.append({"path": rel_path, "blob": encoded})
+                file_list.append({"path": rel_path, "blob": content})
 
         try:
             if file_list:

--- a/libs/agentcore-codeinterpreter/tests/integration_tests/sandbox/test_sandbox.py
+++ b/libs/agentcore-codeinterpreter/tests/integration_tests/sandbox/test_sandbox.py
@@ -82,15 +82,12 @@ class TestAgentCoreSandboxIntegration:
         assert results[0].error is not None
 
     def test_binary_roundtrip(self, sandbox: AgentCoreSandbox) -> None:
-        """Binary content uploaded via base64 may be returned as base64 text."""
-        import base64
-
+        """Binary content uploaded as a blob should round-trip unchanged."""
         content = b"\x00\x01\x02\xff\xfe\xfd"
         sandbox.upload_files([("binary_test.bin", content)])
         results = sandbox.download_files(["binary_test.bin"])
         assert results[0].error is None
-        # AgentCore returns blob uploads as text containing the base64 string
-        assert results[0].content in (content, base64.b64encode(content))
+        assert results[0].content == content
 
     def test_session_id(self, sandbox: AgentCoreSandbox) -> None:
         """The sandbox should have a non-empty session ID."""

--- a/libs/agentcore-codeinterpreter/tests/unit_tests/test_sandbox.py
+++ b/libs/agentcore-codeinterpreter/tests/unit_tests/test_sandbox.py
@@ -7,7 +7,6 @@ AWS credential requirements.
 from __future__ import annotations
 
 import asyncio
-import base64
 from collections.abc import Iterator
 from typing import Any
 from unittest.mock import MagicMock

--- a/libs/agentcore-codeinterpreter/tests/unit_tests/test_sandbox.py
+++ b/libs/agentcore-codeinterpreter/tests/unit_tests/test_sandbox.py
@@ -145,7 +145,6 @@ def test_upload_files_binary_uses_blob() -> None:
     """Non-UTF-8 content should be uploaded as raw blob bytes."""
     sandbox, mock = _make_sandbox()
     binary_content = b"\x80\x81\x82"
-    base64_content = base64.b64encode(binary_content)
 
     sandbox.upload_files([("/data.bin", binary_content)])
 
@@ -153,9 +152,6 @@ def test_upload_files_binary_uses_blob() -> None:
     assert "blob" in content
     assert "text" not in content
     assert content["blob"] == binary_content
-    assert isinstance(content["blob"], bytes)
-    assert content["blob"] != base64_content
-    assert content["blob"] != base64_content.decode("ascii")
 
 
 def test_upload_files_mixed_text_and_binary() -> None:
@@ -762,21 +758,6 @@ def test_aupload_files_uses_dedicated_executor() -> None:
     result = asyncio.run(sandbox.aupload_files([("/test.txt", b"data")]))
     assert result[0].error is None
     assert any("agentcore-sandbox" in name for name in thread_names)
-
-
-def test_aupload_files_binary_uses_raw_blob() -> None:
-    """aupload_files() should preserve raw blob bytes for binary uploads."""
-    sandbox, mock = _make_sandbox()
-    binary_content = b"\x80\x81\x82"
-    base64_content = base64.b64encode(binary_content)
-
-    result = asyncio.run(sandbox.aupload_files([("/data.bin", binary_content)]))
-
-    content = mock.invoke.call_args.kwargs["params"]["content"][0]
-    assert result[0].error is None
-    assert content == {"path": "data.bin", "blob": binary_content}
-    assert content["blob"] != base64_content
-    assert content["blob"] != base64_content.decode("ascii")
 
 
 def test_adownload_files_uses_dedicated_executor() -> None:

--- a/libs/agentcore-codeinterpreter/tests/unit_tests/test_sandbox.py
+++ b/libs/agentcore-codeinterpreter/tests/unit_tests/test_sandbox.py
@@ -7,6 +7,7 @@ AWS credential requirements.
 from __future__ import annotations
 
 import asyncio
+import base64
 from collections.abc import Iterator
 from typing import Any
 from unittest.mock import MagicMock
@@ -141,12 +142,41 @@ def test_upload_files_text() -> None:
 
 
 def test_upload_files_binary_uses_blob() -> None:
-    """Non-UTF-8 content should be base64-encoded as a blob."""
+    """Non-UTF-8 content should be uploaded as raw blob bytes."""
     sandbox, mock = _make_sandbox()
-    sandbox.upload_files([("/data.bin", b"\x80\x81\x82")])
+    binary_content = b"\x80\x81\x82"
+    base64_content = base64.b64encode(binary_content)
+
+    sandbox.upload_files([("/data.bin", binary_content)])
+
     content = mock.invoke.call_args.kwargs["params"]["content"][0]
     assert "blob" in content
     assert "text" not in content
+    assert content["blob"] == binary_content
+    assert isinstance(content["blob"], bytes)
+    assert content["blob"] != base64_content
+    assert content["blob"] != base64_content.decode("ascii")
+
+
+def test_upload_files_mixed_text_and_binary() -> None:
+    """Text and binary files should use the correct writeFiles fields."""
+    sandbox, mock = _make_sandbox()
+    binary_content = b"\x00\xff\xfe"
+
+    result = sandbox.upload_files(
+        [
+            ("/hello.py", b"print('hi')"),
+            ("/data.bin", binary_content),
+        ]
+    )
+
+    uploaded = mock.invoke.call_args.kwargs["params"]["content"]
+    assert uploaded == [
+        {"path": "hello.py", "text": "print('hi')"},
+        {"path": "data.bin", "blob": binary_content},
+    ]
+    assert [response.path for response in result] == ["/hello.py", "/data.bin"]
+    assert [response.error for response in result] == [None, None]
 
 
 def test_upload_files_empty_list() -> None:
@@ -732,6 +762,21 @@ def test_aupload_files_uses_dedicated_executor() -> None:
     result = asyncio.run(sandbox.aupload_files([("/test.txt", b"data")]))
     assert result[0].error is None
     assert any("agentcore-sandbox" in name for name in thread_names)
+
+
+def test_aupload_files_binary_uses_raw_blob() -> None:
+    """aupload_files() should preserve raw blob bytes for binary uploads."""
+    sandbox, mock = _make_sandbox()
+    binary_content = b"\x80\x81\x82"
+    base64_content = base64.b64encode(binary_content)
+
+    result = asyncio.run(sandbox.aupload_files([("/data.bin", binary_content)]))
+
+    content = mock.invoke.call_args.kwargs["params"]["content"][0]
+    assert result[0].error is None
+    assert content == {"path": "data.bin", "blob": binary_content}
+    assert content["blob"] != base64_content
+    assert content["blob"] != base64_content.decode("ascii")
 
 
 def test_adownload_files_uses_dedicated_executor() -> None:


### PR DESCRIPTION
Fixes #1083

## Why

`AgentCoreSandbox.upload_files()` sent non-UTF-8 content as a base64-encoded string in the `blob` field. AgentCore `writeFiles` stores that string literally, so binary files are corrupted on disk.

## What changed

- Send non-UTF-8 upload content as raw `blob` bytes.
- Keep UTF-8 content on the existing `text` path.
- Add unit coverage for raw binary blobs, mixed text/binary uploads, and async upload delegation.
- Tighten the binary integration test expectation to require byte-for-byte roundtrip.

## Testing

- `UV_CACHE_DIR=/tmp/openclaw-uv-cache-langchain-aws make test TEST_FILE=tests/unit_tests/test_sandbox.py`
- `UV_CACHE_DIR=/tmp/openclaw-uv-cache-langchain-aws uv lock --check`
- `UV_CACHE_DIR=/tmp/openclaw-uv-cache-langchain-aws uv run --no-sync pytest -m compile tests/integration_tests`
- `git diff --check`