### PR TITLE
fix(aws): omit temperature/top_p for models that don't support them

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -1803,10 +1803,16 @@ class ChatBedrockConverse(BaseChatModel):
             # profile reports temperature is unsupported, drop both rather than let
             # Bedrock fail the call with a validation error.
             if self.profile and self.profile.get("temperature") is False:
-                if resolved_temperature is not None or resolved_top_p is not None:
+                ignored = []
+                if resolved_temperature is not None:
+                    ignored.append("temperature")
+                if resolved_top_p is not None:
+                    ignored.append("top_p")
+                if ignored:
                     warnings.warn(
                         f"Model {self._get_base_model()} does not support "
-                        "`temperature` or `top_p`; ignoring the provided value(s).",
+                        f"{' or '.join(ignored)}; ignoring the provided "
+                        f"value{'s' if len(ignored) > 1 else ''}.",
                         stacklevel=2,
                     )
                 resolved_temperature = None

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -1793,12 +1793,31 @@ class ChatBedrockConverse(BaseChatModel):
                 ):
                     should_unset_max_tokens = True
 
+            resolved_temperature = (
+                self.temperature if temperature is None else temperature
+            )
+            resolved_top_p = self.top_p if topP is None else topP
+
+            # Some models (e.g. Claude Opus 4.7+) no longer accept ``temperature``
+            # or ``topP`` and reject any request that includes them. When the model
+            # profile reports temperature is unsupported, drop both rather than let
+            # Bedrock fail the call with a validation error.
+            if self.profile and self.profile.get("temperature") is False:
+                if resolved_temperature is not None or resolved_top_p is not None:
+                    warnings.warn(
+                        f"Model {self._get_base_model()} does not support "
+                        "`temperature` or `top_p`; ignoring the provided value(s).",
+                        stacklevel=2,
+                    )
+                resolved_temperature = None
+                resolved_top_p = None
+
             inferenceConfig = {
                 "maxTokens": None
                 if should_unset_max_tokens
                 else (maxTokens or self.max_tokens),
-                "temperature": self.temperature if temperature is None else temperature,
-                "topP": self.top_p if topP is None else topP,
+                "temperature": resolved_temperature,
+                "topP": resolved_top_p,
                 "stopSequences": stop or stopSequences or self.stop_sequences,
             }
         if not toolConfig and tools:

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -3579,6 +3579,44 @@ def test_service_tier_none_not_in_params() -> None:
     assert "serviceTier" not in params
 
 
+def test_temperature_omitted_when_unsupported() -> None:
+    """Models with ``temperature: False`` profile drop temperature/topP.
+
+    Claude Opus 4.7+ rejects requests that include ``temperature`` or ``topP``
+    with a Bedrock ValidationException. When the model profile reports that
+    temperature is unsupported, both values must be dropped from the request.
+    """
+    llm = ChatBedrockConverse(
+        model="anthropic.claude-opus-4-8",
+        region_name="us-west-2",
+        temperature=0,
+        top_p=0.9,
+    )
+    assert llm.profile and llm.profile.get("temperature") is False
+
+    with pytest.warns(UserWarning, match="does not support"):
+        params = llm._converse_params()
+
+    assert "temperature" not in params["inferenceConfig"]
+    assert "topP" not in params["inferenceConfig"]
+
+
+def test_temperature_kept_when_supported() -> None:
+    """Models that support temperature keep the provided value (no warning)."""
+    llm = ChatBedrockConverse(
+        model="anthropic.claude-sonnet-4-6",
+        region_name="us-west-2",
+        temperature=0,
+    )
+    assert llm.profile and llm.profile.get("temperature") is True
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        params = llm._converse_params()
+
+    assert params["inferenceConfig"]["temperature"] == 0
+
+
 def test_service_tier_passed_to_converse() -> None:
     """Test that service_tier is passed to the converse API call."""
     mocked_client = mock.MagicMock()


### PR DESCRIPTION
Thanks for `langchain-aws` and for keeping the model-profile data so well maintained — the profiles already carry exactly the flag this fix needs.

Fixes #1094

## Problem

`ChatBedrockConverse` always puts `temperature` and `topP` into `inferenceConfig`. Claude **Opus 4.7** and **Opus 4.8** reject any request that includes them, so an ordinary call fails at invoke time:

```python
from langchain_aws import ChatBedrockConverse

llm = ChatBedrockConverse(
    model="us.anthropic.claude-opus-4-8",
    region_name="us-west-2",
    temperature=0,
)
llm.invoke("Say hi in one word.")
```

```text
botocore.errorfactory.ValidationException: An error occurred (ValidationException)
when calling the Converse operation: The model returned the following errors:
`temperature` is deprecated for this model.
```

(`top_p` produces the same `` `top_p` is deprecated `` error.)

## Cause

The model profile in `langchain_aws/data/_profiles.py` already records `"temperature": False` for these models, but `_converse_params` never consulted it — it unconditionally set `temperature`/`topP`.

## Fix

When the resolved profile reports `temperature: False`, omit both `temperature` and `topP` from `inferenceConfig` and `warnings.warn` that the values were ignored. This reuses existing profile data and matches how the rest of the class already relies on profiles. Other models are untouched.

## Before / after (verified against live Bedrock, us-west-2)

| Case | Before | After |
|---|---|---|
| Opus 4.8, `temperature=0` | ❌ `ValidationException` | ✅ succeeds (value dropped + `UserWarning`) |
| Opus 4.8, `top_p=0.9` | ❌ `ValidationException` | ✅ succeeds (value dropped + `UserWarning`) |
| Opus 4.7, `temperature=0` | ❌ `ValidationException` | ✅ succeeds (value dropped + `UserWarning`) |
| Opus 4.8, no temperature set | ✅ succeeds | ✅ succeeds (unchanged) |
| Sonnet 4.6, `temperature=0` | ✅ succeeds | ✅ succeeds, value honored (unchanged) |
| Haiku 4.5, `temperature=0` | ✅ succeeds | ✅ succeeds, value honored (unchanged) |
| Public API / arguments / defaults | — | ✅ Unchanged |

## Tests prove they catch the bug

The new test fails against `main` (source fix reverted, test kept):

```text
E       Failed: DID NOT WARN. No warnings of type (<class 'UserWarning'>,) were emitted.
FAILED tests/.../test_bedrock_converse.py::test_temperature_omitted_when_unsupported
1 failed, 254 deselected in 0.29s
```

…and passes with the fix:

```text
2 passed, 253 deselected in 0.23s
```

Full unit suite, lint, format, and mypy all pass locally:

```text
883 passed, 1 skipped, 1 xfailed, 1 xpassed
All checks passed!          # ruff check
133 files already formatted # ruff format
Success: no issues found in 133 source files  # mypy
```

## Review notes

- Behavior-preserving for every model whose profile supports temperature — only models flagged `temperature: False` are affected, and only to drop params Bedrock would reject anyway.
- A natural follow-up would be to also surface `top_p` support in the profile schema (today only `temperature` is encoded), but that's a larger data change; this PR is the minimal fix for the reported breakage.

---
*This contribution was prepared with the assistance of an AI agent (Claude Code). A human reviewed the change, the reasoning, and the test results before submitting.*
