### PR TITLE
test(aws): Update integ for per TTL cache stats support

### DIFF
--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
@@ -410,7 +410,10 @@ def test_tool_use_with_cache_point() -> None:
     assert response.usage_metadata is not None
     input_token_details = response.usage_metadata.get("input_token_details")
     if input_token_details:
-        cache_write_input_tokens = input_token_details.get("cache_creation", 0)
+        cache_write_input_tokens = input_token_details.get("cache_creation", 0) or (
+            input_token_details.get("ephemeral_5m_input_tokens", 0)
+            + input_token_details.get("ephemeral_1h_input_tokens", 0)  # type: ignore[operator]
+        )
         assert cache_write_input_tokens > 0, (
             f"Expected cache write on first call, got {cache_write_input_tokens}"
         )
@@ -444,7 +447,10 @@ def test_cache_control_anthropic() -> None:
     assert isinstance(r1, AIMessage)
     assert r1.usage_metadata is not None
     details = r1.usage_metadata.get("input_token_details", {})
-    cache_write = details.get("cache_creation", 0) or 0
+    cache_write = details.get("cache_creation", 0) or (
+        details.get("ephemeral_5m_input_tokens", 0)
+        + details.get("ephemeral_1h_input_tokens", 0)  # type: ignore[operator]
+    )
     assert cache_write > 0, f"Expected cache write on first call, got {cache_write}"
 
 
@@ -490,7 +496,10 @@ def test_cache_control_nova() -> None:
     assert isinstance(r1, AIMessage)
     assert r1.usage_metadata is not None
     details = r1.usage_metadata.get("input_token_details", {})
-    cache_write = details.get("cache_creation", 0) or 0
+    cache_write = details.get("cache_creation", 0) or (
+        details.get("ephemeral_5m_input_tokens", 0)
+        + details.get("ephemeral_1h_input_tokens", 0)  # type: ignore[operator]
+    )
     assert cache_write > 0, f"Expected cache write on first call, got {cache_write}"
 
 

--- a/libs/aws/tests/integration_tests/middleware/test_prompt_caching.py
+++ b/libs/aws/tests/integration_tests/middleware/test_prompt_caching.py
@@ -36,9 +36,12 @@ def _get_cache_stats(response: AIMessage) -> tuple[int, int]:
     details = um.get("input_token_details")
     if not details:
         return 0, 0
-    cache_read = details.get("cache_read", 0)
-    cache_write = details.get("cache_creation", 0)
-    return cache_read or 0, cache_write or 0
+    cache_read = details.get("cache_read", 0) or 0
+    cache_write = details.get("cache_creation", 0) or (
+        details.get("ephemeral_5m_input_tokens", 0)
+        + details.get("ephemeral_1h_input_tokens", 0)  # type: ignore[operator]
+    )
+    return cache_read, cache_write
 
 
 def _make_many_tools() -> list[type[BaseModel]]:


### PR DESCRIPTION
Updates ChatBedrockConverse and BedrockPromptCachingMiddleware integration tests to work with https://github.com/langchain-ai/langchain-aws/pull/1098.