### PR TITLE
feat(aws): add `langchain-aws` version metadata to models

### DIFF
--- a/libs/aws/langchain_aws/__init__.py
+++ b/libs/aws/langchain_aws/__init__.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING, Any
 
+from langchain_aws._version import __version__
 from langchain_aws.chat_models import ChatBedrock, ChatBedrockConverse
 from langchain_aws.llms import BedrockLLM, SagemakerEndpoint
 from langchain_aws.retrievers import (
@@ -79,6 +80,7 @@ except Exception:
 
 
 __all__ = [
+    "__version__",
     "BedrockEmbeddings",
     "BedrockLLM",
     "ChatAnthropicBedrock",

--- a/libs/aws/langchain_aws/_version.py
+++ b/libs/aws/langchain_aws/_version.py
@@ -1,0 +1,22 @@
+"""Package version helpers."""
+
+from importlib.metadata import PackageNotFoundError, version
+
+from langchain_core.language_models import BaseLanguageModel
+
+try:
+    __version__ = version("langchain-aws")
+except PackageNotFoundError:
+    __version__ = "0.0.0"
+
+
+def _add_langchain_aws_version(model: BaseLanguageModel) -> None:
+    """Record the langchain-aws version in the model's tracing metadata.
+
+    Appends to ``metadata['lc_versions']`` alongside the entries seeded by
+    langchain-core, so every trace carries the package versions that produced it.
+
+    Args:
+        model: The model instance to tag.
+    """
+    model._add_version("langchain-aws", __version__)

--- a/libs/aws/langchain_aws/chat_models/anthropic.py
+++ b/libs/aws/langchain_aws/chat_models/anthropic.py
@@ -16,6 +16,7 @@ from langchain_core.utils import secret_from_env
 from pydantic import ConfigDict, Field, SecretStr, model_validator
 from typing_extensions import Self
 
+from langchain_aws._version import _add_langchain_aws_version
 from langchain_aws.chat_models._anthropic_utils import _create_bedrock_client_params
 from langchain_aws.data._profiles import _PROFILES
 
@@ -195,6 +196,7 @@ class ChatAnthropicBedrock(ChatAnthropic):
         if self.profile is None:
             model = re.sub(r"^[A-Za-z]{2}\.", "", self.model)
             self.profile = _get_default_model_profile(model)
+        _add_langchain_aws_version(self)
         return self
 
     def _make_message_chunk_from_anthropic_event(

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -71,6 +71,7 @@ from langchain_core.utils.utils import _build_model_kwargs
 from pydantic import BaseModel, ConfigDict, Field, SecretStr, model_validator
 from typing_extensions import Self
 
+from langchain_aws._version import _add_langchain_aws_version
 from langchain_aws.chat_models._compat import _convert_from_v1_to_converse
 from langchain_aws.data._profiles import _PROFILES
 from langchain_aws.function_calling import ToolsOutputParser
@@ -1048,6 +1049,7 @@ class ChatBedrockConverse(BaseChatModel):
         if not self.profile:
             self.profile = self._resolve_model_profile()
 
+        _add_langchain_aws_version(self)
         return self
 
     def _resolve_model_profile(self) -> ModelProfile | None:

--- a/libs/aws/langchain_aws/chat_models/bedrock_nova_sonic.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_nova_sonic.py
@@ -36,6 +36,8 @@ from langchain_core.utils import secret_from_env
 from pydantic import ConfigDict, Field, SecretStr, model_validator
 from typing_extensions import Self
 
+from langchain_aws._version import _add_langchain_aws_version
+
 logger = logging.getLogger(__name__)
 
 # Default audio configuration constants
@@ -762,6 +764,7 @@ class ChatBedrockNovaSonic(BaseChatModel):
                 endpoint_url=self.endpoint_url,
                 api_key=self.bedrock_api_key,
             )
+        _add_langchain_aws_version(self)
         return self
 
     @asynccontextmanager

--- a/libs/aws/langchain_aws/chat_models/sagemaker_endpoint.py
+++ b/libs/aws/langchain_aws/chat_models/sagemaker_endpoint.py
@@ -22,6 +22,7 @@ from langchain_core.utils import secret_from_env
 from pydantic import ConfigDict, Field, SecretStr, model_validator
 from typing_extensions import Self
 
+from langchain_aws._version import _add_langchain_aws_version
 from langchain_aws.utils import (
     ContentHandlerBase,
     create_aws_client,
@@ -325,6 +326,7 @@ class ChatSagemakerEndpoint(BaseChatModel):
                 service_name="sagemaker-runtime",
             )
 
+        _add_langchain_aws_version(self)
         return self
 
     @property

--- a/libs/aws/langchain_aws/function_calling.py
+++ b/libs/aws/langchain_aws/function_calling.py
@@ -20,8 +20,8 @@ from langchain_core.outputs import ChatGeneration, Generation
 from langchain_core.prompts.chat import AIMessage
 from langchain_core.tools import BaseTool
 from langchain_core.utils.function_calling import convert_to_openai_tool
-from langchain_core.utils.pydantic import TypeBaseModel
-from pydantic import BaseModel, ConfigDict, SkipValidation
+from langchain_core.utils.pydantic import PydanticBaseModel, TypeBaseModel
+from pydantic import ConfigDict, SkipValidation
 from typing_extensions import TypedDict
 
 PYTHON_TO_JSON_TYPES = {
@@ -198,7 +198,7 @@ class ToolsOutputParser(BaseGenerationOutputParser):
         else:
             return tool_calls
 
-    def _pydantic_parse(self, tool_call: ToolCall) -> BaseModel:
+    def _pydantic_parse(self, tool_call: ToolCall) -> PydanticBaseModel:
         cls_ = {schema.__name__: schema for schema in self.pydantic_schemas or []}[
             tool_call["name"]
         ]

--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -30,6 +30,7 @@ from langchain_core.utils import secret_from_env
 from pydantic import ConfigDict, Field, SecretStr, model_validator
 from typing_extensions import Self
 
+from langchain_aws._version import _add_langchain_aws_version
 from langchain_aws.function_calling import _tools_in_params
 from langchain_aws.utils import (
     anthropic_tokens_supported,
@@ -993,6 +994,7 @@ class BedrockBase(BaseLanguageModel, ABC):
                 # Format: arn:aws:bedrock:region::foundation-model/provider.model-name
                 self.base_model_id = model_arn.split("/")[-1]
 
+        _add_langchain_aws_version(self)
         return self
 
     @property

--- a/libs/aws/langchain_aws/llms/sagemaker_endpoint.py
+++ b/libs/aws/langchain_aws/llms/sagemaker_endpoint.py
@@ -19,6 +19,7 @@ from langchain_core.utils import secret_from_env
 from pydantic import ConfigDict, Field, SecretStr, model_validator
 from typing_extensions import Self
 
+from langchain_aws._version import _add_langchain_aws_version
 from langchain_aws.utils import ContentHandlerBase, create_aws_client
 
 logger = logging.getLogger(__name__)
@@ -303,6 +304,7 @@ class SagemakerEndpoint(LLM):
                 service_name="sagemaker-runtime",
             )
 
+        _add_langchain_aws_version(self)
         return self
 
     @property

--- a/libs/aws/pyproject.toml
+++ b/libs/aws/pyproject.toml
@@ -12,7 +12,7 @@ authors = []
 version = "1.5.1"
 requires-python = ">=3.10"
 dependencies = [
-    "langchain-core>=1.4.0",
+    "langchain-core>=1.4.7",
     "boto3>=1.42.42",
     "pydantic>=2.10.6,<3",
     "numpy>=1.0.0,<3",

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_nova_sonic.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_nova_sonic.py
@@ -5,6 +5,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from langchain_aws._version import __version__
+
 # Mock the aws_sdk_bedrock_runtime before importing the module under test
 mock_sdk_module = MagicMock()
 mock_sdk_models = MagicMock()
@@ -93,6 +95,15 @@ class TestChatBedrockNovaSonicInit:
         mod = _import_module()
         model = mod.ChatBedrockNovaSonic()
         assert model._llm_type == "amazon_bedrock_nova_sonic"
+
+    def test_adds_langchain_aws_version_metadata(self) -> None:
+        mod = _import_module()
+        model = mod.ChatBedrockNovaSonic(
+            metadata={"lc_versions": {"user-package": "1.2.3"}}
+        )
+        assert model.metadata is not None
+        assert model.metadata["lc_versions"]["langchain-aws"] == __version__
+        assert model.metadata["lc_versions"]["user-package"] == "1.2.3"
 
 
 # ---------------------------------------------------------------------------

--- a/libs/aws/tests/unit_tests/test_versioning.py
+++ b/libs/aws/tests/unit_tests/test_versioning.py
@@ -1,0 +1,106 @@
+from typing import Any
+from unittest.mock import MagicMock
+
+from langchain_core.messages import AIMessage
+
+from langchain_aws import (
+    BedrockLLM,
+    ChatAnthropicBedrock,
+    ChatBedrock,
+    ChatBedrockConverse,
+)
+from langchain_aws._version import __version__
+from langchain_aws.chat_models.sagemaker_endpoint import (
+    ChatModelContentHandler,
+    ChatSagemakerEndpoint,
+)
+from langchain_aws.llms.sagemaker_endpoint import LLMContentHandler, SagemakerEndpoint
+
+
+class TestLLMContentHandler(LLMContentHandler):
+    content_type = "application/json"
+    accepts = "application/json"
+
+    def transform_input(self, prompt: str, model_kwargs: dict[str, Any]) -> bytes:
+        return prompt.encode()
+
+    def transform_output(self, output: bytes) -> str:
+        return output.decode()
+
+
+class TestChatModelContentHandler(ChatModelContentHandler):
+    content_type = "application/json"
+    accepts = "application/json"
+
+    def transform_input(
+        self, prompt: list[dict[str, Any]], model_kwargs: dict[str, Any]
+    ) -> bytes:
+        return str(prompt).encode()
+
+    def transform_output(self, output: bytes) -> AIMessage:
+        return AIMessage(content=output.decode())
+
+
+def _assert_langchain_aws_version(model: Any) -> None:
+    assert model.metadata is not None
+    assert model.metadata["lc_versions"]["langchain-aws"] == __version__
+    assert model.metadata["lc_versions"]["user-package"] == "1.2.3"
+
+
+def test_bedrock_models_add_langchain_aws_version_metadata() -> None:
+    metadata = {"lc_versions": {"user-package": "1.2.3"}}
+
+    _assert_langchain_aws_version(
+        ChatBedrock(
+            model_id="anthropic.claude-v2",
+            client=MagicMock(),
+            bedrock_client=MagicMock(),
+            metadata=metadata,
+        )
+    )
+    _assert_langchain_aws_version(
+        ChatBedrockConverse(
+            model_id="anthropic.claude-3-sonnet-20240229-v1:0",
+            client=MagicMock(),
+            bedrock_client=MagicMock(),
+            metadata=metadata,
+        )
+    )
+    _assert_langchain_aws_version(
+        BedrockLLM(
+            model_id="amazon.titan-text-express-v1",
+            client=MagicMock(),
+            bedrock_client=MagicMock(),
+            metadata=metadata,
+        )
+    )
+
+
+def test_sagemaker_models_add_langchain_aws_version_metadata() -> None:
+    metadata = {"lc_versions": {"user-package": "1.2.3"}}
+
+    _assert_langchain_aws_version(
+        SagemakerEndpoint(
+            endpoint_name="endpoint",
+            content_handler=TestLLMContentHandler(),
+            client=MagicMock(),
+            metadata=metadata,
+        )
+    )
+    _assert_langchain_aws_version(
+        ChatSagemakerEndpoint(
+            endpoint_name="endpoint",
+            content_handler=TestChatModelContentHandler(),
+            client=MagicMock(),
+            metadata=metadata,
+        )
+    )
+
+
+def test_anthropic_bedrock_adds_langchain_aws_version_metadata() -> None:
+    model = ChatAnthropicBedrock(
+        model="anthropic.claude-3-sonnet-20240229-v1:0",
+        metadata={"lc_versions": {"user-package": "1.2.3"}},
+    )
+
+    _assert_langchain_aws_version(model)

--- a/libs/aws/tests/unit_tests/test_versioning.py
+++ b/libs/aws/tests/unit_tests/test_versioning.py
@@ -52,7 +52,7 @@ def test_bedrock_models_add_langchain_aws_version_metadata() -> None:
 
     _assert_langchain_aws_version(
         ChatBedrock(
-            model_id="anthropic.claude-v2",
+            model="anthropic.claude-v2",
             client=MagicMock(),
             bedrock_client=MagicMock(),
             metadata=metadata,
@@ -60,7 +60,7 @@ def test_bedrock_models_add_langchain_aws_version_metadata() -> None:
     )
     _assert_langchain_aws_version(
         ChatBedrockConverse(
-            model_id="anthropic.claude-3-sonnet-20240229-v1:0",
+            model="anthropic.claude-3-sonnet-20240229-v1:0",
             client=MagicMock(),
             bedrock_client=MagicMock(),
             metadata=metadata,
@@ -68,7 +68,7 @@ def test_bedrock_models_add_langchain_aws_version_metadata() -> None:
     )
     _assert_langchain_aws_version(
         BedrockLLM(
-            model_id="amazon.titan-text-express-v1",
+            model="amazon.titan-text-express-v1",
             client=MagicMock(),
             bedrock_client=MagicMock(),
             metadata=metadata,
@@ -99,8 +99,10 @@ def test_sagemaker_models_add_langchain_aws_version_metadata() -> None:
 
 def test_anthropic_bedrock_adds_langchain_aws_version_metadata() -> None:
     model = ChatAnthropicBedrock(
-        model="anthropic.claude-3-sonnet-20240229-v1:0",
+        model_name="anthropic.claude-3-sonnet-20240229-v1:0",
         metadata={"lc_versions": {"user-package": "1.2.3"}},
+        timeout=None,
+        stop=None,
     )
 
     _assert_langchain_aws_version(model)

--- a/libs/aws/uv.lock
+++ b/libs/aws/uv.lock
@@ -1128,7 +1128,7 @@ requires-dist = [
     { name = "bedrock-agentcore", marker = "python_full_version >= '3.10' and extra == 'tools'", specifier = ">=1.4.0" },
     { name = "boto3", specifier = ">=1.42.42" },
     { name = "langchain-anthropic", marker = "extra == 'anthropic'" },
-    { name = "langchain-core", specifier = ">=1.4.0" },
+    { name = "langchain-core", specifier = ">=1.4.7" },
     { name = "numpy", specifier = ">=1.0.0,<3" },
     { name = "playwright", marker = "extra == 'tools'", specifier = ">=1.53.0" },
     { name = "pydantic", specifier = ">=2.10.6,<3" },
@@ -1192,7 +1192,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.4.1"
+version = "1.4.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -1205,9 +1205,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/80/c1/276a0d704440490fb0d27ce25e556872ca420d285b9d00eb823374717897/langchain_core-1.4.1.tar.gz", hash = "sha256:8234eb8cd3200f690e278159b7d7cee5976381ec90ece7b48db8d8e8850ab37d", size = 932675, upload-time = "2026-06-05T14:51:40.772Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/2b/fffaff399d20a56d40b9562fa19701e91abd72d8c9d9bc8c2673077b56b6/langchain_core-1.4.7.tar.gz", hash = "sha256:7a825d77de0a3f39adbd9d09612a75e85527e14a52c1601089bcc062972d9f2b", size = 952522, upload-time = "2026-06-12T19:23:57.588Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/79/531d8ee5dc5bf464c18cc86b087569307bc2d6b74548753f26122d08746d/langchain_core-1.4.1-py3-none-any.whl", hash = "sha256:e5dee06e70c123cb98cb0158e4416efac1e386ff47a484901ccf88555e28eec6", size = 549118, upload-time = "2026-06-05T14:51:39.038Z" },
+    { url = "https://files.pythonhosted.org/packages/de/3e/dcdffa60078ae7b3a00ebb4cbbf1a204a14c3609983c604886523a7d4418/langchain_core-1.4.7-py3-none-any.whl", hash = "sha256:bcadd51951140ecdcba98311dbd931ba5de02a5ba8a2288dad5069c1eea2a13d", size = 554941, upload-time = "2026-06-12T19:23:55.826Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Model instances now record the installed `langchain-aws` package version in `metadata['lc_versions']`, matching the tracing metadata seeded by `langchain-core`. The package also exposes `__version__` from `langchain_aws` and raises the `langchain-core` minimum to the release that provides the version metadata hook.

## Changes
- Added `__version__` and `_add_langchain_aws_version` so model instances can consistently tag tracing metadata with the active `langchain-aws` version.
- Exported `__version__` from the top-level `langchain_aws` package for callers that need package-version introspection.
- Applied version tagging during model validation for Bedrock chat/LLM models, including `ChatBedrockConverse`, `ChatAnthropicBedrock`, `ChatBedrockNovaSonic`, and Bedrock-backed LLMs.
- Applied the same metadata tagging to SageMaker chat and LLM integrations through `ChatSagemakerEndpoint` and `SagemakerEndpoint`.
- Bumped the `langchain-core` lower bound to `>=1.4.7` so all supported installs include `BaseLanguageModel._add_version`.