### PR TITLE
feat(langgraph-checkpoint-aws): add batch flush for DeferredCheckpointSaver #1016

### DIFF
--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/__init__.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/__init__.py
@@ -21,7 +21,10 @@ from langgraph_checkpoint_aws.checkpoint.bedrock_sessions.session import (
     BedrockAgentRuntimeSessionClient,
 )
 from langgraph_checkpoint_aws.checkpoint.deferred_saver import (
+    AsyncBatchFlushable,
     DeferredCheckpointSaver,
+    PendingWrite,
+    SyncBatchFlushable,
 )
 from langgraph_checkpoint_aws.checkpoint.dynamodb import (
     DynamoDBSaver,
@@ -107,6 +110,7 @@ __all__ = [
     "AgentCoreMemorySaver",
     "AgentCoreMemoryStore",
     "AgentCoreValkeySaver",
+    "AsyncBatchFlushable",
     "AsyncBedrockAgentRuntimeSessionClient",
     "AsyncBedrockSessionSaver",
     "AsyncValkeySaver",
@@ -116,7 +120,9 @@ __all__ = [
     "DeferredCheckpointSaver",
     "DynamoDBSaver",
     "DynamoDBStore",
+    "PendingWrite",
     "SDK_USER_AGENT",
+    "SyncBatchFlushable",
     "ValkeyCache",
     "ValkeyConnectionError",
     "ValkeyDocumentParsingError",

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/agentcore/helpers.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/agentcore/helpers.py
@@ -47,6 +47,11 @@ DEFAULT_MAX_RETRIES = 3
 DEFAULT_INITIAL_BACKOFF = 0.1  # 100ms
 DEFAULT_MAX_BACKOFF = 2.0  # 2 seconds
 
+# AgentCore CreateEvent API limits
+# https://docs.aws.amazon.com/bedrock-agentcore/latest/APIReference/API_CreateEvent.html
+MAX_PAYLOAD_ITEMS_PER_EVENT = 100  # max items in payload array
+MAX_PAYLOAD_BYTES_PER_EVENT = 10_000_000  # 10 MB max event size
+
 
 class BedrockAgentCoreClientWithRetry:
     """Wrapper around bedrock-agentcore client with retry logic.
@@ -273,25 +278,82 @@ class AgentCoreEventClient:
         )
 
     def store_blob_events_batch(
-        self, events: list[EventType], session_id: str, actor_id: str
+        self,
+        events: list[EventType],
+        session_id: str,
+        actor_id: str,
+        *,
+        max_payload_items: int = MAX_PAYLOAD_ITEMS_PER_EVENT,
+        max_payload_bytes: int = MAX_PAYLOAD_BYTES_PER_EVENT,
     ) -> None:
-        """Store multiple events in a single API call to AgentCore Memory."""
-        # Serialize all events into payload blobs
-        payload = []
+        """Store multiple events, chunking into multiple API calls if needed.
+
+        AgentCore's ``create_event`` API enforces limits on the payload
+        array (max 100 items) and overall request size (~10 MB).  When the
+        batch exceeds either limit, it is split into the fewest possible
+        chunks that each stay within bounds.
+
+        Args:
+            events: The events to store.
+            session_id: The session ID to store events under.
+            actor_id: The actor ID to store events under.
+            max_payload_items: Maximum number of payload blobs per API call.
+            max_payload_bytes: Maximum total serialized bytes per API call.
+        """
+        blobs = [self.serializer.serialize_event(event) for event in events]
+        chunks = self._chunk_payload(blobs, max_payload_items, max_payload_bytes)
         timestamp = datetime.datetime.now(datetime.timezone.utc)
 
-        for event in events:
-            serialized = self.serializer.serialize_event(event)
-            payload.append({"blob": serialized})
+        for chunk in chunks:
+            payload = [{"blob": b} for b in chunk]
+            self.client.create_event(
+                memoryId=self.memory_id,
+                actorId=actor_id,
+                sessionId=session_id,
+                eventTimestamp=timestamp,
+                payload=payload,
+            )
 
-        # Store all events in a single create_event call
-        self.client.create_event(
-            memoryId=self.memory_id,
-            actorId=actor_id,
-            sessionId=session_id,
-            eventTimestamp=timestamp,
-            payload=payload,
-        )
+    @staticmethod
+    def _chunk_payload(
+        blobs: list[str],
+        max_items: int,
+        max_bytes: int,
+    ) -> list[list[str]]:
+        """Split serialized blobs into chunks respecting item count and byte size.
+
+        Args:
+            blobs: Serialized event strings.
+            max_items: Maximum number of blobs per chunk.
+            max_bytes: Maximum total byte size per chunk.
+
+        Returns:
+            List of chunks, each chunk is a list of blob strings.
+        """
+        if not blobs:
+            return []
+
+        chunks: list[list[str]] = []
+        current_chunk: list[str] = []
+        current_bytes = 0
+
+        for blob in blobs:
+            blob_size = len(blob.encode("utf-8"))
+
+            if current_chunk and (
+                len(current_chunk) >= max_items or current_bytes + blob_size > max_bytes
+            ):
+                chunks.append(current_chunk)
+                current_chunk = []
+                current_bytes = 0
+
+            current_chunk.append(blob)
+            current_bytes += blob_size
+
+        if current_chunk:
+            chunks.append(current_chunk)
+
+        return chunks
 
     def get_events(
         self,

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/agentcore/saver.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/agentcore/saver.py
@@ -21,6 +21,8 @@ from langgraph.checkpoint.base import (
     get_checkpoint_metadata,
 )
 
+from langgraph_checkpoint_aws.checkpoint.deferred_saver import PendingWrite
+
 from .constants import (
     EMPTY_CHANNEL_VALUE,
     InvalidConfigError,
@@ -281,6 +283,123 @@ class AgentCoreMemorySaver(BaseCheckpointSaver[str]):
 
         self.checkpoint_event_client.store_blob_event(
             writes_event, checkpoint_config.session_id, checkpoint_config.actor_id
+        )
+
+    def put_with_writes(
+        self,
+        config: RunnableConfig,
+        checkpoint: Checkpoint,
+        metadata: CheckpointMetadata,
+        new_versions: ChannelVersions,
+        pending_writes: Sequence[PendingWrite],
+    ) -> RunnableConfig:
+        """Persist checkpoint and all pending writes in a single API call.
+
+        Args:
+            config: The runnable config associated with this checkpoint.
+            checkpoint: The checkpoint data to persist.
+            metadata: Metadata associated with the checkpoint.
+            new_versions: Channel version information.
+            pending_writes: All buffered writes to persist alongside the
+                checkpoint.
+
+        Returns:
+            A config pointing to the persisted checkpoint.
+        """
+        checkpoint_config = CheckpointerConfig.from_runnable_config(
+            RunnableConfigDict(config)
+        )
+
+        checkpoint_copy = dict(checkpoint)
+        channel_values: dict[str, Any] = {}
+        if "channel_values" in checkpoint_copy:
+            channel_values_obj = checkpoint_copy.pop("channel_values")
+            if isinstance(channel_values_obj, dict):
+                channel_values = channel_values_obj.copy()
+
+        events_to_store: list[CheckpointEvent | ChannelDataEvent | WritesEvent] = []
+
+        for channel, version in new_versions.items():
+            channel_event = ChannelDataEvent(
+                channel=channel,
+                version=str(version),
+                value=channel_values.get(channel, EMPTY_CHANNEL_VALUE),
+                thread_id=checkpoint_config.thread_id,
+                checkpoint_ns=checkpoint_config.checkpoint_ns,
+            )
+            events_to_store.append(channel_event)
+
+        checkpoint_event = CheckpointEvent(
+            checkpoint_id=checkpoint["id"],
+            checkpoint_data=checkpoint_copy,
+            metadata=dict(get_checkpoint_metadata(config, metadata)),
+            parent_checkpoint_id=checkpoint_config.checkpoint_id,
+            thread_id=checkpoint_config.thread_id,
+            checkpoint_ns=checkpoint_config.checkpoint_ns,
+        )
+        events_to_store.append(checkpoint_event)
+
+        for pw in pending_writes:
+            write_items = [
+                WriteItem(
+                    task_id=pw.task_id,
+                    channel=channel,
+                    value=value,
+                    task_path=pw.task_path,
+                )
+                for channel, value in pw.writes
+            ]
+            writes_event = WritesEvent(
+                checkpoint_id=checkpoint["id"],
+                writes=write_items,
+            )
+            events_to_store.append(writes_event)
+
+        typed_events = cast(
+            list[CheckpointEvent | ChannelDataEvent | WritesEvent], events_to_store
+        )
+        self.checkpoint_event_client.store_blob_events_batch(
+            typed_events, checkpoint_config.session_id, checkpoint_config.actor_id
+        )
+
+        return {
+            "configurable": {
+                "thread_id": checkpoint_config.thread_id,
+                "actor_id": checkpoint_config.actor_id,
+                "checkpoint_ns": checkpoint_config.checkpoint_ns,
+                "checkpoint_id": checkpoint["id"],
+            }
+        }
+
+    async def aput_with_writes(
+        self,
+        config: RunnableConfig,
+        checkpoint: Checkpoint,
+        metadata: CheckpointMetadata,
+        new_versions: ChannelVersions,
+        pending_writes: Sequence[PendingWrite],
+    ) -> RunnableConfig:
+        """Async version of :meth:`put_with_writes`.
+
+        Args:
+            config: The runnable config associated with this checkpoint.
+            checkpoint: The checkpoint data to persist.
+            metadata: Metadata associated with the checkpoint.
+            new_versions: Channel version information.
+            pending_writes: All buffered writes to persist alongside the
+                checkpoint.
+
+        Returns:
+            A config pointing to the persisted checkpoint.
+        """
+        return await run_in_executor(
+            None,
+            self.put_with_writes,
+            config,
+            checkpoint,
+            metadata,
+            new_versions,
+            pending_writes,
         )
 
     def delete_thread(self, thread_id: str, actor_id: str = "") -> None:

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/deferred_saver.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/deferred_saver.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import contextlib
 import threading
 from collections.abc import AsyncIterator, Iterator, Sequence
-from typing import Any, NamedTuple
+from typing import Any, NamedTuple, Protocol, runtime_checkable
 
 from langchain_core.runnables import RunnableConfig
 from langgraph.checkpoint.base import (
@@ -40,6 +40,47 @@ class _PendingWrite(NamedTuple):
     task_path: str
 
 
+class PendingWrite(NamedTuple):
+    """A single pending write entry passed to batch flush methods.
+
+    This is the public type used in the ``SyncBatchFlushable`` and
+    ``AsyncBatchFlushable`` protocol signatures.
+    """
+
+    config: RunnableConfig
+    writes: list[tuple[str, Any]]
+    task_id: str
+    task_path: str
+
+
+@runtime_checkable
+class SyncBatchFlushable(Protocol):
+    """Protocol for savers that can persist checkpoint + writes in one sync call."""
+
+    def put_with_writes(
+        self,
+        config: RunnableConfig,
+        checkpoint: Checkpoint,
+        metadata: CheckpointMetadata,
+        new_versions: ChannelVersions,
+        pending_writes: list[PendingWrite],
+    ) -> RunnableConfig: ...
+
+
+@runtime_checkable
+class AsyncBatchFlushable(Protocol):
+    """Protocol for savers that can persist checkpoint + writes in one async call."""
+
+    async def aput_with_writes(
+        self,
+        config: RunnableConfig,
+        checkpoint: Checkpoint,
+        metadata: CheckpointMetadata,
+        new_versions: ChannelVersions,
+        pending_writes: list[PendingWrite],
+    ) -> RunnableConfig: ...
+
+
 class DeferredCheckpointSaver(BaseCheckpointSaver):
     """Checkpoint saver wrapper that buffers writes and flushes on demand.
 
@@ -54,6 +95,10 @@ class DeferredCheckpointSaver(BaseCheckpointSaver):
 
     Args:
         saver: The underlying checkpoint saver to delegate persistence to.
+        batch_writes: When ``True`` and the underlying saver implements
+            ``SyncBatchFlushable`` or ``AsyncBatchFlushable``, flush uses
+            a single ``put_with_writes`` call instead of 1 + N sequential
+            calls.  Defaults to ``False`` for backward compatibility.
 
     Raises:
         ValueError: If *saver* is itself a ``DeferredCheckpointSaver``
@@ -61,14 +106,16 @@ class DeferredCheckpointSaver(BaseCheckpointSaver):
 
     Example::
 
-        deferred = DeferredCheckpointSaver(my_saver)
+        deferred = DeferredCheckpointSaver(my_saver, batch_writes=True)
         graph = workflow.compile(checkpointer=deferred)
 
         with deferred.flush_on_exit():
             graph.invoke(input, config)
     """
 
-    def __init__(self, saver: BaseCheckpointSaver) -> None:
+    def __init__(
+        self, saver: BaseCheckpointSaver, *, batch_writes: bool = False
+    ) -> None:
         if isinstance(saver, DeferredCheckpointSaver):
             msg = (
                 "Nesting DeferredCheckpointSaver is not supported. "
@@ -77,6 +124,7 @@ class DeferredCheckpointSaver(BaseCheckpointSaver):
             raise ValueError(msg)
         super().__init__()
         self._saver = saver
+        self._batch_writes = batch_writes
         self._lock = threading.Lock()
         self._pending_checkpoint: _PendingCheckpoint | None = None
         self._pending_writes: list[_PendingWrite] = []
@@ -388,21 +436,83 @@ class DeferredCheckpointSaver(BaseCheckpointSaver):
     def flush(self) -> RunnableConfig | None:
         """Persist all buffered data to the underlying saver.
 
-        Flushes the buffered checkpoint first, then all accumulated writes.
+        When ``batch_writes=True`` and the saver implements
+        ``SyncBatchFlushable``, the checkpoint and all writes are persisted
+        in a single ``put_with_writes()`` call (fast path).  Otherwise the
+        checkpoint is flushed first, then writes are drained one at a time
+        (fallback path).
+
         The lock is never held during network I/O.
 
-        On checkpoint flush failure the checkpoint is restored to the buffer
-        and the exception is re-raised.  On write flush failure, successfully
-        flushed writes are removed; remaining writes stay in the buffer.
+        On failure the buffered data is restored (unless a newer ``put()``
+        raced in) and the exception is re-raised.
 
         Returns:
-            The config returned by the underlying saver's ``put()``, or
-            ``None`` if no checkpoint was buffered.
+            The config returned by the underlying saver's ``put()`` or
+            ``put_with_writes()``, or ``None`` if no checkpoint was buffered.
 
         Raises:
             Exception: Any exception raised by the underlying saver during
                 persistence is propagated after restoring unflushed data.
         """
+        # --- Fast path: saver supports sync batching ---
+        if self._batch_writes and isinstance(self._saver, SyncBatchFlushable):
+            return self._flush_batched()
+
+        # --- Fallback path: existing 1 + N behavior ---
+        return self._flush_sequential()
+
+    def _flush_batched(self) -> RunnableConfig | None:
+        """Fast path: persist checkpoint + writes in one call."""
+        with self._lock:
+            pending_cp = self._pending_checkpoint
+            pending_writes = list(self._pending_writes)
+            self._pending_checkpoint = None
+            self._pending_writes.clear()
+
+        if pending_cp is None:
+            if pending_writes:
+                with self._lock:
+                    self._pending_writes = pending_writes + self._pending_writes
+            return None
+
+        public_writes = [
+            PendingWrite(
+                config=w.config,
+                writes=w.writes,
+                task_id=w.task_id,
+                task_path=w.task_path,
+            )
+            for w in pending_writes
+        ]
+
+        try:
+            result_config = self._saver.put_with_writes(  # type: ignore[attr-defined]
+                pending_cp.config,
+                pending_cp.checkpoint,
+                pending_cp.metadata,
+                pending_cp.new_versions,
+                public_writes,
+            )
+        except Exception:
+            with self._lock:
+                if self._pending_checkpoint is None:
+                    self._pending_checkpoint = pending_cp
+                self._pending_writes = [
+                    _PendingWrite(
+                        config=w.config,
+                        writes=w.writes,
+                        task_id=w.task_id,
+                        task_path=w.task_path,
+                    )
+                    for w in pending_writes
+                ] + self._pending_writes
+            raise
+
+        return result_config
+
+    def _flush_sequential(self) -> RunnableConfig | None:
+        """Fallback path: flush checkpoint then drain writes one at a time."""
         result_config: RunnableConfig | None = None
 
         # --- Flush checkpoint ---
@@ -459,18 +569,79 @@ class DeferredCheckpointSaver(BaseCheckpointSaver):
     async def aflush(self) -> RunnableConfig | None:
         """Async version of :meth:`flush`.
 
+        When ``batch_writes=True`` and the saver implements
+        ``AsyncBatchFlushable``, uses ``aput_with_writes()`` (fast path).
+        Otherwise falls back to sequential ``aput()`` + N ``aput_writes()``.
+
         Returns:
-            The config returned by the underlying saver's ``aput()``, or
-            ``None`` if no checkpoint was buffered.
+            The config returned by the underlying saver, or ``None`` if no
+            checkpoint was buffered.
 
         Raises:
             Exception: Any exception raised by the underlying saver during
                 persistence is propagated after restoring unflushed data.
         """
+        # --- Fast path: saver supports async batching ---
+        if self._batch_writes and isinstance(self._saver, AsyncBatchFlushable):
+            return await self._aflush_batched()
+
+        # --- Fallback path: existing 1 + N behavior ---
+        return await self._aflush_sequential()
+
+    async def _aflush_batched(self) -> RunnableConfig | None:
+        """Async fast path: persist checkpoint + writes in one call."""
+        with self._lock:
+            pending_cp = self._pending_checkpoint
+            pending_writes = list(self._pending_writes)
+            self._pending_checkpoint = None
+            self._pending_writes.clear()
+
+        if pending_cp is None:
+            if pending_writes:
+                with self._lock:
+                    self._pending_writes = pending_writes + self._pending_writes
+            return None
+
+        public_writes = [
+            PendingWrite(
+                config=w.config,
+                writes=w.writes,
+                task_id=w.task_id,
+                task_path=w.task_path,
+            )
+            for w in pending_writes
+        ]
+
+        try:
+            result_config = await self._saver.aput_with_writes(  # type: ignore[attr-defined]
+                pending_cp.config,
+                pending_cp.checkpoint,
+                pending_cp.metadata,
+                pending_cp.new_versions,
+                public_writes,
+            )
+        except Exception:
+            with self._lock:
+                if self._pending_checkpoint is None:
+                    self._pending_checkpoint = pending_cp
+                self._pending_writes = [
+                    _PendingWrite(
+                        config=w.config,
+                        writes=w.writes,
+                        task_id=w.task_id,
+                        task_path=w.task_path,
+                    )
+                    for w in pending_writes
+                ] + self._pending_writes
+            raise
+
+        return result_config
+
+    async def _aflush_sequential(self) -> RunnableConfig | None:
+        """Async fallback path: flush checkpoint then drain writes."""
         result_config: RunnableConfig | None = None
 
         # --- Flush checkpoint ---
-        # Same race-condition-safe pattern as flush(). See comments there.
         with self._lock:
             pending_cp = self._pending_checkpoint
             self._pending_checkpoint = None
@@ -490,7 +661,6 @@ class DeferredCheckpointSaver(BaseCheckpointSaver):
                 raise
 
         # --- Flush writes one at a time ---
-        # Same peek-then-pop pattern as flush(). See comments there.
         while True:
             with self._lock:
                 if not self._pending_writes:

--- a/libs/langgraph-checkpoint-aws/tests/integration_tests/agentcore/test_batch_flush.py
+++ b/libs/langgraph-checkpoint-aws/tests/integration_tests/agentcore/test_batch_flush.py
@@ -1,0 +1,732 @@
+"""Integration tests for batch flush with AgentCoreMemorySaver.
+
+Tests the DeferredCheckpointSaver batch_writes=True path end-to-end
+against a real AgentCore Memory resource.
+
+Requires:
+    - AGENTCORE_MEMORY_ID environment variable set to a valid memory resource
+    - AWS credentials with bedrock-agentcore:CreateEvent, ListEvents, DeleteEvent
+"""
+
+from __future__ import annotations
+
+import datetime
+import os
+import random
+import string
+
+import pytest
+from langchain_core.runnables import RunnableConfig
+from langgraph.checkpoint.base import (
+    ChannelVersions,
+    Checkpoint,
+    uuid6,
+)
+
+from langgraph_checkpoint_aws.checkpoint.agentcore.saver import AgentCoreMemorySaver
+from langgraph_checkpoint_aws.checkpoint.deferred_saver import DeferredCheckpointSaver
+
+AWS_REGION = os.getenv("AWS_REGION", "us-west-2")
+
+
+def _generate_id(prefix: str = "test") -> str:
+    chars = string.ascii_letters + string.digits
+    return prefix + "".join(random.choices(chars, k=6))
+
+
+def _make_checkpoint(
+    channel_values: dict | None = None,
+    channel_versions: dict | None = None,
+) -> Checkpoint:
+    return Checkpoint(
+        v=1,
+        id=str(uuid6(clock_seq=-2)),
+        ts=datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        channel_values=channel_values or {"messages": ["test message"]},
+        channel_versions=channel_versions or {"messages": "v1"},
+        versions_seen={"node1": {"messages": "v1"}},
+        updated_channels=None,
+    )
+
+
+@pytest.fixture(scope="module")
+def memory_id():
+    mid = os.environ.get("AGENTCORE_MEMORY_ID")
+    if not mid:
+        pytest.skip("AGENTCORE_MEMORY_ID environment variable not set")
+    return mid
+
+
+@pytest.fixture(scope="module")
+def memory_saver(memory_id):
+    return AgentCoreMemorySaver(memory_id=memory_id, region_name=AWS_REGION)
+
+
+class TestBatchFlushIntegration:
+    """End-to-end tests for DeferredCheckpointSaver with batch_writes=True."""
+
+    def test_batch_flush_persists_checkpoint_and_writes(self, memory_saver) -> None:
+        """Batch flush persists checkpoint + writes in a single operation."""
+        thread_id = _generate_id("batchflush")
+        actor_id = _generate_id("actor")
+        deferred = DeferredCheckpointSaver(memory_saver, batch_writes=True)
+        checkpoint = _make_checkpoint()
+
+        config: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "actor_id": actor_id,
+                "checkpoint_ns": "",
+            }
+        }
+        write_config: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "actor_id": actor_id,
+                "checkpoint_ns": "",
+                "checkpoint_id": checkpoint["id"],
+            }
+        }
+
+        try:
+            deferred.put(
+                config,
+                checkpoint,
+                {"source": "input", "step": 1},
+                {"messages": "v1"},
+            )
+            deferred.put_writes(write_config, [("messages", "hello")], "task-1")
+            deferred.put_writes(write_config, [("tools", "result")], "task-2")
+
+            result = deferred.flush()
+
+            assert deferred.is_empty
+            assert result is not None
+            assert result["configurable"]["checkpoint_id"] == checkpoint["id"]
+
+            # Verify checkpoint persisted
+            persisted = memory_saver.get_tuple(write_config)
+            assert persisted is not None
+            assert persisted.checkpoint["id"] == checkpoint["id"]
+
+            # Verify writes persisted
+            assert persisted.pending_writes is not None
+            task_ids = {pw[0] for pw in persisted.pending_writes}
+            assert "task-1" in task_ids
+            assert "task-2" in task_ids
+        finally:
+            memory_saver.delete_thread(thread_id, actor_id)
+
+    def test_batch_flush_no_writes(self, memory_saver) -> None:
+        """Batch flush with only a checkpoint (no writes) works correctly."""
+        thread_id = _generate_id("batchnowrites")
+        actor_id = _generate_id("actor")
+        deferred = DeferredCheckpointSaver(memory_saver, batch_writes=True)
+        checkpoint = _make_checkpoint()
+
+        config: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "actor_id": actor_id,
+                "checkpoint_ns": "",
+            }
+        }
+
+        try:
+            deferred.put(
+                config,
+                checkpoint,
+                {"source": "input", "step": 1},
+                {"messages": "v1"},
+            )
+
+            result = deferred.flush()
+
+            assert deferred.is_empty
+            assert result is not None
+
+            saved_config: RunnableConfig = {
+                "configurable": {
+                    "thread_id": thread_id,
+                    "actor_id": actor_id,
+                    "checkpoint_ns": "",
+                    "checkpoint_id": checkpoint["id"],
+                }
+            }
+            persisted = memory_saver.get_tuple(saved_config)
+            assert persisted is not None
+            assert persisted.checkpoint["id"] == checkpoint["id"]
+        finally:
+            memory_saver.delete_thread(thread_id, actor_id)
+
+    def test_batch_flush_multiple_channels(self, memory_saver) -> None:
+        """Batch flush correctly persists multiple channel versions."""
+        thread_id = _generate_id("batchmulti")
+        actor_id = _generate_id("actor")
+        deferred = DeferredCheckpointSaver(memory_saver, batch_writes=True)
+        new_versions: ChannelVersions = {
+            "messages": "v2",
+            "state": "v2",
+            "results": "v2",
+        }
+        checkpoint = _make_checkpoint(
+            channel_values={
+                "messages": ["msg1", "msg2"],
+                "state": {"key": "value"},
+                "results": [1, 2, 3],
+            },
+            channel_versions=new_versions,
+        )
+
+        config: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "actor_id": actor_id,
+                "checkpoint_ns": "",
+            }
+        }
+
+        try:
+            deferred.put(
+                config,
+                checkpoint,
+                {"source": "loop", "step": 3},
+                new_versions,
+            )
+
+            deferred.flush()
+
+            saved_config: RunnableConfig = {
+                "configurable": {
+                    "thread_id": thread_id,
+                    "actor_id": actor_id,
+                    "checkpoint_ns": "",
+                    "checkpoint_id": checkpoint["id"],
+                }
+            }
+            persisted = memory_saver.get_tuple(saved_config)
+            assert persisted is not None
+            assert persisted.checkpoint["channel_values"]["messages"] == [
+                "msg1",
+                "msg2",
+            ]
+            assert persisted.checkpoint["channel_values"]["state"] == {"key": "value"}
+            assert persisted.checkpoint["channel_values"]["results"] == [1, 2, 3]
+        finally:
+            memory_saver.delete_thread(thread_id, actor_id)
+
+    def test_batch_flush_with_context_manager(self, memory_saver) -> None:
+        """flush_on_exit with batch_writes=True works end-to-end."""
+        thread_id = _generate_id("batchctx")
+        actor_id = _generate_id("actor")
+        deferred = DeferredCheckpointSaver(memory_saver, batch_writes=True)
+        checkpoint = _make_checkpoint()
+
+        config: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "actor_id": actor_id,
+                "checkpoint_ns": "",
+            }
+        }
+        write_config: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "actor_id": actor_id,
+                "checkpoint_ns": "",
+                "checkpoint_id": checkpoint["id"],
+            }
+        }
+
+        try:
+            with deferred.flush_on_exit():
+                deferred.put(
+                    config,
+                    checkpoint,
+                    {"source": "input", "step": 1},
+                    {"messages": "v1"},
+                )
+                deferred.put_writes(write_config, [("messages", "batched")], "task-ctx")
+
+            assert deferred.is_empty
+
+            persisted = memory_saver.get_tuple(write_config)
+            assert persisted is not None
+            assert persisted.checkpoint["id"] == checkpoint["id"]
+            assert persisted.pending_writes is not None
+            assert any(pw[0] == "task-ctx" for pw in persisted.pending_writes)
+        finally:
+            memory_saver.delete_thread(thread_id, actor_id)
+
+    @pytest.mark.asyncio
+    async def test_async_batch_flush(self, memory_saver) -> None:
+        """aflush with batch_writes=True works end-to-end."""
+        thread_id = _generate_id("asyncbatch")
+        actor_id = _generate_id("actor")
+        deferred = DeferredCheckpointSaver(memory_saver, batch_writes=True)
+        checkpoint = _make_checkpoint()
+
+        config: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "actor_id": actor_id,
+                "checkpoint_ns": "",
+            }
+        }
+        write_config: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "actor_id": actor_id,
+                "checkpoint_ns": "",
+                "checkpoint_id": checkpoint["id"],
+            }
+        }
+
+        try:
+            await deferred.aput(
+                config,
+                checkpoint,
+                {"source": "input", "step": 1},
+                {"messages": "v1"},
+            )
+            await deferred.aput_writes(
+                write_config, [("messages", "async-batched")], "task-async"
+            )
+
+            result = await deferred.aflush()
+
+            assert deferred.is_empty
+            assert result is not None
+
+            persisted = memory_saver.get_tuple(write_config)
+            assert persisted is not None
+            assert persisted.checkpoint["id"] == checkpoint["id"]
+            assert persisted.pending_writes is not None
+            assert any(pw[0] == "task-async" for pw in persisted.pending_writes)
+        finally:
+            memory_saver.delete_thread(thread_id, actor_id)
+
+    def test_batch_flush_many_writes(self, memory_saver) -> None:
+        """Batch flush handles many writes from multiple tasks."""
+        thread_id = _generate_id("batchmany")
+        actor_id = _generate_id("actor")
+        deferred = DeferredCheckpointSaver(memory_saver, batch_writes=True)
+        checkpoint = _make_checkpoint()
+
+        config: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "actor_id": actor_id,
+                "checkpoint_ns": "",
+            }
+        }
+        write_config: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "actor_id": actor_id,
+                "checkpoint_ns": "",
+                "checkpoint_id": checkpoint["id"],
+            }
+        }
+
+        try:
+            deferred.put(
+                config,
+                checkpoint,
+                {"source": "loop", "step": 5},
+                {"messages": "v1"},
+            )
+
+            # Simulate a 5-node graph with writes from each node
+            for i in range(5):
+                deferred.put_writes(
+                    write_config,
+                    [(f"channel_{i}", f"value_{i}")],
+                    f"task-{i}",
+                    f"/node/{i}",
+                )
+
+            deferred.flush()
+            assert deferred.is_empty
+
+            persisted = memory_saver.get_tuple(write_config)
+            assert persisted is not None
+            assert persisted.pending_writes is not None
+            persisted_task_ids = {pw[0] for pw in persisted.pending_writes}
+            for i in range(5):
+                assert f"task-{i}" in persisted_task_ids
+        finally:
+            memory_saver.delete_thread(thread_id, actor_id)
+
+    def test_batch_flush_get_tuple_after_flush(self, memory_saver) -> None:
+        """get_tuple reads from backend after batch flush."""
+        thread_id = _generate_id("batchget")
+        actor_id = _generate_id("actor")
+        deferred = DeferredCheckpointSaver(memory_saver, batch_writes=True)
+        checkpoint = _make_checkpoint()
+
+        config: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "actor_id": actor_id,
+                "checkpoint_ns": "",
+            }
+        }
+
+        try:
+            deferred.put(
+                config,
+                checkpoint,
+                {"source": "input", "step": 1},
+                {"messages": "v1"},
+            )
+            deferred.flush()
+
+            # Buffer is empty — get_tuple should delegate to backend
+            assert deferred.is_empty
+            result = deferred.get_tuple(config)
+            assert result is not None
+            assert result.checkpoint["id"] == checkpoint["id"]
+        finally:
+            memory_saver.delete_thread(thread_id, actor_id)
+
+    def test_batch_flush_list_shows_persisted(self, memory_saver) -> None:
+        """list() returns batch-flushed checkpoints."""
+        thread_id = _generate_id("batchlist")
+        actor_id = _generate_id("actor")
+        deferred = DeferredCheckpointSaver(memory_saver, batch_writes=True)
+
+        config: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "actor_id": actor_id,
+                "checkpoint_ns": "",
+            }
+        }
+
+        try:
+            # Buffer and flush — list should not show buffered data
+            deferred.put(
+                config,
+                _make_checkpoint(),
+                {"source": "input", "step": 1},
+                {"messages": "v1"},
+            )
+            assert len(list(deferred.list(config))) == 0
+
+            deferred.flush()
+            assert len(list(deferred.list(config))) >= 1
+        finally:
+            memory_saver.delete_thread(thread_id, actor_id)
+
+    def test_batch_flush_splits_when_exceeding_item_limit(self, memory_saver) -> None:
+        """Payload exceeding MAX_PAYLOAD_ITEMS_PER_EVENT splits into multiple calls.
+
+        We create enough writes to push total payload items over 100.
+        The chunking in store_blob_events_batch should split the batch
+        transparently and all data should persist correctly.
+        """
+        thread_id = _generate_id("batchsplit")
+        actor_id = _generate_id("actor")
+        deferred = DeferredCheckpointSaver(memory_saver, batch_writes=True)
+        checkpoint = _make_checkpoint()
+
+        config: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "actor_id": actor_id,
+                "checkpoint_ns": "",
+            }
+        }
+        write_config: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "actor_id": actor_id,
+                "checkpoint_ns": "",
+                "checkpoint_id": checkpoint["id"],
+            }
+        }
+
+        try:
+            # 1 channel event + 1 checkpoint event = 2 payload items from put
+            # Each put_writes adds 1 WritesEvent = 1 payload item
+            # To exceed 100: we need 99+ writes (2 + 99 = 101 > 100)
+            deferred.put(
+                config,
+                checkpoint,
+                {"source": "loop", "step": 10},
+                {"messages": "v1"},
+            )
+
+            num_writes = 105
+            for i in range(num_writes):
+                deferred.put_writes(
+                    write_config,
+                    [(f"channel_{i}", f"value_{i}")],
+                    f"task-{i}",
+                    f"/node/{i}",
+                )
+
+            deferred.flush()
+            assert deferred.is_empty
+
+            # Verify checkpoint persisted
+            persisted = memory_saver.get_tuple(write_config)
+            assert persisted is not None
+            assert persisted.checkpoint["id"] == checkpoint["id"]
+
+            # Verify all writes persisted
+            assert persisted.pending_writes is not None
+            persisted_task_ids = {pw[0] for pw in persisted.pending_writes}
+            for i in range(num_writes):
+                assert f"task-{i}" in persisted_task_ids
+        finally:
+            memory_saver.delete_thread(thread_id, actor_id)
+
+    def test_store_blob_events_batch_chunking_by_bytes_direct(
+        self, memory_saver
+    ) -> None:
+        """Directly test byte-based chunking with a lowered max_payload_bytes.
+
+        Calls store_blob_events_batch with max_payload_bytes set below the
+        total serialized size, forcing the batch to split across multiple
+        CreateEvent API calls. Verifies all events persist correctly.
+        """
+        from langgraph_checkpoint_aws.checkpoint.agentcore.models import (
+            ChannelDataEvent,
+            CheckpointEvent,
+            WriteItem,
+            WritesEvent,
+        )
+
+        thread_id = _generate_id("chunkbytes")
+        actor_id = _generate_id("actor")
+
+        try:
+            large_value = "Y" * 5000  # ~5 KB per channel value
+            events: list[ChannelDataEvent | CheckpointEvent | WritesEvent] = []
+            for i in range(4):
+                events.append(
+                    ChannelDataEvent(
+                        channel=f"big_ch_{i}",
+                        version="v1",
+                        value=large_value,
+                        thread_id=thread_id,
+                        checkpoint_ns="",
+                    )
+                )
+            events.append(
+                CheckpointEvent(
+                    checkpoint_id="byte-chunk-ckpt",
+                    checkpoint_data={
+                        "v": 1,
+                        "id": "byte-chunk-ckpt",
+                        "ts": "2025-01-01",
+                    },
+                    metadata={"source": "input", "step": 0},
+                    parent_checkpoint_id=None,
+                    thread_id=thread_id,
+                    checkpoint_ns="",
+                )
+            )
+            for i in range(3):
+                events.append(
+                    WritesEvent(
+                        checkpoint_id="byte-chunk-ckpt",
+                        writes=[
+                            WriteItem(
+                                task_id=f"task-byte-{i}",
+                                channel=f"write_ch_{i}",
+                                value=large_value,
+                                task_path=f"/node/{i}",
+                            )
+                        ],
+                    )
+                )
+
+            # Measure actual serialized size of one large event
+            serialized_sample = (
+                memory_saver.checkpoint_event_client.serializer.serialize_event(
+                    events[0]
+                )
+            )
+            one_blob_bytes = len(serialized_sample.encode("utf-8"))
+
+            # Set max_payload_bytes to fit ~2 blobs per call
+            max_bytes = one_blob_bytes * 2 + 100
+
+            memory_saver.checkpoint_event_client.store_blob_events_batch(
+                events,
+                thread_id,
+                actor_id,
+                max_payload_bytes=max_bytes,
+            )
+
+            # Verify all 8 events are retrievable
+            retrieved = memory_saver.checkpoint_event_client.get_events(
+                thread_id, actor_id
+            )
+            assert len(retrieved) == 8
+
+            # Verify checkpoint present
+            checkpoints = [
+                e
+                for e in retrieved
+                if hasattr(e, "checkpoint_id") and hasattr(e, "checkpoint_data")
+            ]
+            assert len(checkpoints) == 1
+            assert checkpoints[0].checkpoint_id == "byte-chunk-ckpt"
+
+            # Verify channel data present
+            channel_events = [
+                e for e in retrieved if hasattr(e, "channel") and hasattr(e, "version")
+            ]
+            assert len(channel_events) == 4
+
+            # Verify writes present
+            writes_events = [
+                e
+                for e in retrieved
+                if hasattr(e, "writes") and not hasattr(e, "checkpoint_data")
+            ]
+            assert len(writes_events) == 3
+        finally:
+            memory_saver.delete_thread(thread_id, actor_id)
+
+    def test_store_blob_events_batch_chunking_direct(self, memory_saver) -> None:
+        """Directly test store_blob_events_batch with a lowered item limit.
+
+        Calls the client directly with max_payload_items=3 and verifies
+        all events persist correctly across multiple API calls.
+        """
+        from langgraph_checkpoint_aws.checkpoint.agentcore.models import (
+            ChannelDataEvent,
+            CheckpointEvent,
+            WriteItem,
+            WritesEvent,
+        )
+
+        thread_id = _generate_id("chunkdirect")
+        actor_id = _generate_id("actor")
+
+        try:
+            # Build 7 events: 3 channels + 1 checkpoint + 3 writes
+            events: list[ChannelDataEvent | CheckpointEvent | WritesEvent] = []
+            for i in range(3):
+                events.append(
+                    ChannelDataEvent(
+                        channel=f"ch_{i}",
+                        version="v1",
+                        value=f"value_{i}",
+                        thread_id=thread_id,
+                        checkpoint_ns="",
+                    )
+                )
+            events.append(
+                CheckpointEvent(
+                    checkpoint_id="chunk-ckpt-1",
+                    checkpoint_data={"v": 1, "id": "chunk-ckpt-1", "ts": "2025-01-01"},
+                    metadata={"source": "input", "step": 0},
+                    parent_checkpoint_id=None,
+                    thread_id=thread_id,
+                    checkpoint_ns="",
+                )
+            )
+            for i in range(3):
+                events.append(
+                    WritesEvent(
+                        checkpoint_id="chunk-ckpt-1",
+                        writes=[
+                            WriteItem(
+                                task_id=f"task-chunk-{i}",
+                                channel=f"write_ch_{i}",
+                                value=f"write_val_{i}",
+                                task_path=f"/node/{i}",
+                            )
+                        ],
+                    )
+                )
+
+            # Store with max_payload_items=3 — forces 3 API calls: [3, 3, 1]
+            memory_saver.checkpoint_event_client.store_blob_events_batch(
+                events,
+                thread_id,
+                actor_id,
+                max_payload_items=3,
+            )
+
+            # Verify all events are retrievable
+            retrieved = memory_saver.checkpoint_event_client.get_events(
+                thread_id, actor_id
+            )
+            assert len(retrieved) == 7
+
+            # Verify checkpoint is present
+            checkpoints = [
+                e
+                for e in retrieved
+                if hasattr(e, "checkpoint_id") and hasattr(e, "checkpoint_data")
+            ]
+            assert len(checkpoints) == 1
+            assert checkpoints[0].checkpoint_id == "chunk-ckpt-1"
+        finally:
+            memory_saver.delete_thread(thread_id, actor_id)
+
+    def test_put_with_writes_direct(self, memory_saver) -> None:
+        """Test put_with_writes directly on AgentCoreMemorySaver."""
+        from langgraph_checkpoint_aws.checkpoint.deferred_saver import PendingWrite
+
+        thread_id = _generate_id("directpww")
+        actor_id = _generate_id("actor")
+        checkpoint = _make_checkpoint()
+
+        config: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "actor_id": actor_id,
+                "checkpoint_ns": "",
+            }
+        }
+
+        pending_writes = [
+            PendingWrite(
+                config={
+                    "configurable": {
+                        "thread_id": thread_id,
+                        "actor_id": actor_id,
+                        "checkpoint_ns": "",
+                        "checkpoint_id": checkpoint["id"],
+                    }
+                },
+                writes=[("messages", "direct-write")],
+                task_id="task-direct",
+                task_path="/direct",
+            ),
+        ]
+
+        try:
+            result = memory_saver.put_with_writes(
+                config,
+                checkpoint,
+                {"source": "input", "step": 1},
+                {"messages": "v1"},
+                pending_writes,
+            )
+
+            assert result["configurable"]["checkpoint_id"] == checkpoint["id"]
+
+            saved_config: RunnableConfig = {
+                "configurable": {
+                    "thread_id": thread_id,
+                    "actor_id": actor_id,
+                    "checkpoint_ns": "",
+                    "checkpoint_id": checkpoint["id"],
+                }
+            }
+            persisted = memory_saver.get_tuple(saved_config)
+            assert persisted is not None
+            assert persisted.checkpoint["id"] == checkpoint["id"]
+            assert persisted.pending_writes is not None
+            assert any(pw[0] == "task-direct" for pw in persisted.pending_writes)
+        finally:
+            memory_saver.delete_thread(thread_id, actor_id)

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_saver.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_saver.py
@@ -608,6 +608,145 @@ class TestAgentCoreMemorySaver:
 
         assert "checkpoint_id is required" in str(exc_info.value)
 
+    def test_put_with_writes_success(
+        self,
+        saver,
+        mock_boto_client,
+        runnable_config,
+        sample_checkpoint,
+        sample_checkpoint_metadata,
+    ):
+        """put_with_writes sends checkpoint + writes in a single create_event."""
+        from langgraph_checkpoint_aws.checkpoint.deferred_saver import PendingWrite
+
+        new_versions = {"default": "v2", "tasks": "v3"}
+        pending_writes = [
+            PendingWrite(
+                config=runnable_config,
+                writes=[("channel_1", "value_1"), ("channel_2", "value_2")],
+                task_id="task_1",
+                task_path="/path/1",
+            ),
+            PendingWrite(
+                config=runnable_config,
+                writes=[(TASKS, {"task": "data"})],
+                task_id="task_2",
+                task_path="/path/2",
+            ),
+        ]
+
+        result = saver.put_with_writes(
+            runnable_config,
+            sample_checkpoint,
+            sample_checkpoint_metadata,
+            new_versions,
+            pending_writes,
+        )
+
+        assert result["configurable"]["checkpoint_id"] == "checkpoint_123"
+        assert result["configurable"]["thread_id"] == "test_thread_id"
+        assert result["configurable"]["actor_id"] == "test_actor_id"
+        assert result["configurable"]["checkpoint_ns"] == "test_namespace"
+
+        mock_boto_client.create_event.assert_called_once()
+        call_args = mock_boto_client.create_event.call_args[1]
+        assert call_args["memoryId"] == saver.memory_id
+        assert call_args["actorId"] == "test_actor_id"
+        # 2 channels + 1 checkpoint + 2 writes events = 5 blobs
+        assert len(call_args["payload"]) == 5
+
+    def test_put_with_writes_no_pending_writes(
+        self,
+        saver,
+        mock_boto_client,
+        runnable_config,
+        sample_checkpoint,
+        sample_checkpoint_metadata,
+    ):
+        """put_with_writes with empty writes list behaves like put."""
+        new_versions = {"default": "v2"}
+
+        result = saver.put_with_writes(
+            runnable_config,
+            sample_checkpoint,
+            sample_checkpoint_metadata,
+            new_versions,
+            [],
+        )
+
+        assert result["configurable"]["checkpoint_id"] == "checkpoint_123"
+        mock_boto_client.create_event.assert_called_once()
+        call_args = mock_boto_client.create_event.call_args[1]
+        # 1 channel + 1 checkpoint = 2 blobs (no writes)
+        assert len(call_args["payload"]) == 2
+
+    def test_put_with_writes_preserves_channel_data(
+        self,
+        saver,
+        mock_boto_client,
+        runnable_config,
+        sample_checkpoint_metadata,
+    ):
+        """put_with_writes serializes channel values from checkpoint."""
+        checkpoint = Checkpoint(
+            v=1,
+            id="checkpoint_456",
+            ts="2024-01-01T00:00:00Z",
+            channel_values={"messages": ["hello", "world"], "state": 42},
+            channel_versions={"messages": "v1", "state": "v1"},
+            versions_seen={},
+            pending_sends=[],
+        )
+        new_versions = {"messages": "v2", "state": "v2"}
+
+        saver.put_with_writes(
+            runnable_config,
+            checkpoint,
+            sample_checkpoint_metadata,
+            new_versions,
+            [],
+        )
+
+        mock_boto_client.create_event.assert_called_once()
+        call_args = mock_boto_client.create_event.call_args[1]
+        # 2 channels + 1 checkpoint = 3 blobs
+        assert len(call_args["payload"]) == 3
+
+    async def test_aput_with_writes_delegates_to_sync(
+        self,
+        saver,
+        mock_boto_client,
+        runnable_config,
+        sample_checkpoint,
+        sample_checkpoint_metadata,
+    ):
+        """aput_with_writes runs put_with_writes in executor."""
+        from langgraph_checkpoint_aws.checkpoint.deferred_saver import PendingWrite
+
+        new_versions = {"default": "v2"}
+        pending_writes = [
+            PendingWrite(
+                config=runnable_config,
+                writes=[("channel_1", "value_1")],
+                task_id="task_1",
+                task_path="",
+            ),
+        ]
+
+        result = await saver.aput_with_writes(
+            runnable_config,
+            sample_checkpoint,
+            sample_checkpoint_metadata,
+            new_versions,
+            pending_writes,
+        )
+
+        assert result["configurable"]["checkpoint_id"] == "checkpoint_123"
+        mock_boto_client.create_event.assert_called_once()
+        call_args = mock_boto_client.create_event.call_args[1]
+        # 1 channel + 1 checkpoint + 1 writes event = 3 blobs
+        assert len(call_args["payload"]) == 3
+
     def test_delete_thread_success(
         self,
         saver,
@@ -1058,6 +1197,323 @@ class TestAgentCoreEventClient:
         mock_boto_client.create_event.assert_called_once()
         call_args = mock_boto_client.create_event.call_args[1]
         assert len(call_args["payload"]) == 2
+
+    def test_store_blob_events_batch_chunks_by_item_count(
+        self,
+        client,
+        mock_boto_client,
+        sample_channel_data_event,
+    ):
+        """Batches exceeding max_payload_items are split into multiple calls."""
+        # Create 5 events but set max to 2 items per call
+        events = [sample_channel_data_event] * 5
+        client.store_blob_events_batch(
+            events, "session_id", "actor_id", max_payload_items=2
+        )
+
+        # Should produce 3 API calls: [2, 2, 1]
+        assert mock_boto_client.create_event.call_count == 3
+        calls = mock_boto_client.create_event.call_args_list
+        assert len(calls[0][1]["payload"]) == 2
+        assert len(calls[1][1]["payload"]) == 2
+        assert len(calls[2][1]["payload"]) == 1
+
+    def test_store_blob_events_batch_chunks_by_byte_size(
+        self,
+        client,
+        mock_boto_client,
+        sample_checkpoint_event,
+    ):
+        """Batches exceeding max_payload_bytes are split into multiple calls."""
+        # Serialize one event to measure its size
+        serialized = client.serializer.serialize_event(sample_checkpoint_event)
+        blob_size = len(serialized.encode("utf-8"))
+
+        # Set max bytes to fit at most 2 blobs
+        max_bytes = blob_size * 2 + 1
+        events = [sample_checkpoint_event] * 5
+
+        client.store_blob_events_batch(
+            events, "session_id", "actor_id", max_payload_bytes=max_bytes
+        )
+
+        # Should produce 3 API calls: [2, 2, 1]
+        assert mock_boto_client.create_event.call_count == 3
+        calls = mock_boto_client.create_event.call_args_list
+        assert len(calls[0][1]["payload"]) == 2
+        assert len(calls[1][1]["payload"]) == 2
+        assert len(calls[2][1]["payload"]) == 1
+
+    def test_store_blob_events_batch_single_oversized_blob(
+        self,
+        client,
+        mock_boto_client,
+        sample_checkpoint_event,
+    ):
+        """A single blob that exceeds max_payload_bytes still gets its own call."""
+        # Set max bytes smaller than one blob
+        events = [sample_checkpoint_event]
+        client.store_blob_events_batch(
+            events, "session_id", "actor_id", max_payload_bytes=1
+        )
+
+        # Still sends one call (a single blob is always in its own chunk)
+        mock_boto_client.create_event.assert_called_once()
+        assert len(mock_boto_client.create_event.call_args[1]["payload"]) == 1
+
+    def test_store_blob_events_batch_within_limits_single_call(
+        self,
+        client,
+        mock_boto_client,
+        sample_channel_data_event,
+    ):
+        """Batch within limits sends a single API call."""
+        events = [sample_channel_data_event] * 50
+        client.store_blob_events_batch(events, "session_id", "actor_id")
+
+        # Default limit is 100 items, so 50 stays within one call
+        mock_boto_client.create_event.assert_called_once()
+        assert len(mock_boto_client.create_event.call_args[1]["payload"]) == 50
+
+    def test_store_blob_events_batch_empty_list(
+        self,
+        client,
+        mock_boto_client,
+    ):
+        """Empty event list makes no API calls."""
+        client.store_blob_events_batch([], "session_id", "actor_id")
+        mock_boto_client.create_event.assert_not_called()
+
+    def test_store_blob_events_batch_exactly_at_limit(
+        self,
+        client,
+        mock_boto_client,
+        sample_channel_data_event,
+    ):
+        """Exactly 100 events fit in one call (the max)."""
+        events = [sample_channel_data_event] * 100
+        client.store_blob_events_batch(events, "session_id", "actor_id")
+
+        mock_boto_client.create_event.assert_called_once()
+        assert len(mock_boto_client.create_event.call_args[1]["payload"]) == 100
+
+    def test_store_blob_events_batch_101_events_splits(
+        self,
+        client,
+        mock_boto_client,
+        sample_channel_data_event,
+    ):
+        """101 events split into two calls: [100, 1]."""
+        events = [sample_channel_data_event] * 101
+        client.store_blob_events_batch(events, "session_id", "actor_id")
+
+        assert mock_boto_client.create_event.call_count == 2
+        calls = mock_boto_client.create_event.call_args_list
+        assert len(calls[0][1]["payload"]) == 100
+        assert len(calls[1][1]["payload"]) == 1
+
+    def test_store_blob_events_batch_both_limits_hit(
+        self,
+        client,
+        mock_boto_client,
+        sample_checkpoint_event,
+    ):
+        """When both item count and byte size limits apply, the stricter wins."""
+        serialized = client.serializer.serialize_event(sample_checkpoint_event)
+        blob_size = len(serialized.encode("utf-8"))
+
+        # max_payload_items=3 but byte size only allows 1
+        events = [sample_checkpoint_event] * 4
+        client.store_blob_events_batch(
+            events,
+            "session_id",
+            "actor_id",
+            max_payload_items=3,
+            max_payload_bytes=blob_size + 1,
+        )
+
+        # Byte limit forces 1 per chunk = 4 calls
+        assert mock_boto_client.create_event.call_count == 4
+        for call_entry in mock_boto_client.create_event.call_args_list:
+            assert len(call_entry[1]["payload"]) == 1
+
+    def test_store_blob_events_batch_preserves_order(
+        self,
+        client,
+        mock_boto_client,
+        sample_checkpoint_event,
+        sample_channel_data_event,
+        sample_writes_event,
+    ):
+        """Chunked events preserve their original order across calls."""
+        events = [
+            sample_channel_data_event,
+            sample_checkpoint_event,
+            sample_writes_event,
+        ]
+        client.store_blob_events_batch(
+            events, "session_id", "actor_id", max_payload_items=1
+        )
+
+        assert mock_boto_client.create_event.call_count == 3
+        calls = mock_boto_client.create_event.call_args_list
+
+        # Deserialize each payload blob to verify order
+        blob_0 = calls[0][1]["payload"][0]["blob"]
+        blob_1 = calls[1][1]["payload"][0]["blob"]
+        blob_2 = calls[2][1]["payload"][0]["blob"]
+
+        event_0 = client.serializer.deserialize_event(blob_0)
+        event_1 = client.serializer.deserialize_event(blob_1)
+        event_2 = client.serializer.deserialize_event(blob_2)
+
+        assert isinstance(event_0, ChannelDataEvent)
+        assert isinstance(event_1, CheckpointEvent)
+        assert isinstance(event_2, WritesEvent)
+
+    def test_store_blob_events_batch_uses_same_timestamp(
+        self,
+        client,
+        mock_boto_client,
+        sample_channel_data_event,
+    ):
+        """All chunked calls use the same eventTimestamp."""
+        events = [sample_channel_data_event] * 5
+        client.store_blob_events_batch(
+            events, "session_id", "actor_id", max_payload_items=2
+        )
+
+        assert mock_boto_client.create_event.call_count == 3
+        timestamps = [
+            call_entry[1]["eventTimestamp"]
+            for call_entry in mock_boto_client.create_event.call_args_list
+        ]
+        # All timestamps should be identical
+        assert timestamps[0] == timestamps[1] == timestamps[2]
+
+    def test_store_blob_events_batch_uses_correct_session_and_actor(
+        self,
+        client,
+        mock_boto_client,
+        sample_channel_data_event,
+    ):
+        """All chunked calls use the same session_id, actor_id, and memory_id."""
+        events = [sample_channel_data_event] * 3
+        client.store_blob_events_batch(
+            events, "my-session", "my-actor", max_payload_items=1
+        )
+
+        assert mock_boto_client.create_event.call_count == 3
+        for call_entry in mock_boto_client.create_event.call_args_list:
+            kwargs = call_entry[1]
+            assert kwargs["memoryId"] == "test-memory-id"
+            assert kwargs["sessionId"] == "my-session"
+            assert kwargs["actorId"] == "my-actor"
+
+
+class TestChunkPayload:
+    """Direct unit tests for AgentCoreEventClient._chunk_payload static method."""
+
+    def test_empty_input(self):
+        result = AgentCoreEventClient._chunk_payload([], 100, 10_000_000)
+        assert result == []
+
+    def test_single_blob_within_limits(self):
+        result = AgentCoreEventClient._chunk_payload(["hello"], 100, 10_000_000)
+        assert result == [["hello"]]
+
+    def test_splits_by_item_count(self):
+        blobs = ["a", "b", "c", "d", "e"]
+        result = AgentCoreEventClient._chunk_payload(blobs, 2, 10_000_000)
+        assert result == [["a", "b"], ["c", "d"], ["e"]]
+
+    def test_splits_by_byte_size(self):
+        # Each blob is 10 bytes UTF-8
+        blobs = ["x" * 10] * 5
+        # Allow at most 25 bytes per chunk (fits 2 blobs of 10 bytes each)
+        result = AgentCoreEventClient._chunk_payload(blobs, 100, 25)
+        assert result == [["x" * 10, "x" * 10], ["x" * 10, "x" * 10], ["x" * 10]]
+
+    def test_single_blob_exceeds_byte_limit(self):
+        """A blob larger than max_bytes still gets its own chunk."""
+        big_blob = "x" * 1000
+        result = AgentCoreEventClient._chunk_payload([big_blob], 100, 10)
+        assert result == [[big_blob]]
+
+    def test_multiple_oversized_blobs(self):
+        """Each oversized blob gets its own chunk."""
+        blobs = ["x" * 100, "y" * 100, "z" * 100]
+        result = AgentCoreEventClient._chunk_payload(blobs, 100, 50)
+        assert result == [["x" * 100], ["y" * 100], ["z" * 100]]
+
+    def test_mixed_sizes(self):
+        """Mix of small and large blobs chunk correctly."""
+        small = "s"  # 1 byte
+        big = "B" * 50  # 50 bytes
+        blobs = [small, small, big, small, big]
+        # Chunk 1: s(1) + s(1) + B*50(50) + s(1) = 53 bytes, fits in 60
+        # Adding next big(50) would be 103 > 60, so new chunk
+        # Chunk 2: B*50(50) = 50 bytes
+        result = AgentCoreEventClient._chunk_payload(blobs, 100, 60)
+        assert result == [[small, small, big, small], [big]]
+
+    def test_item_limit_one(self):
+        """Max 1 item per chunk gives one chunk per blob."""
+        blobs = ["a", "b", "c"]
+        result = AgentCoreEventClient._chunk_payload(blobs, 1, 10_000_000)
+        assert result == [["a"], ["b"], ["c"]]
+
+    def test_exact_byte_boundary(self):
+        """Blob that exactly fills the byte budget starts a new chunk."""
+        # Each blob is exactly 5 bytes
+        blobs = ["12345", "67890", "abcde"]
+        # Max 10 bytes: first two fit exactly, third starts new chunk
+        result = AgentCoreEventClient._chunk_payload(blobs, 100, 10)
+        assert result == [["12345", "67890"], ["abcde"]]
+
+    def test_unicode_byte_counting(self):
+        """Byte size accounts for multi-byte UTF-8 characters."""
+        # Each emoji is 4 bytes in UTF-8
+        emoji_blob = "\U0001f600"  # single emoji, 4 bytes
+        blobs = [emoji_blob] * 3
+        # Max 8 bytes: fits 2 emoji blobs (4 + 4 = 8), third starts new chunk
+        result = AgentCoreEventClient._chunk_payload(blobs, 100, 8)
+        assert result == [[emoji_blob, emoji_blob], [emoji_blob]]
+
+    def test_preserves_blob_order(self):
+        blobs = ["first", "second", "third", "fourth", "fifth"]
+        result = AgentCoreEventClient._chunk_payload(blobs, 2, 10_000_000)
+        flat = [blob for chunk in result for blob in chunk]
+        assert flat == blobs
+
+    def test_default_limits_no_split_for_typical_payload(self):
+        """Typical small payloads stay in one chunk with default limits."""
+        blobs = ["x" * 200] * 50  # 50 blobs of 200 bytes = 10 KB total
+        result = AgentCoreEventClient._chunk_payload(blobs, 100, 10_000_000)
+        assert len(result) == 1
+        assert len(result[0]) == 50
+
+
+class TestAgentCoreEventClientGetAndDelete:
+    """Continuation of AgentCoreEventClient tests for get/delete operations."""
+
+    @pytest.fixture
+    def mock_boto_client(self):
+        mock_client = Mock()
+        mock_client.create_event = MagicMock()
+        mock_client.list_events = MagicMock()
+        mock_client.delete_event = MagicMock()
+        return mock_client
+
+    @pytest.fixture
+    def serializer(self):
+        return EventSerializer(JsonPlusSerializer())
+
+    @pytest.fixture
+    def client(self, mock_boto_client, serializer):
+        with patch("boto3.client") as mock_boto3_client:
+            mock_boto3_client.return_value = mock_boto_client
+            yield AgentCoreEventClient("test-memory-id", serializer)
 
     def test_get_events(
         self, client, mock_boto_client, serializer, sample_checkpoint_event

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/test_batch_flush.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/test_batch_flush.py
@@ -1,0 +1,546 @@
+"""Unit tests for batch flush functionality with AgentCoreMemorySaver."""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from langchain_core.runnables import RunnableConfig
+from langgraph.checkpoint.base import (
+    ChannelVersions,
+    Checkpoint,
+    CheckpointMetadata,
+)
+from langgraph.checkpoint.memory import MemorySaver
+
+from langgraph_checkpoint_aws.checkpoint.agentcore.saver import AgentCoreMemorySaver
+from langgraph_checkpoint_aws.checkpoint.deferred_saver import (
+    AsyncBatchFlushable,
+    DeferredCheckpointSaver,
+    PendingWrite,
+    SyncBatchFlushable,
+)
+
+
+def _make_config(
+    thread_id: str = "thread-1",
+    actor_id: str = "actor-1",
+    checkpoint_ns: str = "",
+    checkpoint_id: str | None = None,
+    **extra: Any,
+) -> RunnableConfig:
+    cfg: RunnableConfig = {
+        "configurable": {
+            "thread_id": thread_id,
+            "actor_id": actor_id,
+            "checkpoint_ns": checkpoint_ns,
+            **extra,
+        }
+    }
+    if checkpoint_id is not None:
+        cfg["configurable"]["checkpoint_id"] = checkpoint_id
+    return cfg
+
+
+def _make_checkpoint(checkpoint_id: str = "ckpt-1") -> Checkpoint:
+    return Checkpoint(
+        v=1,
+        id=checkpoint_id,
+        ts="2025-01-01T00:00:00+00:00",
+        channel_values={"messages": ["hello"]},
+        channel_versions={"messages": "v1"},
+        versions_seen={"node1": {"messages": "v1"}},
+        updated_channels=None,
+    )
+
+
+def _make_metadata(step: int = 0) -> CheckpointMetadata:
+    return CheckpointMetadata(
+        source="input",
+        step=step,
+        parents={},
+    )
+
+
+@pytest.fixture
+def mock_boto_client():
+    mock_client = Mock()
+    mock_client.create_event = MagicMock()
+    mock_client.list_events = MagicMock(return_value={"events": []})
+    mock_client.delete_event = MagicMock()
+    return mock_client
+
+
+@pytest.fixture
+def agentcore_saver(mock_boto_client):
+    with patch("boto3.client") as mock_boto3_client:
+        mock_boto3_client.return_value = mock_boto_client
+        yield AgentCoreMemorySaver(memory_id="test-memory-id")
+
+
+class TestProtocolDetection:
+    """AgentCoreMemorySaver satisfies batch flush protocols."""
+
+    def test_satisfies_sync_protocol(self, agentcore_saver) -> None:
+        assert isinstance(agentcore_saver, SyncBatchFlushable)
+
+    def test_satisfies_async_protocol(self, agentcore_saver) -> None:
+        assert isinstance(agentcore_saver, AsyncBatchFlushable)
+
+    def test_memory_saver_does_not_satisfy_sync_protocol(self) -> None:
+        saver = MemorySaver()
+        assert not isinstance(saver, SyncBatchFlushable)
+
+    def test_memory_saver_does_not_satisfy_async_protocol(self) -> None:
+        saver = MemorySaver()
+        assert not isinstance(saver, AsyncBatchFlushable)
+
+
+class TestBatchFlushFastPath:
+    """flush() fast path using AgentCoreMemorySaver.put_with_writes."""
+
+    def test_flush_calls_put_with_writes_single_api_call(
+        self, agentcore_saver, mock_boto_client
+    ) -> None:
+        """Batch flush sends checkpoint + writes in one create_event call."""
+        deferred = DeferredCheckpointSaver(agentcore_saver, batch_writes=True)
+        config = _make_config()
+
+        new_versions: ChannelVersions = {"messages": "v1"}
+        deferred.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), new_versions)
+        write_config = _make_config(checkpoint_id="ckpt-1")
+        deferred.put_writes(write_config, [("ch1", "v1")], "task-1")
+        deferred.put_writes(write_config, [("ch2", "v2")], "task-2")
+
+        result = deferred.flush()
+
+        assert deferred.is_empty
+        assert result is not None
+        assert result["configurable"]["checkpoint_id"] == "ckpt-1"
+        # Only ONE create_event call for the entire flush
+        mock_boto_client.create_event.assert_called_once()
+
+        call_args = mock_boto_client.create_event.call_args[1]
+        payload = call_args["payload"]
+        # Payload should contain: channel events + checkpoint event + writes events
+        # 1 channel ("messages": "v1") + 1 checkpoint + 2 writes = 4 blobs
+        assert len(payload) == 4
+
+    def test_flush_fast_path_no_writes(self, agentcore_saver, mock_boto_client) -> None:
+        """Batch flush with checkpoint only, no pending writes."""
+        deferred = DeferredCheckpointSaver(agentcore_saver, batch_writes=True)
+        config = _make_config()
+
+        new_versions: ChannelVersions = {"messages": "v1"}
+        deferred.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), new_versions)
+
+        result = deferred.flush()
+
+        assert deferred.is_empty
+        assert result is not None
+        mock_boto_client.create_event.assert_called_once()
+        # 1 channel + 1 checkpoint = 2 blobs
+        payload = mock_boto_client.create_event.call_args[1]["payload"]
+        assert len(payload) == 2
+
+    def test_flush_fast_path_multiple_channels_and_writes(
+        self, agentcore_saver, mock_boto_client
+    ) -> None:
+        """Batch flush with multiple channels and multiple writes."""
+        deferred = DeferredCheckpointSaver(agentcore_saver, batch_writes=True)
+        config = _make_config()
+        new_versions: ChannelVersions = {
+            "messages": "v1",
+            "state": "v2",
+            "results": "v3",
+        }
+
+        deferred.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), new_versions)
+        write_config = _make_config(checkpoint_id="ckpt-1")
+        deferred.put_writes(write_config, [("ch1", "v1")], "task-1")
+        deferred.put_writes(write_config, [("ch2", "v2"), ("ch3", "v3")], "task-2")
+        deferred.put_writes(write_config, [("ch4", "v4")], "task-3")
+
+        deferred.flush()
+
+        mock_boto_client.create_event.assert_called_once()
+        # 3 channels + 1 checkpoint + 3 writes events = 7 blobs
+        payload = mock_boto_client.create_event.call_args[1]["payload"]
+        assert len(payload) == 7
+
+    def test_flush_fast_path_no_checkpoint_restores_writes(
+        self, agentcore_saver, mock_boto_client
+    ) -> None:
+        """If only writes are buffered (no checkpoint), they stay in the buffer."""
+        deferred = DeferredCheckpointSaver(agentcore_saver, batch_writes=True)
+
+        write_config = _make_config(checkpoint_id="ckpt-1")
+        deferred.put_writes(write_config, [("ch1", "v1")], "task-1")
+
+        result = deferred.flush()
+
+        assert result is None
+        assert deferred.has_buffered_writes
+        mock_boto_client.create_event.assert_not_called()
+
+    def test_flush_fast_path_failure_restores_all(
+        self, agentcore_saver, mock_boto_client
+    ) -> None:
+        """On failure, both checkpoint and writes are restored to the buffer."""
+        deferred = DeferredCheckpointSaver(agentcore_saver, batch_writes=True)
+        config = _make_config()
+
+        new_versions: ChannelVersions = {"messages": "v1"}
+        deferred.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), new_versions)
+        write_config = _make_config(checkpoint_id="ckpt-1")
+        deferred.put_writes(write_config, [("ch1", "v1")], "task-1")
+        deferred.put_writes(write_config, [("ch2", "v2")], "task-2")
+
+        mock_boto_client.create_event.side_effect = RuntimeError("network error")
+
+        with pytest.raises(RuntimeError, match="network error"):
+            deferred.flush()
+
+        assert deferred.has_buffered_checkpoint
+        assert deferred.has_buffered_writes
+
+    def test_flush_fast_path_failure_does_not_clobber_new_checkpoint(
+        self, agentcore_saver, mock_boto_client
+    ) -> None:
+        """Restore on failure must not overwrite a newer put() that raced in."""
+        deferred = DeferredCheckpointSaver(agentcore_saver, batch_writes=True)
+        config = _make_config()
+
+        deferred.put(config, _make_checkpoint("ckpt-old"), _make_metadata(), {})
+
+        def failing_create_event(**kwargs):
+            # Simulate a new put() arriving during I/O
+            deferred.put(config, _make_checkpoint("ckpt-new"), _make_metadata(1), {})
+            msg = "network error"
+            raise RuntimeError(msg)
+
+        mock_boto_client.create_event.side_effect = failing_create_event
+
+        with pytest.raises(RuntimeError, match="network error"):
+            deferred.flush()
+
+        result = deferred.get_tuple(_make_config())
+        assert result is not None
+        assert result.checkpoint["id"] == "ckpt-new"
+
+    def test_flush_fast_path_preserves_session_and_actor(
+        self, agentcore_saver, mock_boto_client
+    ) -> None:
+        """Batch flush sends correct session/actor derived from config."""
+        deferred = DeferredCheckpointSaver(agentcore_saver, batch_writes=True)
+        config = _make_config(thread_id="my-thread", actor_id="my-actor")
+
+        deferred.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), {})
+        deferred.flush()
+
+        call_args = mock_boto_client.create_event.call_args[1]
+        assert call_args["sessionId"] == "my-thread"
+        assert call_args["actorId"] == "my-actor"
+
+
+class TestBatchFlushFallback:
+    """When batch_writes=False, fallback path is used (1 + N calls)."""
+
+    def test_batch_writes_false_uses_sequential(
+        self, agentcore_saver, mock_boto_client
+    ) -> None:
+        """With batch_writes=False, flush makes separate API calls."""
+        deferred = DeferredCheckpointSaver(agentcore_saver, batch_writes=False)
+        config = _make_config()
+
+        new_versions: ChannelVersions = {"messages": "v1"}
+        deferred.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), new_versions)
+        write_config = _make_config(checkpoint_id="ckpt-1")
+        deferred.put_writes(write_config, [("ch1", "v1")], "task-1")
+        deferred.put_writes(write_config, [("ch2", "v2")], "task-2")
+
+        deferred.flush()
+
+        assert deferred.is_empty
+        # 1 call for put() + 2 calls for put_writes() = 3 total
+        assert mock_boto_client.create_event.call_count == 3
+
+    def test_non_batch_saver_uses_sequential(self) -> None:
+        """MemorySaver doesn't implement BatchFlushable, so fallback is used."""
+        saver = MemorySaver()
+        deferred = DeferredCheckpointSaver(saver, batch_writes=True)
+        config = _make_config()
+
+        deferred.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), {})
+        write_config = _make_config(checkpoint_id="ckpt-1")
+        deferred.put_writes(write_config, [("ch1", "v1")], "task-1")
+
+        result = deferred.flush()
+
+        assert deferred.is_empty
+        assert result is not None
+
+
+class TestBatchFlushAsync:
+    """aflush() fast path with AgentCoreMemorySaver."""
+
+    @pytest.mark.asyncio
+    async def test_aflush_calls_aput_with_writes(
+        self, agentcore_saver, mock_boto_client
+    ) -> None:
+        deferred = DeferredCheckpointSaver(agentcore_saver, batch_writes=True)
+        config = _make_config()
+
+        new_versions: ChannelVersions = {"messages": "v1"}
+        deferred.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), new_versions)
+        write_config = _make_config(checkpoint_id="ckpt-1")
+        deferred.put_writes(write_config, [("ch1", "v1")], "task-1")
+
+        result = await deferred.aflush()
+
+        assert deferred.is_empty
+        assert result is not None
+        # Single API call for the batch
+        mock_boto_client.create_event.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_aflush_fast_path_failure_restores_all(
+        self, agentcore_saver, mock_boto_client
+    ) -> None:
+        deferred = DeferredCheckpointSaver(agentcore_saver, batch_writes=True)
+        config = _make_config()
+
+        new_versions: ChannelVersions = {"messages": "v1"}
+        deferred.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), new_versions)
+        write_config = _make_config(checkpoint_id="ckpt-1")
+        deferred.put_writes(write_config, [("ch1", "v1")], "task-1")
+
+        mock_boto_client.create_event.side_effect = RuntimeError("async batch fail")
+
+        with pytest.raises(RuntimeError, match="async batch fail"):
+            await deferred.aflush()
+
+        assert deferred.has_buffered_checkpoint
+        assert deferred.has_buffered_writes
+
+    @pytest.mark.asyncio
+    async def test_aflush_fast_path_failure_does_not_clobber(
+        self, agentcore_saver, mock_boto_client
+    ) -> None:
+        deferred = DeferredCheckpointSaver(agentcore_saver, batch_writes=True)
+        config = _make_config()
+
+        deferred.put(config, _make_checkpoint("ckpt-old"), _make_metadata(), {})
+
+        def failing_create_event(**kwargs):
+            deferred.put(config, _make_checkpoint("ckpt-new"), _make_metadata(1), {})
+            msg = "async fail"
+            raise RuntimeError(msg)
+
+        mock_boto_client.create_event.side_effect = failing_create_event
+
+        with pytest.raises(RuntimeError, match="async fail"):
+            await deferred.aflush()
+
+        result = deferred.get_tuple(_make_config())
+        assert result is not None
+        assert result.checkpoint["id"] == "ckpt-new"
+
+    @pytest.mark.asyncio
+    async def test_aflush_non_batch_saver_uses_sequential(self) -> None:
+        saver = MemorySaver()
+        deferred = DeferredCheckpointSaver(saver, batch_writes=True)
+        config = _make_config()
+
+        deferred.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), {})
+
+        result = await deferred.aflush()
+
+        assert deferred.is_empty
+        assert result is not None
+
+
+class TestBatchFlushContextManagers:
+    """Context managers use the fast path when batch_writes=True."""
+
+    def test_flush_on_exit_uses_batch(self, agentcore_saver, mock_boto_client) -> None:
+        deferred = DeferredCheckpointSaver(agentcore_saver, batch_writes=True)
+        config = _make_config()
+        new_versions: ChannelVersions = {"messages": "v1"}
+
+        with deferred.flush_on_exit():
+            deferred.put(
+                config, _make_checkpoint("ckpt-1"), _make_metadata(), new_versions
+            )
+            write_config = _make_config(checkpoint_id="ckpt-1")
+            deferred.put_writes(write_config, [("ch1", "v1")], "task-1")
+
+        assert deferred.is_empty
+        mock_boto_client.create_event.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_aflush_on_exit_uses_batch(
+        self, agentcore_saver, mock_boto_client
+    ) -> None:
+        deferred = DeferredCheckpointSaver(agentcore_saver, batch_writes=True)
+        config = _make_config()
+        new_versions: ChannelVersions = {"messages": "v1"}
+
+        async with deferred.aflush_on_exit():
+            deferred.put(
+                config, _make_checkpoint("ckpt-1"), _make_metadata(), new_versions
+            )
+            write_config = _make_config(checkpoint_id="ckpt-1")
+            deferred.put_writes(write_config, [("ch1", "v1")], "task-1")
+
+        assert deferred.is_empty
+        mock_boto_client.create_event.assert_called_once()
+
+
+class TestBatchFlushThreadSafety:
+    """Concurrent operations with batch_writes=True."""
+
+    def test_concurrent_flush_no_double_persist(
+        self, agentcore_saver, mock_boto_client
+    ) -> None:
+        deferred = DeferredCheckpointSaver(agentcore_saver, batch_writes=True)
+        config = _make_config()
+        new_versions: ChannelVersions = {"messages": "v1"}
+        deferred.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), new_versions)
+        write_config = _make_config(checkpoint_id="ckpt-1")
+        deferred.put_writes(write_config, [("ch1", "v1")], "task-1")
+
+        errors: list[Exception] = []
+
+        def flusher() -> None:
+            try:
+                deferred.flush()
+            except Exception as e:
+                errors.append(e)
+
+        threads = [
+            threading.Thread(target=flusher),
+            threading.Thread(target=flusher),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(errors) == 0
+        assert deferred.is_empty
+        # Only one thread should have called create_event
+        mock_boto_client.create_event.assert_called_once()
+
+
+class TestPutWithWritesDirect:
+    """Test AgentCoreMemorySaver.put_with_writes directly."""
+
+    def test_put_with_writes_creates_correct_events(
+        self, agentcore_saver, mock_boto_client
+    ) -> None:
+        """put_with_writes produces channel + checkpoint + writes events."""
+        config = _make_config(checkpoint_id="parent-ckpt")
+        checkpoint = _make_checkpoint("ckpt-1")
+        metadata = _make_metadata()
+        new_versions: ChannelVersions = {"messages": "v1", "state": "v2"}
+
+        pending_writes = [
+            PendingWrite(
+                config=_make_config(checkpoint_id="ckpt-1"),
+                writes=[("ch1", "val1")],
+                task_id="task-1",
+                task_path="/path/1",
+            ),
+            PendingWrite(
+                config=_make_config(checkpoint_id="ckpt-1"),
+                writes=[("ch2", "val2"), ("ch3", "val3")],
+                task_id="task-2",
+                task_path="/path/2",
+            ),
+        ]
+
+        result = agentcore_saver.put_with_writes(
+            config, checkpoint, metadata, new_versions, pending_writes
+        )
+
+        assert result["configurable"]["checkpoint_id"] == "ckpt-1"
+        assert result["configurable"]["thread_id"] == "thread-1"
+        assert result["configurable"]["actor_id"] == "actor-1"
+
+        mock_boto_client.create_event.assert_called_once()
+        call_args = mock_boto_client.create_event.call_args[1]
+        payload = call_args["payload"]
+        # 2 channels + 1 checkpoint + 2 writes events = 5
+        assert len(payload) == 5
+        assert call_args["memoryId"] == "test-memory-id"
+        assert call_args["sessionId"] == "thread-1"
+        assert call_args["actorId"] == "actor-1"
+
+    def test_put_with_writes_empty_writes_list(
+        self, agentcore_saver, mock_boto_client
+    ) -> None:
+        """put_with_writes with no pending writes works like put."""
+        config = _make_config()
+        checkpoint = _make_checkpoint("ckpt-1")
+        new_versions: ChannelVersions = {"messages": "v1"}
+
+        result = agentcore_saver.put_with_writes(
+            config, checkpoint, _make_metadata(), new_versions, []
+        )
+
+        assert result["configurable"]["checkpoint_id"] == "ckpt-1"
+        mock_boto_client.create_event.assert_called_once()
+        # 1 channel + 1 checkpoint = 2
+        payload = mock_boto_client.create_event.call_args[1]["payload"]
+        assert len(payload) == 2
+
+    @pytest.mark.asyncio
+    async def test_aput_with_writes_delegates_to_sync(
+        self, agentcore_saver, mock_boto_client
+    ) -> None:
+        """aput_with_writes runs put_with_writes in executor."""
+        config = _make_config()
+        checkpoint = _make_checkpoint("ckpt-1")
+        new_versions: ChannelVersions = {"messages": "v1"}
+
+        pending_writes = [
+            PendingWrite(
+                config=_make_config(checkpoint_id="ckpt-1"),
+                writes=[("ch1", "val1")],
+                task_id="task-1",
+                task_path="",
+            ),
+        ]
+
+        result = await agentcore_saver.aput_with_writes(
+            config, checkpoint, _make_metadata(), new_versions, pending_writes
+        )
+
+        assert result["configurable"]["checkpoint_id"] == "ckpt-1"
+        mock_boto_client.create_event.assert_called_once()
+
+
+class TestPendingWriteType:
+    """PendingWrite public type is correctly constructed."""
+
+    def test_pending_write_fields(self) -> None:
+        config = _make_config(checkpoint_id="ckpt-1")
+        pw = PendingWrite(
+            config=config,
+            writes=[("ch1", "v1"), ("ch2", "v2")],
+            task_id="task-1",
+            task_path="path/to/task",
+        )
+        assert pw.config is config
+        assert pw.writes == [("ch1", "v1"), ("ch2", "v2")]
+        assert pw.task_id == "task-1"
+        assert pw.task_path == "path/to/task"
+
+    def test_pending_write_is_namedtuple(self) -> None:
+        config = _make_config()
+        pw = PendingWrite(config=config, writes=[], task_id="t", task_path="")
+        assert hasattr(pw, "_fields")
+        assert set(pw._fields) == {"config", "writes", "task_id", "task_path"}


### PR DESCRIPTION
Closes #1016

### Summary

Reduces flush latency from 1+N sequential API calls to 1 by batching the checkpoint and all pending writes into a single `CreateEvent` call when the underlying saver supports it.

### Usage

```python
from langgraph_checkpoint_aws import DeferredCheckpointSaver, AgentCoreMemorySaver

inner = AgentCoreMemorySaver(memory_id="my-memory")
saver = DeferredCheckpointSaver(inner, batch_writes=True)
```

When `batch_writes=True`, `DeferredCheckpointSaver.flush()` combines the checkpoint put and all pending writes into a single batched API call instead of issuing them sequentially.

### Changes

- **`deferred_saver.py`**: Added `batch_writes` constructor kwarg; `flush()` / `aflush()` now call `put_with_writes` / `aput_with_writes` on the inner saver when batch mode is enabled and the saver implements the `SyncBatchFlushable` / `AsyncBatchFlushable` protocol
- **`saver.py` (AgentCoreMemorySaver)**: Implements `put_with_writes` / `aput_with_writes` — combines checkpoint + writes into a single batch call
- **`helpers.py`**: Added `store_blob_events_batch()` with payload chunking that respects the 100-item and 10 MB `CreateEvent` API limits
- **`__init__.py`**: Exports new `SyncBatchFlushable`, `AsyncBatchFlushable`, and `PendingWrite` types

### Tests

- Unit tests for batch flush logic in `DeferredCheckpointSaver` (protocol detection, fallback to sequential, batching behavior)
- Unit tests for `AgentCoreMemorySaver.put_with_writes` / `aput_with_writes`
- Integration tests validating end-to-end batch flush with the AgentCore memory service
```
=================================================================== test session starts ====================================================================
platform linux -- Python 3.12.13, pytest-9.0.3, pluggy-1.6.0 -- /local/home/keypa/Project/langchain-aws/libs/langgraph-checkpoint-aws/.venv/bin/python
cachedir: .pytest_cache
rootdir: /local/home/keypa/Project/langchain-aws/libs/langgraph-checkpoint-aws
configfile: pyproject.toml
plugins: anyio-4.13.0, socket-0.8.0, mock-3.15.1, xdist-3.8.0, langsmith-0.8.8, asyncio-1.4.0, cov-7.1.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 12 items                                                                                                                                         

tests/integration_tests/agentcore/test_batch_flush.py::TestBatchFlushIntegration::test_batch_flush_persists_checkpoint_and_writes PASSED             [  8%]
tests/integration_tests/agentcore/test_batch_flush.py::TestBatchFlushIntegration::test_batch_flush_no_writes PASSED                                  [ 16%]
tests/integration_tests/agentcore/test_batch_flush.py::TestBatchFlushIntegration::test_batch_flush_multiple_channels PASSED                          [ 25%]
tests/integration_tests/agentcore/test_batch_flush.py::TestBatchFlushIntegration::test_batch_flush_with_context_manager PASSED                       [ 33%]
tests/integration_tests/agentcore/test_batch_flush.py::TestBatchFlushIntegration::test_async_batch_flush PASSED                                      [ 41%]
tests/integration_tests/agentcore/test_batch_flush.py::TestBatchFlushIntegration::test_batch_flush_many_writes PASSED                                [ 50%]
tests/integration_tests/agentcore/test_batch_flush.py::TestBatchFlushIntegration::test_batch_flush_get_tuple_after_flush PASSED                      [ 58%]
tests/integration_tests/agentcore/test_batch_flush.py::TestBatchFlushIntegration::test_batch_flush_list_shows_persisted PASSED                       [ 66%]
tests/integration_tests/agentcore/test_batch_flush.py::TestBatchFlushIntegration::test_batch_flush_splits_when_exceeding_item_limit PASSED           [ 75%]
tests/integration_tests/agentcore/test_batch_flush.py::TestBatchFlushIntegration::test_store_blob_events_batch_chunking_by_bytes_direct PASSED       [ 83%]
tests/integration_tests/agentcore/test_batch_flush.py::TestBatchFlushIntegration::test_store_blob_events_batch_chunking_direct PASSED                [ 91%]
tests/integration_tests/agentcore/test_batch_flush.py::TestBatchFlushIntegration::test_put_with_writes_direct PASSED                                 [100%]

=================================================================== slowest 5 durations ====================================================================
1.80s call     tests/integration_tests/agentcore/test_batch_flush.py::TestBatchFlushIntegration::test_store_blob_events_batch_chunking_by_bytes_direct
1.32s call     tests/integration_tests/agentcore/test_batch_flush.py::TestBatchFlushIntegration::test_store_blob_events_batch_chunking_direct
1.20s call     tests/integration_tests/agentcore/test_batch_flush.py::TestBatchFlushIntegration::test_batch_flush_splits_when_exceeding_item_limit
0.76s call     tests/integration_tests/agentcore/test_batch_flush.py::TestBatchFlushIntegration::test_batch_flush_persists_checkpoint_and_writes
0.71s call     tests/integration_tests/agentcore/test_batch_flush.py::TestBatchFlushIntegration::test_batch_flush_get_tuple_after_flush
=================================================================== 12 passed in 10.51s ====================================================================
```
### Areas requiring careful review

- Payload chunking logic in `store_blob_events_batch`: splits into chunks of ≤100 items and ≤10 MB to stay within CreateEvent API limits. Reviewers should verify the size calculation and edge cases.
- Protocol-based duck typing (`SyncBatchFlushable` / `AsyncBatchFlushable`): the `DeferredCheckpointSaver` uses `isinstance` checks against these protocols to determine if batching is supported. This keeps the interface non-breaking for existing savers that do not implement batch flush.