### PR TITLE
fix(aws): strip null anyOf variants to stay within Bedrock 16-union-type limit

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -2962,6 +2962,48 @@ def _set_additional_properties_false(schema: dict) -> None:
                 _set_additional_properties_false(sub_schema)
 
 
+def _strip_null_anyof(schema: Any) -> Any:
+    """Recursively strip ``{type: null}`` variants from ``anyOf`` and type arrays.
+
+    Bedrock's Converse API enforces a hard limit of 16 union-typed parameters
+    (``anyOf`` or array types) across all tool schemas in a single request.
+    MCP tools commonly encode optional parameters as either
+    ``anyOf: [{type: X}, {type: null}]`` or ``{type: [X, null]}``, both of
+    which count against the budget.  Stripping the null branch collapses each
+    nullable parameter to its concrete type while preserving correct
+    tool-calling behavior — Bedrock callers can still omit optional parameters
+    without the schema needing to declare them as union types.
+    """
+    if not isinstance(schema, dict):
+        return schema
+    result: Dict[str, Any] = {}
+    for key, value in schema.items():
+        if key == "anyOf" and isinstance(value, list):
+            non_null = [
+                _strip_null_anyof(v)
+                for v in value
+                if not (isinstance(v, dict) and v.get("type") == "null")
+            ]
+            if len(non_null) == 1:
+                # Unwrap single remaining type inline rather than keeping anyOf.
+                result.update(non_null[0])
+                continue
+            result[key] = non_null if non_null else value
+        elif key == "type" and isinstance(value, list):
+            # Collapse {"type": [..., "null"]} the same way as anyOf nullables.
+            non_null = [t for t in value if t != "null"]
+            result[key] = non_null[0] if len(non_null) == 1 else (non_null or value)
+        elif isinstance(value, dict):
+            result[key] = _strip_null_anyof(value)
+        elif isinstance(value, list):
+            result[key] = [
+                _strip_null_anyof(v) if isinstance(v, dict) else v for v in value
+            ]
+        else:
+            result[key] = value
+    return result
+
+
 def _format_tools(
     tools: Sequence[Union[Dict[str, Any], TypeBaseModel, Callable, BaseTool]],
 ) -> List[Dict[Literal["toolSpec"], Dict[str, Union[Dict[str, Any], str]]]]:
@@ -2974,6 +3016,7 @@ def _format_tools(
                 formatted_tools.append(tool)
             else:
                 spec = convert_to_openai_tool(tool)["function"]
+                spec["parameters"] = _strip_null_anyof(spec["parameters"])
                 spec["inputSchema"] = {"json": spec.pop("parameters")}
                 formatted_tools.append({"toolSpec": spec})
 

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -56,6 +56,7 @@ from langchain_aws.chat_models.bedrock_converse import (
     _snake_to_camel,
     _snake_to_camel_keys,
     _split_inline_reasoning,
+    _strip_null_anyof,
 )
 from langchain_aws.function_calling import convert_to_anthropic_tool
 
@@ -6170,3 +6171,96 @@ class TestNonAsciiPreservation:
         schema_str = config["textFormat"]["structure"]["jsonSchema"]["schema"]
         assert self._CJK in schema_str
         assert "\\u" not in schema_str
+
+
+class TestStripNullAnyof:
+    """Tests for _strip_null_anyof."""
+
+    def test_single_non_null_anyof_unwrapped(self) -> None:
+        """anyOf with one non-null branch is unwrapped to the concrete type."""
+        schema = {"anyOf": [{"type": "string"}, {"type": "null"}]}
+        result = _strip_null_anyof(schema)
+        assert result == {"type": "string"}
+
+    def test_multi_type_anyof_preserved(self) -> None:
+        """anyOf with multiple non-null branches is left intact."""
+        schema = {"anyOf": [{"type": "string"}, {"type": "integer"}]}
+        result = _strip_null_anyof(schema)
+        assert result == {"anyOf": [{"type": "string"}, {"type": "integer"}]}
+
+    def test_nested_properties_in_object_schema(self) -> None:
+        """Nullable params inside object properties are unwrapped recursively."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "name": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+                "count": {"anyOf": [{"type": "integer"}, {"type": "null"}]},
+            },
+        }
+        result = _strip_null_anyof(schema)
+        assert result["properties"]["name"] == {"type": "string"}
+        assert result["properties"]["count"] == {"type": "integer"}
+
+    def test_non_dict_passthrough(self) -> None:
+        """Non-dict values are returned unchanged."""
+        assert _strip_null_anyof("hello") == "hello"
+        assert _strip_null_anyof(42) == 42
+        assert _strip_null_anyof(None) is None
+
+    def test_schema_without_anyof_unchanged(self) -> None:
+        """A schema with no anyOf is returned structurally identical."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "x": {"type": "string"},
+                "y": {"type": "integer"},
+            },
+        }
+        result = _strip_null_anyof(schema)
+        assert result["type"] == "object"
+        assert result["properties"]["x"] == {"type": "string"}
+        assert result["properties"]["y"] == {"type": "integer"}
+
+    def test_all_null_anyof_left_unchanged(self) -> None:
+        """anyOf where all branches are null is left as-is (guards against empty)."""
+        schema = {"anyOf": [{"type": "null"}]}
+        result = _strip_null_anyof(schema)
+        assert "anyOf" in result
+
+    def test_type_array_null_collapsed(self) -> None:
+        """{"type": [X, "null"]} collapses to the concrete type."""
+        assert _strip_null_anyof({"type": ["string", "null"]}) == {"type": "string"}
+
+    def test_type_array_multi_non_null_preserved(self) -> None:
+        """Genuine multi-type unions keep their non-null members."""
+        result = _strip_null_anyof({"type": ["string", "integer", "null"]})
+        assert result == {"type": ["string", "integer"]}
+
+
+def test_format_tools_strips_null_anyof() -> None:
+    """_format_tools removes null anyOf branches from tool parameter schemas."""
+    openai_tool = {
+        "type": "function",
+        "function": {
+            "name": "search",
+            "description": "Search for something",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"},
+                    "limit": {
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
+                    "offset": {"type": ["integer", "null"]},
+                },
+                "required": ["query"],
+            },
+        },
+    }
+    result = _format_tools([openai_tool])
+    assert len(result) == 1
+    tool_spec = cast(Dict[str, Any], result[0]["toolSpec"])
+    input_schema: Dict[str, Any] = tool_spec["inputSchema"]["json"]
+    assert input_schema["properties"]["limit"] == {"type": "integer"}
+    assert input_schema["properties"]["offset"] == {"type": "integer"}
+    assert input_schema["properties"]["query"] == {"type": "string"}


### PR DESCRIPTION
## Problem

Bedrock's Converse API hard-limits tool schemas to **16 union-typed parameters** (`anyOf` or array types) across all tools in a single request. With a typical set of 4 LangSmith MCP tools the total reaches 20, and Bedrock throws:

```
ValidationException: The model returned the following errors: Schemas contains too many
parameters with union types (20 parameters with type arrays or anyOf). This causes
exponential compilation cost. Reduce the number of nullable or union-typed parameters
(limit: 16 parameters with unions).
```

## Root cause chain

**Step 1 — `langchain-core` PR #29812** added support for passing raw JSON schema dicts as `args_schema` to tools ([commit `d04fa1ae`](https://github.com/langchain-ai/langchain/commit/d04fa1ae50f432c3ad108c68eb2e27e781d628ba)). This introduced a new routing branch in `_format_tool_to_openai_function`:

[`function_calling.py` L344–L347 @ `38f88cc`](https://github.com/langchain-ai/langchain/blob/38f88cc5ecd7ec1e7bf8c15daf96d98bcb87650c/libs/core/langchain_core/utils/function_calling.py#L344-L347)

```python
if isinstance(tool.tool_call_schema, dict):
    return _convert_json_schema_to_openai_function(
        tool.tool_call_schema, name=tool.name, description=tool.description
    )
```

[`_convert_json_schema_to_openai_function` L123 @ `38f88cc`](https://github.com/langchain-ai/langchain/blob/38f88cc5ecd7ec1e7bf8c15daf96d98bcb87650c/libs/core/langchain_core/utils/function_calling.py#L123) passes the schema through with **no filtering** — `anyOf: [{type: X}, {type: null}]` entries are preserved intact.

**Step 2 — `langchain-mcp-adapters`** sets `args_schema=tool.inputSchema` directly from the MCP protocol dict. MCP tools encode every optional parameter as `anyOf: [{type: X}, {type: null}]`. Because `args_schema` is now a dict, the new code path is taken and all nullable parameters reach Bedrock as union types.

**Step 3 — `langchain-aws` 1.5.0** raised its minimum `langchain-core` requirement from `>=1.2.24` to `>=1.4.0`, pulling in this dict passthrough behavior for the first time. `_format_tools` in `bedrock_converse.py` receives the schema intact and forwards it to Bedrock:

[`bedrock_converse.py` L2866–L2883 @ `9483e73`](https://github.com/langchain-ai/langchain-aws/blob/9483e734e5af7193ec60b8439d740aa58f9ea1b7/libs/aws/langchain_aws/chat_models/bedrock_converse.py#L2866-L2883)

```python
spec = convert_to_openai_tool(tool)["function"]
spec["inputSchema"] = {"json": spec.pop("parameters")}
```

## Why the fix belongs here

The `langchain-core` change was intentional — preserving `anyOf: [type, null]` is correct for OpenAI, Anthropic, and every other provider. The 16-union-type limit is **Bedrock-specific**. The fix belongs in `_format_tools` in `langchain-aws`, which is the layer that knows about Bedrock's constraints.

## Fix

Add `_strip_null_anyof()` and call it in `_format_tools()` before packaging the schema into `inputSchema`. Also handles the `{"type": ["X", "null"]}` type-array nullable form, which Bedrock counts equally against the limit.

**New helper** [`_strip_null_anyof` L2965–L3004 @ `810c008`](https://github.com/evipani/langchain-aws/blob/810c008b447f3c1b4cf5edbec7547bcc32297f20/libs/aws/langchain_aws/chat_models/bedrock_converse.py#L2965-L3004)

**Modified `_format_tools`** [L3007–L3024 @ `810c008`](https://github.com/evipani/langchain-aws/blob/810c008b447f3c1b4cf5edbec7547bcc32297f20/libs/aws/langchain_aws/chat_models/bedrock_converse.py#L3007-L3024) — [key line L3019](https://github.com/evipani/langchain-aws/blob/810c008b447f3c1b4cf5edbec7547bcc32297f20/libs/aws/langchain_aws/chat_models/bedrock_converse.py#L3019)

```python
spec = convert_to_openai_tool(tool)["function"]
spec["parameters"] = _strip_null_anyof(spec["parameters"])  # strip before Bedrock
spec["inputSchema"] = {"json": spec.pop("parameters")}
```

Stripping the null branch collapses each nullable parameter to its concrete type. Bedrock callers can still omit optional parameters — the schema does not need to declare them as union types for that to work.

## Changes

- `libs/aws/langchain_aws/chat_models/bedrock_converse.py`: add `_strip_null_anyof()` and call it in `_format_tools()`
- `libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py`: add `TestStripNullAnyof` (8 unit tests) and `test_format_tools_strips_null_anyof`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
