### PR TITLE
test(aws): clarify `xfail` reasons for Bedrock mixed `text`+`tool_use` turn

### DIFF
--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
@@ -70,7 +70,19 @@ class TestBedrockMistralStandard(ChatModelIntegrationTests):
     def has_tool_choice(self) -> bool:
         return False
 
-    @pytest.mark.xfail(reason="Human messages following AI messages not supported.")
+    # This standard test feeds back an AIMessage whose content mixes a text
+    # block and a `tool_use` block in a single assistant turn. Mistral models on
+    # Bedrock reject that turn shape with
+    # `ValidationException: messages.1.content: Conversation blocks and tool use
+    # blocks cannot be provided in the same turn` (Anthropic models accept it, so
+    # the conversion in `_messages_to_bedrock` is correct and must not change).
+    @pytest.mark.xfail(
+        reason=(
+            "Mistral on Bedrock rejects an assistant turn that mixes text and "
+            "tool_use blocks: 'Conversation blocks and tool use blocks cannot be "
+            "provided in the same turn'."
+        )
+    )
     def test_tool_message_histories_list_content(
         self, model: BaseChatModel, my_adder_tool: BaseTool
     ) -> None:
@@ -195,8 +207,16 @@ class TestBedrockMetaStandard(ChatModelIntegrationTests):
     def test_tool_calling_with_no_arguments(self, model: BaseChatModel) -> None:
         pass
 
+    # See `TestBedrockMistralStandard` above: the synthetic history mixes a text
+    # block and a tool_use block in one assistant turn, which Meta models on Bedrock
+    # reject with 'Conversation blocks and tool use blocks cannot be provided in the
+    # same turn' (Anthropic models accept it).
     @pytest.mark.xfail(
-        reason="Human messages following AI messages not supported by Bedrock."
+        reason=(
+            "Meta on Bedrock rejects an assistant turn that mixes text and "
+            "tool_use blocks: 'Conversation blocks and tool use blocks cannot be "
+            "provided in the same turn'."
+        )
     )
     def test_tool_message_histories_list_content(
         self, model: BaseChatModel, my_adder_tool: BaseTool


### PR DESCRIPTION
The `ChatBedrockConverse` standard test classes for **Mistral Large** (`mistral.mistral-large-2402-v1:0`) and **Llama 3.2 90B** (`us.meta.llama3-2-90b-instruct-v1:0`) already `xfail` `test_tool_message_histories_list_content`, but with the misleading reason *"Human messages following AI messages not supported."*

LangSmith traces of the recurring scheduled-test failures show the actual Bedrock error is:

```
ValidationException: messages.1.content: Conversation blocks and tool use blocks cannot be provided in the same turn
```

`messages[1]` is the assistant turn — the standard test feeds back a synthetic `AIMessage` whose content mixes a `text` block and a `tool_use` block in a single turn. Mistral and Meta models on Bedrock reject that shape; **Anthropic models accept it**, which is why `_messages_to_bedrock` emits a single mixed-content assistant message and why that behavior is correct and unchanged here.

## Why this is the right change

This is a model/provider capability limitation, not a library defect. A naive "fix" (splitting text and `tool_use` into two consecutive assistant messages) would break Anthropic models and would itself violate Bedrock role-alternation. So the correct action is to keep the `xfail` and make its recorded reason accurate.

## Changes

- Correct the `xfail` reason on `test_tool_message_histories_list_content` for the Mistral Large and Llama 3.2 90B test classes to cite the real `ValidationException`.
- Add comments documenting the root cause (mixed text + `tool_use` in one assistant turn) and noting that Anthropic models accept it.
