### PR TITLE
feat(aws): surface per-TTL cache breakdown from cacheDetails

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -47,7 +47,7 @@ from langchain_core.messages import (
     merge_message_runs,
 )
 from langchain_core.messages import content as types
-from langchain_core.messages.ai import AIMessageChunk, UsageMetadata
+from langchain_core.messages.ai import AIMessageChunk, InputTokenDetails, UsageMetadata
 from langchain_core.messages.tool import tool_call as create_tool_call
 from langchain_core.messages.tool import tool_call_chunk
 from langchain_core.output_parsers import JsonOutputKeyToolsParser, PydanticToolsParser
@@ -2167,13 +2167,29 @@ def _extract_usage_metadata(response: Dict[str, Any]) -> UsageMetadata:
     )
     total_tokens = usage_dict.get("totalTokens", input_tokens + output_tokens)
 
+    input_token_details: dict = {
+        "cache_read": cache_read_input_tokens,
+        "cache_creation": cache_write_input_tokens,
+    }
+
+    # Parse per-TTL cache breakdown from cacheDetails (if present)
+    cache_details = usage_dict.get("cacheDetails", [])
+    if cache_details:
+        cache_5m = sum(
+            d.get("inputTokens", 0) for d in cache_details if d.get("ttl") == "5m"
+        )
+        cache_1h = sum(
+            d.get("inputTokens", 0) for d in cache_details if d.get("ttl") == "1h"
+        )
+        input_token_details["ephemeral_5m_input_tokens"] = cache_5m
+        input_token_details["ephemeral_1h_input_tokens"] = cache_1h
+
     usage = UsageMetadata(
         input_tokens=input_tokens,
         output_tokens=output_tokens,
-        input_token_details={
-            "cache_read": cache_read_input_tokens,
-            "cache_creation": cache_write_input_tokens,
-        },
+        input_token_details=InputTokenDetails(
+            **{k: v for k, v in input_token_details.items() if v is not None},
+        ),
         total_tokens=total_tokens,
     )
     return usage

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -2181,8 +2181,12 @@ def _extract_usage_metadata(response: Dict[str, Any]) -> UsageMetadata:
         cache_1h = sum(
             d.get("inputTokens", 0) for d in cache_details if d.get("ttl") == "1h"
         )
-        input_token_details["ephemeral_5m_input_tokens"] = cache_5m
-        input_token_details["ephemeral_1h_input_tokens"] = cache_1h
+        if cache_5m:
+            input_token_details["ephemeral_5m_input_tokens"] = cache_5m
+        if cache_1h:
+            input_token_details["ephemeral_1h_input_tokens"] = cache_1h
+        if cache_5m + cache_1h > 0:
+            input_token_details["cache_creation"] = 0
 
     usage = UsageMetadata(
         input_tokens=input_tokens,

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -828,6 +828,86 @@ def test__extract_usage_metadata_with_prompt_caching() -> None:
     }
 
 
+def test__extract_usage_metadata_with_per_ttl_cache_details() -> None:
+    """Test that cacheDetails per-TTL breakdown populates ephemeral_* keys."""
+    response = {
+        "usage": {
+            "inputTokens": 100,
+            "outputTokens": 50,
+            "totalTokens": 850,
+            "cacheReadInputTokens": 200,
+            "cacheWriteInputTokens": 500,
+            "cacheDetails": [
+                {"inputTokens": 300, "ttl": "5m"},
+                {"inputTokens": 200, "ttl": "1h"},
+            ],
+        }
+    }
+
+    usage_metadata = _extract_usage_metadata(response)
+
+    assert usage_metadata["input_tokens"] == 800  # 100 + 200 + 500
+    assert usage_metadata["output_tokens"] == 50
+    assert usage_metadata["total_tokens"] == 850
+    assert usage_metadata["input_token_details"]["cache_read"] == 200
+    assert usage_metadata["input_token_details"]["cache_creation"] == 500
+    assert usage_metadata["input_token_details"]["ephemeral_5m_input_tokens"] == 300  # type: ignore[typeddict-item]
+    assert usage_metadata["input_token_details"]["ephemeral_1h_input_tokens"] == 200  # type: ignore[typeddict-item]
+
+
+def test__extract_usage_metadata_without_cache_details() -> None:
+    """Test that missing cacheDetails doesn't break existing behavior."""
+    response = {
+        "usage": {
+            "inputTokens": 100,
+            "outputTokens": 50,
+            "totalTokens": 150,
+            "cacheReadInputTokens": 0,
+            "cacheWriteInputTokens": 0,
+        }
+    }
+
+    usage_metadata = _extract_usage_metadata(response)
+
+    assert usage_metadata["input_tokens"] == 100
+    assert usage_metadata["output_tokens"] == 50
+    assert usage_metadata["input_token_details"] == {
+        "cache_read": 0,
+        "cache_creation": 0,
+    }
+    # ephemeral_* keys should not be present when cacheDetails is absent
+    assert "ephemeral_5m_input_tokens" not in usage_metadata["input_token_details"]
+    assert "ephemeral_1h_input_tokens" not in usage_metadata["input_token_details"]
+
+
+def test__extract_usage_metadata_with_malformed_cache_details() -> None:
+    """Test that malformed cacheDetails entries are handled gracefully."""
+    response = {
+        "usage": {
+            "inputTokens": 100,
+            "outputTokens": 50,
+            "totalTokens": 650,
+            "cacheReadInputTokens": 200,
+            "cacheWriteInputTokens": 300,
+            "cacheDetails": [
+                {"inputTokens": 100, "ttl": "5m"},
+                {"ttl": "5m"},  # Missing inputTokens - should default to 0
+                {"inputTokens": 50, "ttl": "1h"},
+            ],
+        }
+    }
+
+    usage_metadata = _extract_usage_metadata(response)
+
+    assert usage_metadata["input_tokens"] == 600  # 100 + 200 + 300
+    assert usage_metadata["output_tokens"] == 50
+    assert usage_metadata["input_token_details"]["cache_read"] == 200
+    assert usage_metadata["input_token_details"]["cache_creation"] == 300
+    # 100 from first entry, 0 from second entry (missing inputTokens)
+    assert usage_metadata["input_token_details"]["ephemeral_5m_input_tokens"] == 100  # type: ignore[typeddict-item]
+    assert usage_metadata["input_token_details"]["ephemeral_1h_input_tokens"] == 50  # type: ignore[typeddict-item]
+
+
 @mock.patch.dict(os.environ, {"AWS_REGION": "us-west-1"})
 def test_chat_bedrock_converse_different_regions() -> None:
     region = "ap-south-2"

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -850,7 +850,8 @@ def test__extract_usage_metadata_with_per_ttl_cache_details() -> None:
     assert usage_metadata["output_tokens"] == 50
     assert usage_metadata["total_tokens"] == 850
     assert usage_metadata["input_token_details"]["cache_read"] == 200
-    assert usage_metadata["input_token_details"]["cache_creation"] == 500
+    # cache_creation zeroed when per-TTL breakdown present (avoids double-counting)
+    assert usage_metadata["input_token_details"]["cache_creation"] == 0
     assert usage_metadata["input_token_details"]["ephemeral_5m_input_tokens"] == 300  # type: ignore[typeddict-item]
     assert usage_metadata["input_token_details"]["ephemeral_1h_input_tokens"] == 200  # type: ignore[typeddict-item]
 
@@ -880,6 +881,35 @@ def test__extract_usage_metadata_without_cache_details() -> None:
     assert "ephemeral_1h_input_tokens" not in usage_metadata["input_token_details"]
 
 
+def test__extract_usage_metadata_with_single_ttl_cache_details() -> None:
+    """Test that only non-zero TTL keys are added."""
+    response = {
+        "usage": {
+            "inputTokens": 100,
+            "outputTokens": 50,
+            "totalTokens": 450,
+            "cacheReadInputTokens": 50,
+            "cacheWriteInputTokens": 300,
+            "cacheDetails": [
+                {"inputTokens": 300, "ttl": "5m"},
+                # No 1h entries
+            ],
+        }
+    }
+
+    usage_metadata = _extract_usage_metadata(response)
+
+    assert usage_metadata["input_tokens"] == 450  # 100 + 50 + 300
+    assert usage_metadata["output_tokens"] == 50
+    assert usage_metadata["input_token_details"]["cache_read"] == 50
+    # cache_creation is zeroed when per-TTL breakdown is present
+    assert usage_metadata["input_token_details"]["cache_creation"] == 0
+    # Only 5m key should be present (non-zero)
+    assert usage_metadata["input_token_details"]["ephemeral_5m_input_tokens"] == 300  # type: ignore[typeddict-item]
+    # 1h key should NOT be present (zero value)
+    assert "ephemeral_1h_input_tokens" not in usage_metadata["input_token_details"]
+
+
 def test__extract_usage_metadata_with_malformed_cache_details() -> None:
     """Test that malformed cacheDetails entries are handled gracefully."""
     response = {
@@ -902,7 +932,8 @@ def test__extract_usage_metadata_with_malformed_cache_details() -> None:
     assert usage_metadata["input_tokens"] == 600  # 100 + 200 + 300
     assert usage_metadata["output_tokens"] == 50
     assert usage_metadata["input_token_details"]["cache_read"] == 200
-    assert usage_metadata["input_token_details"]["cache_creation"] == 300
+    # cache_creation zeroed when per-TTL breakdown present (avoids double-counting)
+    assert usage_metadata["input_token_details"]["cache_creation"] == 0
     # 100 from first entry, 0 from second entry (missing inputTokens)
     assert usage_metadata["input_token_details"]["ephemeral_5m_input_tokens"] == 100  # type: ignore[typeddict-item]
     assert usage_metadata["input_token_details"]["ephemeral_1h_input_tokens"] == 50  # type: ignore[typeddict-item]


### PR DESCRIPTION
  ## Summary

 Adds per-TTL cache token breakdown to `input_token_details` when Bedrock returns `cacheDetails`, matching the pattern established in `langchain-anthropic` (ref: [langchain_anthropic](https://github.com/langchain-ai/langchain/blob/master/libs/partners/anthropic/langchain_anthropic/chat_models.py#L2362)). 
  ## Background

  Anthropic offers two prompt-cache tiers (5-minute and 1-hour TTL) at different pricing — the 1h tier costs ~2x the 5m tier. The Bedrock Converse API exposes this breakdown via `usage.cacheDetails`:

  ```json
  {
    "usage": {
      "cacheWriteInputTokens": 500,
      "cacheDetails": [
        {"inputTokens": 300, "ttl": "5m"},
        {"inputTokens": 200, "ttl": "1h"}
      ]
    }
  }
  ```