### PR TITLE
docs(aws): clarify prompt caching middleware and helper docstrings

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -837,7 +837,8 @@ def _apply_cache_control_to_messages(
     cache_control: Optional[Dict[str, Any]],
     formatted_messages: Optional[List[Dict[str, Any]]],
 ) -> None:
-    """Apply cache_control to the last content block of the last message."""
+    """Apply cache_control to the last content block of the latest message with
+    cacheable content."""
     if not cache_control or not formatted_messages:
         return
     for fmt_msg in reversed(formatted_messages):

--- a/libs/aws/langchain_aws/middleware/prompt_caching.py
+++ b/libs/aws/langchain_aws/middleware/prompt_caching.py
@@ -38,9 +38,12 @@ class BedrockPromptCachingMiddleware(AgentMiddleware):
     Optimizes API usage by caching conversation prefixes for supported models
     on AWS Bedrock. Supports Anthropic Claude and Amazon Nova models.
 
-    For ChatBedrock (InvokeModel API), adds ``cache_control`` to the last
-    message's content block. For ChatBedrockConverse (Converse API), appends
-    ``cachePoint`` blocks to the system prompt and last message.
+    The middleware passes cache settings through ``model_settings`` rather than
+    modifying messages directly. ``ChatBedrock`` and ``ChatBedrockConverse``
+    apply the provider-specific cache markers at request time: ``ChatBedrock``
+    (InvokeModel API) adds ``cache_control`` to message content, while
+    ``ChatBedrockConverse`` (Converse API) inserts ``cachePoint`` blocks. Cache
+    placement varies by API and model family.
 
     Requires both 'langchain' and 'langchain-aws' packages to be installed.
 


### PR DESCRIPTION
The `BedrockPromptCachingMiddleware` docstring implied the middleware tags the last message's content block itself. It doesn't — it passes `cache_control` settings through `model_settings`, and `ChatBedrock`/`ChatBedrockConverse` apply the provider-specific markers at request time. Docstring-only; no runtime behavior changes.