### PR TITLE
test(aws): restore stable Bedrock Meta standard model

### DIFF
--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
@@ -160,7 +160,7 @@ class TestBedrockMetaStandard(ChatModelIntegrationTests):
 
     @property
     def chat_model_params(self) -> dict:
-        return {"model": "us.meta.llama4-maverick-17b-instruct-v1:0"}
+        return {"model": "us.meta.llama3-2-90b-instruct-v1:0"}
 
     @property
     def standard_chat_model_params(self) -> dict:


### PR DESCRIPTION
Bedrock Meta standard integration tests need a model that exercises the adapter behavior without introducing model-quality noise. Llama 4 Maverick consistently emits duplicate weather tool calls for the inherited agent-loop test, while Llama 3.2 90B returns one tool call and completes the full loop.

## Changes
- Restore `TestBedrockMetaStandard` to `us.meta.llama3-2-90b-instruct-v1:0`, which passes the standard chat-model agent-loop contract without requiring an xfail.
- Keep the test focused on LangChain adapter compatibility rather than duplicate tool-call behavior from Llama 4 Maverick.

## Testing
- `uv --directory libs/aws run pytest -q tests/integration_tests/chat_models/test_bedrock_converse.py::TestBedrockMetaStandard::test_agent_loop -vv -s`
- `uv --directory libs/aws run pytest -q tests/integration_tests/chat_models/test_bedrock_converse.py::TestBedrockMetaStandard -vv -s`
- `uv --directory libs/aws run ruff check tests/integration_tests/chat_models/test_bedrock_converse.py`
- `python -m py_compile libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py`

Careful review: this reverts the Meta standard model choice from #1125 after smoke testing showed Llama 4 Maverick is not stable for this inherited assertion.

AI assistance disclosure: I used an AI coding assistant to inspect the failing CI job, run Bedrock smoke tests across Meta model candidates, and prepare this change.