### PR TITLE
fix(aws): validate Bedrock embedding media inputs

### DIFF
--- a/libs/aws/langchain_aws/embeddings/bedrock.py
+++ b/libs/aws/langchain_aws/embeddings/bedrock.py
@@ -416,11 +416,18 @@ class BedrockEmbeddings(BaseModel, Embeddings):
             return data, fmt, "s3"
 
         data_uri_match = re.match(
-            r"^data:(?:image|video|audio)/([a-zA-Z0-9]+);base64,(.+)$", data
+            r"^data:(image|video|audio)/([a-zA-Z0-9]+);base64,(.+)$", data
         )
         if data_uri_match:
-            fmt = data_uri_match.group(1).lower()
-            b64 = data_uri_match.group(2)
+            data_uri_media_type = data_uri_match.group(1)
+            if data_uri_media_type != media_type:
+                msg = (
+                    f"Data URI media type '{data_uri_media_type}' does not match "
+                    f"requested media type '{media_type}'"
+                )
+                raise ValueError(msg)
+            fmt = data_uri_match.group(2).lower()
+            b64 = data_uri_match.group(3)
             return b64, fmt, "inline"
 
         if os.path.isfile(data):
@@ -432,7 +439,7 @@ class BedrockEmbeddings(BaseModel, Embeddings):
 
         # Assume raw base64 string
         try:
-            decoded = base64.b64decode(data)
+            decoded = base64.b64decode(data, validate=True)
             fmt = self._detect_media_format(decoded)
             return data, fmt, "inline"
         except Exception:

--- a/libs/aws/tests/unit_tests/embeddings/test_bedrock_multimodal.py
+++ b/libs/aws/tests/unit_tests/embeddings/test_bedrock_multimodal.py
@@ -200,6 +200,29 @@ class TestMediaInputNormalization:
         assert source_kind == "inline"
         assert payload == b64
 
+    def test_load_audio_data_uri(self) -> None:
+        embeddings = BedrockEmbeddings(
+            model_id="amazon.nova-2-multimodal-embeddings-v1:0"
+        )
+        audio_bytes = b"ID3" + b"\x00" * 20
+        b64 = base64.b64encode(audio_bytes).decode("utf-8")
+        data_uri = f"data:audio/mp3;base64,{b64}"
+
+        payload, fmt, source_kind = embeddings._load_media(data_uri, "audio")
+
+        assert fmt == "mp3"
+        assert source_kind == "inline"
+        assert payload == b64
+
+    def test_load_data_uri_rejects_media_type_mismatch(self) -> None:
+        embeddings = BedrockEmbeddings(model_id="amazon.titan-embed-image-v1")
+        audio_bytes = b"ID3" + b"\x00" * 20
+        b64 = base64.b64encode(audio_bytes).decode("utf-8")
+        data_uri = f"data:audio/mp3;base64,{b64}"
+
+        with pytest.raises(ValueError, match="does not match requested media type"):
+            embeddings._load_media(data_uri, "image")
+
     def test_load_raw_base64(self) -> None:
         embeddings = BedrockEmbeddings(model_id="amazon.titan-embed-image-v1")
         b64 = base64.b64encode(JPEG_BYTES).decode("utf-8")
@@ -244,6 +267,12 @@ class TestMediaInputNormalization:
 
         with pytest.raises(ValueError, match="Could not interpret input"):
             embeddings._load_media("not-valid-base64-!!!", "image")
+
+    def test_load_plain_string_not_treated_as_base64(self) -> None:
+        embeddings = BedrockEmbeddings(model_id="amazon.titan-embed-image-v1")
+
+        with pytest.raises(ValueError, match="Could not interpret input"):
+            embeddings._load_media("not a path", "image")
 
 
 class TestImageRequestBuilders:

--- a/libs/aws/tests/unit_tests/embeddings/test_bedrock_multimodal.py
+++ b/libs/aws/tests/unit_tests/embeddings/test_bedrock_multimodal.py
@@ -274,6 +274,14 @@ class TestMediaInputNormalization:
         with pytest.raises(ValueError, match="Could not interpret input"):
             embeddings._load_media("not a path", "image")
 
+    def test_load_wrapped_base64_rejected(self) -> None:
+        embeddings = BedrockEmbeddings(model_id="amazon.titan-embed-image-v1")
+        wrapped = base64.encodebytes(JPEG_BYTES * 2).decode("utf-8")
+        assert "\n" in wrapped.strip()
+
+        with pytest.raises(ValueError, match="Could not interpret input"):
+            embeddings._load_media(wrapped, "image")
+
 
 class TestImageRequestBuilders:
     """Test _build_image_request for each provider."""


### PR DESCRIPTION
## Summary
- reject Bedrock embedding data URIs whose media family does not match the requested embedding media type
- use strict raw base64 decoding before media format detection
- add regression tests for audio data URIs, media type mismatches, and plain strings that should not be treated as base64

## Tests
- uv tree --depth 0
- uv lock --check
- env -u AWS_ACCESS_KEY_ID -u AWS_SECRET_ACCESS_KEY -u AWS_SESSION_TOKEN -u BEDROCK_AWS_ACCESS_KEY_ID -u BEDROCK_AWS_SECRET_ACCESS_KEY uv run --group test pytest --disable-socket --allow-unix-socket tests/unit_tests/embeddings/test_bedrock_multimodal.py -q
- env -u AWS_ACCESS_KEY_ID -u AWS_SECRET_ACCESS_KEY -u AWS_SESSION_TOKEN -u BEDROCK_AWS_ACCESS_KEY_ID -u BEDROCK_AWS_SECRET_ACCESS_KEY uv run --group test pytest --disable-socket --allow-unix-socket tests/unit_tests/embeddings -q
- uv run --no-sync pytest -m compile tests/integration_tests -q
- uv run --no-sync pytest tests/unit_tests/test_standard.py -q
- uv run --group lint ruff check langchain_aws/embeddings/bedrock.py tests/unit_tests/embeddings/test_bedrock_multimodal.py
- uv run --group lint ruff format langchain_aws/embeddings/bedrock.py tests/unit_tests/embeddings/test_bedrock_multimodal.py --diff
- git diff --check