### PR TITLE
test(aws): update Bedrock Meta standard model

### DIFF
--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
@@ -160,7 +160,7 @@ class TestBedrockMetaStandard(ChatModelIntegrationTests):
 
     @property
     def chat_model_params(self) -> dict:
-        return {"model": "us.meta.llama3-2-90b-instruct-v1:0"}
+        return {"model": "us.meta.llama4-maverick-17b-instruct-v1:0"}
 
     @property
     def standard_chat_model_params(self) -> dict:


### PR DESCRIPTION
The Meta standard Bedrock Converse integration currently uses Llama 3.2 90B, which can produce misleading traces for tool-result agent loops even when the adapter payload is valid. This updates the standard Meta model to Llama 4 Maverick, a newer Bedrock Meta model already covered in local tool-choice unit tests.

This keeps the standard integration focused on LangChain adapter compatibility rather than surfacing known model-quality noise from an older Llama 3.2 model.

Careful review: this only changes the model used by `TestBedrockMetaStandard`; it does not change request serialization or test assertions.

Tests:
- `uv run ruff check libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py`
- `python -m py_compile libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py`
- `uv run pytest -q libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py::test_llama_bind_tools_tool_choice_variants`

AI assistance disclosure: I used an AI coding assistant to inspect the existing tests, compare local model coverage, and make this one-line update.