### PR TITLE
fix(agentcore-codeinterpreter): resolve read-plane paths against sandbox cwd

### DIFF
--- a/libs/agentcore-codeinterpreter/langchain_agentcore_codeinterpreter/sandbox.py
+++ b/libs/agentcore-codeinterpreter/langchain_agentcore_codeinterpreter/sandbox.py
@@ -14,6 +14,9 @@ from deepagents.backends.protocol import (
     ExecuteResponse,
     FileDownloadResponse,
     FileUploadResponse,
+    GlobResult,
+    GrepResult,
+    LsResult,
     ReadResult,
     WriteResult,
 )
@@ -174,7 +177,7 @@ class AgentCoreSandbox(BaseSandbox):
         against the real cwd before shell preflight commands and stripped of
         the cwd prefix before the AgentCore ``writeFiles``/``readFiles`` APIs.
         Pass the known cwd via the ``cwd`` constructor argument, or let the
-        sandbox detect it automatically on the first ``write()`` call.
+        sandbox detect it automatically on the first path operation via ``pwd``.
 
     Example:
         .. code-block:: python
@@ -209,7 +212,7 @@ class AgentCoreSandbox(BaseSandbox):
                 ``write()`` uses it to resolve virtual paths to real absolute
                 paths and to strip the prefix before the AgentCore
                 ``writeFiles`` API. When omitted, the cwd is detected
-                automatically on the first ``write()`` call via ``pwd``.
+                automatically on the first path operation via ``pwd``.
         """
         self._interpreter = interpreter
         self._cwd: str | None = cwd.rstrip("/") if cwd is not None else None
@@ -477,6 +480,68 @@ class AgentCoreSandbox(BaseSandbox):
                 FileUploadResponse(path=path, error="permission_denied")
                 for path, _ in files
             ]
+
+    # ------------------------------------------------------------------
+    # Read-plane overrides — resolve virtual/relative paths against the
+    # sandbox cwd before the inherited ``BaseSandbox`` shell operations,
+    # which would otherwise run against the literal path.
+    #
+    # ``write()`` and ``download_files()`` already resolve paths to the real
+    # cwd, but ``BaseSandbox.ls``/``read``/``grep``/``glob``/``edit`` execute
+    # shell commands against the path verbatim. When the sandbox cwd is not
+    # ``/`` (e.g. ``/opt/amazon/genesis1p-tools/var``), an absolute virtual
+    # path like ``/workspace/file.py`` — which is exactly what the deepagents
+    # filesystem tools produce via ``validate_path`` — does not exist on disk
+    # and these operations fail. Resolving against the cwd here keeps the
+    # read plane symmetric with the write plane.
+    # ------------------------------------------------------------------
+
+    def ls(self, path: str) -> LsResult:
+        """List a directory, resolving ``path`` against the sandbox cwd."""
+        return super().ls(self._to_absolute_path(path))
+
+    def read(
+        self,
+        file_path: str,
+        offset: int = 0,
+        limit: int = 2000,
+    ) -> ReadResult:
+        """Read a file, resolving ``file_path`` against the sandbox cwd."""
+        return super().read(self._to_absolute_path(file_path), offset, limit)
+
+    def grep(
+        self,
+        pattern: str,
+        path: str | None = None,
+        glob: str | None = None,
+    ) -> GrepResult:
+        """Search file contents, resolving ``path`` against the sandbox cwd."""
+        resolved = self._to_absolute_path(path) if path else path
+        return super().grep(pattern, resolved, glob)
+
+    def glob(
+        self,
+        pattern: str,
+        path: str | None = None,
+    ) -> GlobResult:
+        """Match paths by glob, resolving ``path`` against the sandbox cwd."""
+        resolved = self._to_absolute_path(path) if path else path
+        return super().glob(pattern, resolved)
+
+    def edit(
+        self,
+        file_path: str,
+        old_string: str,
+        new_string: str,
+        replace_all: bool = False,  # noqa: FBT001, FBT002
+    ) -> EditResult:
+        """Edit a file, resolving ``file_path`` against the sandbox cwd."""
+        return super().edit(
+            self._to_absolute_path(file_path),
+            old_string,
+            new_string,
+            replace_all,
+        )
 
     # ------------------------------------------------------------------
     # Async overrides — use a dedicated executor to avoid starving the

--- a/libs/agentcore-codeinterpreter/langchain_agentcore_codeinterpreter/sandbox.py
+++ b/libs/agentcore-codeinterpreter/langchain_agentcore_codeinterpreter/sandbox.py
@@ -481,21 +481,6 @@ class AgentCoreSandbox(BaseSandbox):
                 for path, _ in files
             ]
 
-    # ------------------------------------------------------------------
-    # Read-plane overrides — resolve virtual/relative paths against the
-    # sandbox cwd before the inherited ``BaseSandbox`` shell operations,
-    # which would otherwise run against the literal path.
-    #
-    # ``write()`` and ``download_files()`` already resolve paths to the real
-    # cwd, but ``BaseSandbox.ls``/``read``/``grep``/``glob``/``edit`` execute
-    # shell commands against the path verbatim. When the sandbox cwd is not
-    # ``/`` (e.g. ``/opt/amazon/genesis1p-tools/var``), an absolute virtual
-    # path like ``/workspace/file.py`` — which is exactly what the deepagents
-    # filesystem tools produce via ``validate_path`` — does not exist on disk
-    # and these operations fail. Resolving against the cwd here keeps the
-    # read plane symmetric with the write plane.
-    # ------------------------------------------------------------------
-
     def ls(self, path: str) -> LsResult:
         """List a directory, resolving ``path`` against the sandbox cwd."""
         return super().ls(self._to_absolute_path(path))

--- a/libs/agentcore-codeinterpreter/tests/unit_tests/test_sandbox.py
+++ b/libs/agentcore-codeinterpreter/tests/unit_tests/test_sandbox.py
@@ -658,7 +658,6 @@ def test_read_plane_resolves_virtual_paths(
 ) -> None:
     """Read-plane methods should resolve virtual paths against the sandbox cwd."""
     sandbox, _ = _make_sandbox(cwd="/opt/sandbox")
-    base_method = getattr(BaseSandbox, method_name)
     result: Any
 
     with patch.object(
@@ -681,7 +680,6 @@ def test_read_plane_resolves_virtual_paths(
             mock_method.assert_called_once_with(expected_path)
 
     assert result == return_value
-    assert base_method is not None
 
 
 def test_grep_with_none_path_passes_through() -> None:

--- a/libs/agentcore-codeinterpreter/tests/unit_tests/test_sandbox.py
+++ b/libs/agentcore-codeinterpreter/tests/unit_tests/test_sandbox.py
@@ -9,10 +9,19 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Iterator
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from botocore.exceptions import ClientError
+from deepagents.backends.protocol import (
+    EditResult,
+    FileData,
+    GlobResult,
+    GrepResult,
+    LsResult,
+    ReadResult,
+)
+from deepagents.backends.sandbox import BaseSandbox
 
 from langchain_agentcore_codeinterpreter import AgentCoreSandbox
 from langchain_agentcore_codeinterpreter.sandbox import (
@@ -593,6 +602,121 @@ def test_write_root_cwd_preserves_existing_behavior() -> None:
     ]
     uploaded_path = write_files_calls[0].kwargs["params"]["content"][0]["path"]
     assert uploaded_path == "hello.py"
+
+
+# ------------------------------------------------------------------
+# Read-plane path normalization (ls/read/grep/glob/edit)
+# ------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("method_name", "virtual_path", "expected_path", "extra_args", "return_value"),
+    [
+        (
+            "ls",
+            "/workspace",
+            "/opt/sandbox/workspace",
+            (),
+            LsResult(entries=[]),
+        ),
+        (
+            "read",
+            "/workspace/hello.py",
+            "/opt/sandbox/workspace/hello.py",
+            (0, 2000),
+            ReadResult(file_data=FileData(content="hello", encoding="utf-8")),
+        ),
+        (
+            "grep",
+            "/workspace",
+            "/opt/sandbox/workspace",
+            ("needle", None),
+            GrepResult(matches=[]),
+        ),
+        (
+            "glob",
+            "/workspace",
+            "/opt/sandbox/workspace",
+            ("*.py",),
+            GlobResult(matches=[]),
+        ),
+        (
+            "edit",
+            "/workspace/hello.py",
+            "/opt/sandbox/workspace/hello.py",
+            ("old", "new", False),
+            EditResult(path="/opt/sandbox/workspace/hello.py", occurrences=1),
+        ),
+    ],
+)
+def test_read_plane_resolves_virtual_paths(
+    method_name: str,
+    virtual_path: str,
+    expected_path: str,
+    extra_args: tuple[Any, ...],
+    return_value: Any,
+) -> None:
+    """Read-plane methods should resolve virtual paths against the sandbox cwd."""
+    sandbox, _ = _make_sandbox(cwd="/opt/sandbox")
+    base_method = getattr(BaseSandbox, method_name)
+    result: Any
+
+    with patch.object(
+        BaseSandbox, method_name, return_value=return_value
+    ) as mock_method:
+        if method_name == "grep":
+            result = sandbox.grep(extra_args[0], virtual_path)
+            mock_method.assert_called_once_with(extra_args[0], expected_path, None)
+        elif method_name == "glob":
+            result = sandbox.glob(extra_args[0], virtual_path)
+            mock_method.assert_called_once_with(extra_args[0], expected_path)
+        elif method_name == "read":
+            result = sandbox.read(virtual_path, *extra_args)
+            mock_method.assert_called_once_with(expected_path, *extra_args)
+        elif method_name == "edit":
+            result = sandbox.edit(virtual_path, *extra_args)
+            mock_method.assert_called_once_with(expected_path, *extra_args)
+        else:
+            result = sandbox.ls(virtual_path)
+            mock_method.assert_called_once_with(expected_path)
+
+    assert result == return_value
+    assert base_method is not None
+
+
+def test_grep_with_none_path_passes_through() -> None:
+    """grep() should not resolve when path is None (BaseSandbox defaults to '.')."""
+    sandbox, _ = _make_sandbox(cwd="/opt/sandbox")
+
+    with patch.object(
+        BaseSandbox, "grep", return_value=GrepResult(matches=[])
+    ) as mock_grep:
+        sandbox.grep("needle")
+        mock_grep.assert_called_once_with("needle", None, None)
+
+
+def test_glob_with_none_path_passes_through() -> None:
+    """glob() should not resolve when path is None (BaseSandbox defaults to '/')."""
+    sandbox, _ = _make_sandbox(cwd="/opt/sandbox")
+
+    with patch.object(
+        BaseSandbox, "glob", return_value=GlobResult(matches=[])
+    ) as mock_glob:
+        sandbox.glob("*.py")
+        mock_glob.assert_called_once_with("*.py", None)
+
+
+def test_read_root_cwd_preserves_virtual_path() -> None:
+    """When cwd is /, read() should pass virtual paths through unchanged."""
+    sandbox, _ = _make_sandbox(cwd="/")
+
+    with patch.object(
+        BaseSandbox,
+        "read",
+        return_value=ReadResult(file_data=FileData(content="ok", encoding="utf-8")),
+    ) as mock_read:
+        sandbox.read("/workspace/hello.py")
+        mock_read.assert_called_once_with("/workspace/hello.py", 0, 2000)
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
Fixes #1103

## Summary

Follow-up to #1073 (`write()`) and #1076 (`download_files()`), which made the **write plane** cwd-aware. This PR applies the same `_to_absolute_path()` resolution to the **read plane** — `ls()`, `read()`, `grep()`, `glob()`, and `edit()` — so `AgentCoreSandbox` behaves consistently when the sandbox working directory is not `/` (e.g. the AWS-managed `aws.codeinterpreter.v1` image, whose cwd is `/opt/amazon/genesis1p-tools/var`).

## Root cause

`AgentCoreSandbox` overrides `write()`/`upload_files()`/`download_files()` to map paths to the real sandbox cwd, but `ls`/`read`/`grep`/`glob`/`edit` were inherited unchanged from `BaseSandbox`. Those run shell commands against the **literal** path.

When `cwd != "/"`, a virtual path such as `/workspace/file.py` does not exist on disk (the real file is at `<cwd>/workspace/file.py`), so read-plane operations fail with `path_not_found` / `file_not_found` even though `write("/workspace/file.py")` succeeded. DeepAgents filesystem tools normalize every path to a leading-slash absolute via `validate_path()`, so `read_file("skills/x")` becomes `read("/skills/x")` and fails.

## Changes

- Override `ls`, `read`, `grep`, `glob`, and `edit` to resolve paths via `_to_absolute_path()` before delegating to `BaseSandbox`.
- Async variants (`aread`, `aedit`, etc.) inherit the fix automatically via the sync methods.
- No behavior change when `cwd == "/"`: `_to_absolute_path` passes paths through unchanged.
- 8 new unit tests covering virtual-path resolution, `None` path passthrough, and root-cwd backward compatibility.

## Areas requiring careful review

- `grep`/`glob` with `path=None` intentionally pass `None` through so `BaseSandbox` defaults (`.` and `/`) are preserved.
- `edit()` was included for symmetry with `read()` — same `validate_path()` normalization applies to `edit_file`.

## Test plan

- [x] `cd libs/agentcore-codeinterpreter && make format`
- [x] `cd libs/agentcore-codeinterpreter && make lint`
- [x] `cd libs/agentcore-codeinterpreter && uv run --group test pytest tests/unit_tests/test_sandbox.py` — 55 passed
- [x] Manual: `write("/workspace/f.txt")` then `read("/workspace/f.txt")` and `ls("/workspace")` round-trip on a live `aws.codeinterpreter.v1` session

> This PR was implemented with the assistance of an AI agent (Cursor). The contributor verified all changes: tests pass, lint passes, and the fix mirrors the approach described in #1103.