### PR TITLE
fix(aws): preserve code interpreter sessions across tool calls

### DIFF
--- a/libs/aws/langchain_aws/tools/code_interpreter_toolkit.py
+++ b/libs/aws/langchain_aws/tools/code_interpreter_toolkit.py
@@ -753,8 +753,12 @@ async def create_code_interpreter_toolkit(
 
 
 def _get_thread_id(config: Optional[RunnableConfig] = None) -> str:
-    """Extract session key, using checkpoint_ns for subagent isolation."""
-    return get_session_key(config)
+    """Extract the code interpreter session key.
+
+    Code interpreter state should persist across tool calls within the same
+    LangGraph thread, even when LangGraph injects a per-tool checkpoint_ns.
+    """
+    return get_session_key(config, include_checkpoint_ns=False)
 
 
 def _extract_output_from_stream(response: Any) -> str:

--- a/libs/aws/langchain_aws/tools/utils.py
+++ b/libs/aws/langchain_aws/tools/utils.py
@@ -54,12 +54,16 @@ def get_current_page(browser: SyncBrowser) -> SyncPage:
     return context.pages[-1]
 
 
-def get_session_key(config: Optional[RunnableConfig] = None) -> str:
+def get_session_key(
+    config: Optional[RunnableConfig] = None,
+    *,
+    include_checkpoint_ns: bool = True,
+) -> str:
     """Build a session key from RunnableConfig.
 
     Uses thread_id as the base key and appends checkpoint_ns
-    when present.  This ensures parallel LangGraph subgraphs get
-    separate sessions even when they share a thread_id.
+    when present and requested. This ensures parallel LangGraph
+    subgraphs can get separate sessions even when they share a thread_id.
 
     Examples::
 
@@ -69,6 +73,7 @@ def get_session_key(config: Optional[RunnableConfig] = None) -> str:
 
     Args:
         config: LangGraph ``RunnableConfig`` passed to tool invocations.
+        include_checkpoint_ns: Whether to append ``checkpoint_ns`` when present.
 
     Returns:
         String key for indexing session dictionaries.
@@ -80,6 +85,6 @@ def get_session_key(config: Optional[RunnableConfig] = None) -> str:
     thread_id = configurable.get("thread_id", "default")
     checkpoint_ns = configurable.get("checkpoint_ns", "")
 
-    if checkpoint_ns:
+    if include_checkpoint_ns and checkpoint_ns:
         return f"{thread_id}:{checkpoint_ns}"
     return thread_id

--- a/libs/aws/tests/unit_tests/tools/test_browser_toolkit.py
+++ b/libs/aws/tests/unit_tests/tools/test_browser_toolkit.py
@@ -803,6 +803,21 @@ class TestGetSessionKey:
         )
         assert get_session_key(config) == "thread-1:subagent-a:abc123"
 
+    def test_can_ignore_checkpoint_ns_when_requested(self) -> None:
+        """Test returns thread_id only when checkpoint_ns is explicitly disabled."""
+        from langchain_aws.tools.utils import get_session_key
+
+        config: RunnableConfig = cast(
+            RunnableConfig,
+            {
+                "configurable": {
+                    "thread_id": "thread-1",
+                    "checkpoint_ns": "subagent-a:abc123",
+                }
+            },
+        )
+        assert get_session_key(config, include_checkpoint_ns=False) == "thread-1"
+
     def test_ignores_empty_checkpoint_ns(self) -> None:
         """Test ignores empty checkpoint_ns string."""
         from langchain_aws.tools.utils import get_session_key

--- a/libs/aws/tests/unit_tests/tools/test_code_interpreter_toolkit.py
+++ b/libs/aws/tests/unit_tests/tools/test_code_interpreter_toolkit.py
@@ -390,8 +390,8 @@ class TestGetOrCreateInterpreter:
             assert interpreter is mock_interpreter
             assert "default" in toolkit._code_interpreters
 
-    def test_uses_checkpoint_ns_for_session_key(self) -> None:
-        """Test session key includes checkpoint_ns for subagent isolation."""
+    def test_ignores_checkpoint_ns_for_session_key(self) -> None:
+        """Test session key ignores checkpoint_ns for persistence across tools."""
         from langchain_aws.tools.code_interpreter_toolkit import CodeInterpreterToolkit
 
         toolkit = CodeInterpreterToolkit()
@@ -415,7 +415,48 @@ class TestGetOrCreateInterpreter:
             )
             toolkit._get_or_create_interpreter(config)
 
-            assert "thread-1:research-acme:abc123" in toolkit._code_interpreters
+            assert "thread-1" in toolkit._code_interpreters
+            assert "thread-1:research-acme:abc123" not in toolkit._code_interpreters
+
+    def test_reuses_interpreter_across_checkpoint_namespaces(self) -> None:
+        """Same thread_id with different checkpoint_ns values shares a session."""
+        from langchain_aws.tools.code_interpreter_toolkit import CodeInterpreterToolkit
+
+        toolkit = CodeInterpreterToolkit()
+
+        with patch(
+            "langchain_aws.tools.code_interpreter_toolkit.CodeInterpreter"
+        ) as mock_class:
+            mock_interpreter = MagicMock()
+            mock_interpreter.start = MagicMock()
+            mock_interpreter.session_id = "test-session"
+            mock_class.return_value = mock_interpreter
+
+            first_config: RunnableConfig = cast(
+                RunnableConfig,
+                {
+                    "configurable": {
+                        "thread_id": "thread-1",
+                        "checkpoint_ns": "tools:first",
+                    }
+                },
+            )
+            second_config: RunnableConfig = cast(
+                RunnableConfig,
+                {
+                    "configurable": {
+                        "thread_id": "thread-1",
+                        "checkpoint_ns": "tools:second",
+                    }
+                },
+            )
+
+            first_interpreter = toolkit._get_or_create_interpreter(first_config)
+            second_interpreter = toolkit._get_or_create_interpreter(second_config)
+
+            assert first_interpreter is second_interpreter
+            assert mock_class.call_count == 1
+            assert list(toolkit._code_interpreters) == ["thread-1"]
 
 
 class TestGetThreadId:
@@ -449,8 +490,8 @@ class TestGetThreadId:
 
         assert thread_id == "default"
 
-    def test_includes_checkpoint_ns(self) -> None:
-        """Test includes checkpoint_ns in session key."""
+    def test_ignores_checkpoint_ns(self) -> None:
+        """Test ignores checkpoint_ns in session key."""
         from langchain_aws.tools.code_interpreter_toolkit import _get_thread_id
 
         config: RunnableConfig = cast(
@@ -464,7 +505,7 @@ class TestGetThreadId:
         )
         thread_id = _get_thread_id(config)
 
-        assert thread_id == "thread-1:subagent:xyz"
+        assert thread_id == "thread-1"
 
 
 class TestExtractOutputFromStream:


### PR DESCRIPTION
Fixes #1057

## Why

LangGraph can inject a per-tool `checkpoint_ns` into tool call configs. The AWS code interpreter toolkit used that value as part of its session key, so sequential tool calls in the same thread could create separate code interpreter sessions and lose state.

Browser tools still rely on `checkpoint_ns` for subagent/session isolation, so this change keeps the shared helper's default behavior unchanged and opts code interpreter out explicitly.

## What changed

- Add a keyword-only `include_checkpoint_ns` option to `get_session_key()`, defaulting to the existing behavior.
- Make code interpreter `_get_thread_id()` ignore `checkpoint_ns` so sessions are keyed by `thread_id`.
- Add regression coverage for reusing one code interpreter session across different `checkpoint_ns` values.
- Keep browser/session-key tests proving `checkpoint_ns` is still included by default.

## Testing

```bash
cd libs/aws
uv sync --group test --group test_integration
uv run --no-sync pytest tests/unit_tests/tools/test_code_interpreter_toolkit.py tests/unit_tests/tools/test_browser_toolkit.py -q
git diff --check
```

Result: `87 passed`.

## Review notes

Please check the session-key semantics: code interpreter now persists state by `thread_id`, while browser tools retain `thread_id:checkpoint_ns` isolation.