### PR TITLE
feat(aws): native Bedrock batch inference support

### DIFF
--- a/libs/aws/langchain_aws/__init__.py
+++ b/libs/aws/langchain_aws/__init__.py
@@ -10,6 +10,11 @@ from langchain_aws.retrievers import (
 )
 
 if TYPE_CHECKING:
+    from langchain_aws.batch import (
+        BatchJob,
+        BedrockBatchManager,
+        BedrockBatchNode,
+    )
     from langchain_aws.chains import (
         create_neptune_opencypher_qa_chain,
         create_neptune_sparql_qa_chain,
@@ -81,6 +86,9 @@ except Exception:
 
 __all__ = [
     "__version__",
+    "BatchJob",
+    "BedrockBatchManager",
+    "BedrockBatchNode",
     "BedrockEmbeddings",
     "BedrockLLM",
     "ChatAnthropicBedrock",
@@ -124,11 +132,17 @@ def __getattr__(name: str) -> Any:
             "langchain_aws.chat_models",
             'pip install "langchain-aws[nova-sonic]"',
         ),
+        "BedrockBatchNode": (
+            "langchain_aws.batch",
+            'pip install "langchain-aws[batch]"',
+        ),
     }
 
     # Modules deferred to avoid importing heavyweight transitive deps
     # (e.g. numpy, neptune connector) at package import time
     _deferred_imports: dict[str, str] = {
+        "BatchJob": "langchain_aws.batch",
+        "BedrockBatchManager": "langchain_aws.batch",
         "BedrockEmbeddings": "langchain_aws.embeddings",
         "BedrockRerank": "langchain_aws.document_compressors.rerank",
         "InMemorySemanticCache": "langchain_aws.vectorstores.inmemorydb",

--- a/libs/aws/langchain_aws/batch/__init__.py
+++ b/libs/aws/langchain_aws/batch/__init__.py
@@ -1,0 +1,8 @@
+from langchain_aws.batch.manager import BatchJob, BedrockBatchManager
+from langchain_aws.batch.node import BedrockBatchNode
+
+__all__ = [
+    "BatchJob",
+    "BedrockBatchManager",
+    "BedrockBatchNode",
+]

--- a/libs/aws/langchain_aws/batch/_formatting.py
+++ b/libs/aws/langchain_aws/batch/_formatting.py
@@ -1,0 +1,132 @@
+"""Internal LangChain <-> Bedrock Converse batch-record conversion helpers.
+
+This module keeps the serialization/format logic out of :class:`BedrockBatchManager`
+(see patterns-and-conventions §8). It is intended to reuse the existing Converse
+helpers in ``chat_models/bedrock_converse.py`` (``_messages_to_bedrock`` and
+``_parse_response``) so batch records share the exact request and response shapes
+as synchronous ``ChatBedrockConverse`` calls.
+
+A leading-underscore module name marks this as internal, not public API.
+"""
+
+from __future__ import annotations
+
+import json  # noqa: F401
+import warnings  # noqa: F401
+from typing import Any, Dict, List, Optional, Union
+
+from langchain_core.messages import (  # noqa: F401
+    AIMessage,
+    BaseMessage,
+    convert_to_messages,
+)
+from pydantic import BaseModel
+
+from langchain_aws.chat_models.bedrock_converse import (  # noqa: F401
+    _messages_to_bedrock,
+    _parse_response,
+)
+
+# A single batch input: anything ``convert_to_messages`` accepts under
+# ``"messages"`` plus optional per-record overrides mirroring Converse fields.
+BatchInput = Dict[str, Any]
+
+
+class BatchRecordError(BaseModel):
+    """A per-record error reported in a batch output file.
+
+    Attributes:
+        record_id: The ``recordId`` of the failed input record.
+        error_code: Provider/HTTP error code (e.g. ``400``).
+        error_message: Human-readable error description from Bedrock.
+    """
+
+    record_id: str
+    error_code: Union[int, str]
+    error_message: str
+
+
+def make_record_id(index: int) -> str:
+    """Generate a stable, ordered record ID for the input at ``index``.
+
+    Args:
+        index: Zero-based position of the record in the submitted batch.
+
+    Returns:
+        An 11+ character record ID such as ``"CALL0000001"``.
+    """
+    raise NotImplementedError
+
+
+def build_model_input(
+    batch_input: BatchInput,
+    *,
+    inference_config: Optional[Dict[str, Any]] = None,
+    additional_model_request_fields: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Build a Converse ``modelInput`` body from a single batch input.
+
+    The returned dict matches the Converse request body minus ``modelId`` (which
+    is a job-level parameter for batch inference).
+
+    Args:
+        batch_input: Mapping with a ``"messages"`` key (LangChain message input)
+            and optional ``"system"`` entry.
+        inference_config: Converse ``inferenceConfig`` (e.g. ``maxTokens``).
+        additional_model_request_fields: Provider-specific request fields passed
+            through verbatim.
+
+    Returns:
+        A Converse ``modelInput`` mapping ready to embed in a JSONL record.
+    """
+    raise NotImplementedError
+
+
+def validate_model_input(
+    model_input: Dict[str, Any], *, reject_multi_turn: bool = False
+) -> None:
+    """Reject Converse features that batch inference does not support.
+
+    Performs instant, client-side validation so callers fail fast before any S3
+    upload or job creation (see the issue's pre-flight validation goal).
+
+    Args:
+        model_input: A Converse ``modelInput`` body, as built by
+            :func:`build_model_input`.
+        reject_multi_turn: If ``True``, raise on multi-turn conversations rather
+            than emitting a warning.
+
+    Raises:
+        ValueError: If the input contains tool config or structured-output
+            config, or (when ``reject_multi_turn``) multiple user turns.
+    """
+    raise NotImplementedError
+
+
+def to_jsonl(records: List[Dict[str, Any]]) -> str:
+    """Serialize batch records to a newline-delimited JSON (JSONL) string.
+
+    Args:
+        records: A list of ``{"recordId", "modelInput"}`` mappings.
+
+    Returns:
+        A JSONL string with one record per line.
+    """
+    raise NotImplementedError
+
+
+def parse_output_line(line: str) -> Union[AIMessage, BatchRecordError]:
+    """Parse one line of a Bedrock batch output JSONL file.
+
+    Each line contains either a ``modelOutput`` (Converse response body) or an
+    ``error`` object that replaces it. Successful records are parsed with the
+    same ``_parse_response`` helper used by ``ChatBedrockConverse``.
+
+    Args:
+        line: A single JSONL line from the job's S3 output file.
+
+    Returns:
+        An :class:`~langchain_core.messages.AIMessage` for successful records, or
+        a :class:`BatchRecordError` describing the failure.
+    """
+    raise NotImplementedError

--- a/libs/aws/langchain_aws/batch/manager.py
+++ b/libs/aws/langchain_aws/batch/manager.py
@@ -1,0 +1,249 @@
+"""Native Amazon Bedrock batch inference for the Converse API format.
+
+``BedrockBatchManager`` handles the full batch lifecycle -- submit, monitor,
+retrieve -- while keeping inputs and outputs in LangChain-native types.
+
+It is a plain orchestration class (not a pydantic model) that builds its boto3
+clients in ``__init__`` via ``create_aws_client``, mirroring the style of
+``AmazonS3Vectors``. ``BatchJob`` -- the value object it returns -- stays a
+pydantic model so it serializes cleanly into LangGraph state.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Literal, Optional
+
+from langchain_core.messages import AIMessage
+from pydantic import BaseModel
+
+from langchain_aws.batch._formatting import BatchInput
+from langchain_aws.chat_models import ChatBedrockConverse
+from langchain_aws.utils import create_aws_client  # noqa: F401
+
+# Public, normalized job state. Raw Bedrock statuses (Submitted, InProgress,
+# Completed, Failed, Stopping, Stopped, PartiallyCompleted, Expired,
+# Validating, Scheduled) are collapsed via ``_normalize_status``.
+BatchJobStatus = Literal["SUBMITTED", "IN_PROGRESS", "COMPLETED", "FAILED"]
+
+
+class BatchJob(BaseModel):
+    """A handle to a submitted Bedrock batch inference job.
+
+    Returned by :meth:`BedrockBatchManager.submit` and passed back to the other
+    lifecycle methods to identify the job and locate its outputs.
+
+    Attributes:
+        job_arn: ARN of the ``model-invocation-job``; the canonical identifier.
+        job_name: Human-readable job name.
+        model_id: Bedrock model ID the job runs against.
+        input_s3_uri: S3 URI of the uploaded JSONL input.
+        output_s3_uri: S3 URI prefix where results are written.
+        record_count: Number of records submitted.
+    """
+
+    job_arn: str
+    job_name: str
+    model_id: str
+    input_s3_uri: str
+    output_s3_uri: str
+    record_count: int
+
+
+class BedrockBatchManager:
+    """Submit, monitor, and retrieve Bedrock batch inference jobs.
+
+    Uses the Converse request/response format, so any model supported by
+    ``ChatBedrockConverse`` works without code changes.
+
+    Example:
+        ```python
+        from langchain_aws import ChatBedrockConverse
+        from langchain_aws.batch import BedrockBatchManager
+
+        model = ChatBedrockConverse(model="anthropic.claude-3-5-sonnet-20241022-v2:0")
+        batch = BedrockBatchManager(
+            model=model,
+            input_s3_uri="s3://my-bucket/batch-input/",
+            output_s3_uri="s3://my-bucket/batch-output/",
+            role_arn="arn:aws:iam::123456789012:role/BedrockBatchRole",
+        )
+        job = batch.submit(
+            [{"messages": [("user", f"Classify: {doc}")]} for doc in docs]
+        )
+        results = batch.get_results(job.job_arn)
+        ```
+    """
+
+    def __init__(
+        self,
+        *,
+        model: ChatBedrockConverse,
+        input_s3_uri: str,
+        output_s3_uri: str,
+        role_arn: str,
+        output_kms_key_id: Optional[str] = None,
+        timeout_hours: Optional[int] = None,
+        client: Any = None,
+        s3_client: Any = None,
+    ) -> None:
+        """Build the manager and its boto3 clients.
+
+        The bedrock control-plane and S3 clients are constructed via
+        ``create_aws_client``, reusing the region and credentials already
+        configured on ``model`` so credentials live in one place. Pre-built
+        clients may be injected (e.g. for testing).
+
+        Args:
+            model: Configured ``ChatBedrockConverse`` whose model ID and inference
+                settings drive the batch job.
+            input_s3_uri: S3 URI prefix to upload the generated JSONL input to.
+            output_s3_uri: S3 URI prefix where Bedrock writes the job's outputs.
+            role_arn: IAM service role ARN Bedrock assumes to read inputs / write
+                outputs.
+            output_kms_key_id: Optional KMS key ARN to encrypt outputs. Defaults to
+                AWS-managed keys.
+            timeout_hours: Optional ``timeoutDurationInHours`` for the job.
+            client: Optional pre-built bedrock control-plane client.
+            s3_client: Optional pre-built S3 client.
+        """
+        raise NotImplementedError
+
+    # ------------------------------------------------------------------ #
+    # Public lifecycle API
+    # ------------------------------------------------------------------ #
+    def submit(
+        self,
+        inputs: List[BatchInput],
+        *,
+        job_name: Optional[str] = None,
+        verify_seconds: int = 30,
+        reject_multi_turn: bool = False,
+    ) -> BatchJob:
+        """Validate, upload, create, and verify a batch inference job.
+
+        Catches as many errors as possible before returning, so a misconfigured
+        job surfaces immediately rather than hours later. The sequence is:
+
+        1. **Client-side validation (instant)** -- :meth:`_build_records` runs
+           :func:`~langchain_aws.batch._formatting.validate_model_input` on every
+           record, rejecting tools, structured output, and (optionally) multi-turn
+           before any network call.
+        2. **Upload (S3)** -- :meth:`_upload_jsonl` writes the JSONL input.
+        3. **Job creation (instant)** -- :meth:`_create_job` calls
+           ``CreateModelInvocationJob``; an unsupported model is rejected here.
+        4. **Infrastructure verification (~``verify_seconds``)** --
+           :meth:`_verify_infrastructure` polls once to surface fast failures
+           (KMS/S3 permission errors). The job is only returned if this passes.
+
+        Args:
+            inputs: One mapping per record, each with a ``"messages"`` key.
+            job_name: Optional job name. A timestamped name is generated if omitted.
+            verify_seconds: Seconds to wait before polling once to confirm the job
+                did not fail immediately on infrastructure errors.
+            reject_multi_turn: Raise instead of warn on multi-turn inputs.
+
+        Returns:
+            A :class:`BatchJob` handle for the running job.
+
+        Raises:
+            ValueError: If inputs use unsupported features or the job fails
+                infrastructure verification.
+        """
+        raise NotImplementedError
+
+    def get_status(self, job: BatchJob) -> BatchJobStatus:
+        """Return the live, normalized status of a batch job.
+
+        Args:
+            job: The :class:`BatchJob` returned by :meth:`submit`.
+
+        Returns:
+            One of ``SUBMITTED``, ``IN_PROGRESS``, ``COMPLETED``, ``FAILED``.
+        """
+        raise NotImplementedError
+
+    def get_results(
+        self, job: BatchJob, *, include_errors: bool = False
+    ) -> List[AIMessage]:
+        """Download and parse a completed job's outputs into ``AIMessage`` objects.
+
+        Uses ``job.output_s3_uri`` and ``job.job_arn`` to locate the output files
+        and ``job.record_count`` to validate completeness.
+
+        Args:
+            job: The :class:`BatchJob` returned by :meth:`submit`.
+            include_errors: If ``True``, log a summary of per-record errors.
+
+        Returns:
+            Parsed ``AIMessage`` results, in input order.
+
+        Raises:
+            ValueError: If the job has not completed.
+        """
+        raise NotImplementedError
+
+    def cancel(self, job: BatchJob) -> None:
+        """Request that Bedrock stop a running batch job.
+
+        Args:
+            job: The :class:`BatchJob` returned by :meth:`submit`.
+        """
+        raise NotImplementedError
+
+    # ------------------------------------------------------------------ #
+    # Private helpers
+    # ------------------------------------------------------------------ #
+    def _build_records(
+        self, inputs: List[BatchInput], *, reject_multi_turn: bool
+    ) -> List[Dict[str, Any]]:
+        """Convert LangChain inputs to validated Converse JSONL records."""
+        raise NotImplementedError
+
+    def _resolve_inference_settings(
+        self,
+    ) -> tuple[Optional[Dict[str, Any]], Optional[Dict[str, Any]]]:
+        """Derive Converse ``inferenceConfig`` / additional fields from the model."""
+        raise NotImplementedError
+
+    def _upload_jsonl(self, jsonl: str, *, job_name: str) -> str:
+        """Upload the JSONL body to S3 and return its full URI."""
+        raise NotImplementedError
+
+    def _create_job(self, input_uri: str, *, job_name: str) -> str:
+        """Call ``CreateModelInvocationJob`` and return the job ARN."""
+        raise NotImplementedError
+
+    def _verify_infrastructure(self, job_arn: str, *, seconds: int) -> None:
+        """Wait briefly, then poll once to surface fast infra failures.
+
+        Infrastructure errors (KMS/S3 permissions, bad bucket) fail jobs within
+        seconds, so a short window catches them without a long wait.
+
+        Raises:
+            ValueError: If the job is already ``FAILED``, with the Bedrock-supplied
+                failure message and remediation guidance.
+        """
+        raise NotImplementedError
+
+    def _iter_output_lines(self, job: BatchJob) -> List[str]:
+        """Read all output JSONL lines for a completed job from S3.
+
+        Output files are written under ``{job.output_s3_uri}/{jobId}/`` as
+        ``<input-file>.jsonl.out``.
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def _parse_s3_uri(uri: str) -> tuple[str, str]:
+        """Split an ``s3://bucket/key`` URI into ``(bucket, key)``."""
+        raise NotImplementedError
+
+    @staticmethod
+    def _normalize_status(raw_status: str) -> BatchJobStatus:
+        """Collapse a raw Bedrock job status into the public status set."""
+        raise NotImplementedError
+
+    @staticmethod
+    def _default_job_name() -> str:
+        """Generate a unique, timestamped default job name."""
+        raise NotImplementedError

--- a/libs/aws/langchain_aws/batch/node.py
+++ b/libs/aws/langchain_aws/batch/node.py
@@ -1,0 +1,80 @@
+"""Optional LangGraph node wrapping ``BedrockBatchManager``.
+
+``BedrockBatchNode`` submits a batch job, checkpoints the graph via LangGraph's
+``interrupt``, and resumes when the job completes -- so the host process can shut
+down in between. LangGraph is an optional dependency
+(``pip install "langchain-aws[batch]"``); the import is guarded so the base
+package stays lightweight (see patterns-and-conventions §4).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from langchain_core.messages import AIMessage  # noqa: F401
+
+from langchain_aws.batch._formatting import BatchInput  # noqa: F401
+from langchain_aws.batch.manager import BedrockBatchManager  # noqa: F401
+from langchain_aws.chat_models import ChatBedrockConverse  # noqa: F401
+
+
+class BedrockBatchNode:
+    """A durable LangGraph node that runs Bedrock batch inference.
+
+    The node is callable as a LangGraph node function. On first execution it
+    submits a job and interrupts; on resume it checks status and, once complete,
+    returns parsed results to the graph state.
+
+    !!! warning
+        Requires the ``batch`` extra:
+        ``pip install "langchain-aws[batch]"``.
+    """
+
+    def __init__(
+        self,
+        *,
+        model_id: str,
+        s3_bucket: str,
+        role_arn: str,
+        input_key: str = "batch_inputs",
+        output_key: str = "batch_results",
+        region_name: Optional[str] = None,
+        output_kms_key_id: Optional[str] = None,
+    ) -> None:
+        """Initialize the node.
+
+        Args:
+            model_id: Bedrock model ID to run the batch job against.
+            s3_bucket: Bucket used for both input and output prefixes.
+            role_arn: IAM service role ARN for the batch job.
+            input_key: State key holding the list of batch inputs.
+            output_key: State key to write parsed results to.
+            region_name: AWS region. Falls back to standard resolution.
+            output_kms_key_id: Optional KMS key ARN for output encryption.
+
+        Raises:
+            ImportError: If LangGraph is not installed.
+        """
+        try:
+            import langgraph  # noqa: F401
+        except ImportError as e:
+            msg = (
+                "Cannot import langgraph. Please install it with "
+                '`pip install "langchain-aws[batch]"`.'
+            )
+            raise ImportError(msg) from e
+
+        raise NotImplementedError
+
+    def __call__(self, state: Dict[str, Any]) -> Dict[str, Any]:
+        """Submit (or resume) the batch job as part of graph execution.
+
+        Args:
+            state: The current LangGraph state. Reads inputs from ``input_key``.
+
+        Returns:
+            A partial state update writing parsed results to ``output_key``.
+        """
+        from langgraph.types import interrupt  # noqa: F401
+
+        raise NotImplementedError

--- a/libs/aws/pyproject.toml
+++ b/libs/aws/pyproject.toml
@@ -27,6 +27,7 @@ tools = ["bedrock-agentcore>=1.4.0; python_version>='3.10'", "playwright>=1.53.0
 anthropic = ["langchain-anthropic", "anthropic[bedrock]"]
 valkey = ["valkey-glide-sync>=2.0.0"]
 nova-sonic = ["aws-sdk-bedrock-runtime; python_version>='3.12'"]
+batch = ["langgraph>=1.0.0"]
 
 [dependency-groups]
 test = [

--- a/libs/aws/uv.lock
+++ b/libs/aws/uv.lock
@@ -1072,6 +1072,9 @@ anthropic = [
     { name = "anthropic", extra = ["bedrock"] },
     { name = "langchain-anthropic" },
 ]
+batch = [
+    { name = "langgraph" },
+]
 nova-sonic = [
     { name = "aws-sdk-bedrock-runtime", marker = "python_full_version >= '3.12'" },
 ]
@@ -1129,12 +1132,13 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.42" },
     { name = "langchain-anthropic", marker = "extra == 'anthropic'" },
     { name = "langchain-core", specifier = ">=1.4.7" },
+    { name = "langgraph", marker = "extra == 'batch'", specifier = ">=1.0.0" },
     { name = "numpy", specifier = ">=1.0.0,<3" },
     { name = "playwright", marker = "extra == 'tools'", specifier = ">=1.53.0" },
     { name = "pydantic", specifier = ">=2.10.6,<3" },
     { name = "valkey-glide-sync", marker = "extra == 'valkey'", specifier = ">=2.0.0" },
 ]
-provides-extras = ["tools", "anthropic", "valkey", "nova-sonic"]
+provides-extras = ["tools", "anthropic", "valkey", "nova-sonic", "batch"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

A **design-preview skeleton** for native Amazon Bedrock batch inference using the Converse API format, as proposed in issue #1116 .

This PR sketches the public surface that would close that gap. **Every method body is `raise NotImplementedError`** — the goal is to align on shape, naming, and placement with maintainers *before* implementing.

## What's included

- `langchain_aws/batch/_formatting.py` — internal LangChain ⇄ Converse JSONL conversion + client-side validation, reusing `_messages_to_bedrock` / `_parse_response` from `bedrock_converse.py`.
- `langchain_aws/batch/manager.py` — `BedrockBatchManager` (plain orchestration class) and `BatchJob` (pydantic handle). Lifecycle: `submit` / `get_status` / `get_results` / `cancel`.
- `langchain_aws/batch/node.py` — optional LangGraph `BedrockBatchNode` (submit → checkpoint via `interrupt` → resume → results).
- Public API wiring in `langchain_aws/__init__.py` and a new optional `batch` extra (`langgraph`) in `pyproject.toml` / `uv.lock`.

## Design decisions (seeking feedback)

- **`BedrockBatchManager` is a plain class, not a pydantic model** — it's an imperative orchestrator (not a Runnable), so it mirrors `AmazonS3Vectors`: clients built in `__init__` via `create_aws_client`, with optional client injection for testing.
- **Credentials live in one place** — region/credentials are reused from the passed-in `ChatBedrockConverse` rather than re-declaring the credential block.
- **`BatchJob` stays pydantic and is threaded through** the lifecycle methods (not just returned), so it serializes into LangGraph state and carries the context (`output_s3_uri`, `record_count`) needed to locate/validate results.
- **LangGraph is an optional dependency** — the heavy import is deferred into `BedrockBatchNode`, so `import langchain_aws.batch` stays light and raises a friendly install hint only on construction.
- **Pre-flight validation** is the UX centerpiece: `submit()` fails fast in four stages (client-side validation → S3 upload → `CreateModelInvocationJob` → a brief infra-verification poll) so a misconfigured job surfaces in seconds, not hours.

## Intentionally NOT in this PR

- Method implementations (all `raise NotImplementedError`).
- Tests — will follow the implementation, with VCR cassettes for the AWS shapes per the repo convention.

## Areas that need careful review

- **First plain `s3` client + first S3 object I/O in the package.** Repo-wide there is no existing `"s3"` client or S3 helper (only an `s3vectors` client), so the credential path, `s3://` parsing, and output-file discovery in `_upload_jsonl` / `_iter_output_lines` are net-new surface area.
- **API ergonomics:** lifecycle methods take a `BatchJob` (strict) rather than a raw ARN string — is that the right contract, or should they accept `str | BatchJob`?
- **`langgraph>=1.0.0` lower bound** for the `batch` extra.
- **`submit()` blocking for `verify_seconds`** (default 30s) — acceptable, or should verification be opt-in / async?

## Additional food for thought

Likely out of scope due to the potential requirement of external infrastructure:

- Suppose a user submits a massive job that will take 20+ hours to completely process. In a remote LangGraph environment, the node doesn't necessarily have to be awake this whole time but will require some external mechanism to wake up that node. Perhaps that external integration could be an EventBride rule + HTTPS endpoint as a target (assuming the node is exposed as a Lambda / ECS / EC2 / etc endpoint)? These endpoints will surely require an API Key, OAuth, or some form of auth to secure it. 

That being said, in general does this direction align with the roadmap? Happy to iterate on the design here before filling in the implementation.