### PR TITLE
fix(agentcore-codeinterpreter): Override additional BaseSandbox async helpers

### DIFF
--- a/libs/agentcore-codeinterpreter/langchain_agentcore_codeinterpreter/sandbox.py
+++ b/libs/agentcore-codeinterpreter/langchain_agentcore_codeinterpreter/sandbox.py
@@ -667,3 +667,63 @@ class AgentCoreSandbox(BaseSandbox):
             _AGENTCORE_EXECUTOR,
             lambda: self.download_files(paths),
         )
+
+    async def als(self, path: str) -> LsResult:
+        """Async version of :meth:`ls`.
+
+        Args:
+            path: Directory path to list, resolved against the sandbox cwd.
+
+        Returns:
+            ``LsResult`` with directory entries on success or ``error`` on
+            failure.
+        """
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            _AGENTCORE_EXECUTOR,
+            lambda: self.ls(path),
+        )
+
+    async def agrep(
+        self,
+        pattern: str,
+        path: str | None = None,
+        glob: str | None = None,
+    ) -> GrepResult:
+        """Async version of :meth:`grep`.
+
+        Args:
+            pattern: Literal string to search for.
+            path: Directory or file to search in, resolved against the sandbox
+                cwd. When ``None``, the ``BaseSandbox`` default is used.
+            glob: Optional file-name glob to restrict the search.
+
+        Returns:
+            ``GrepResult`` with a list of matches or ``error`` on failure.
+        """
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            _AGENTCORE_EXECUTOR,
+            lambda: self.grep(pattern, path, glob),
+        )
+
+    async def aglob(
+        self,
+        pattern: str,
+        path: str | None = None,
+    ) -> GlobResult:
+        """Async version of :meth:`glob`.
+
+        Args:
+            pattern: Glob pattern to match.
+            path: Directory to search in, resolved against the sandbox cwd.
+                When ``None``, the ``BaseSandbox`` default is used.
+
+        Returns:
+            ``GlobResult`` with a list of matches or ``error`` on failure.
+        """
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            _AGENTCORE_EXECUTOR,
+            lambda: self.glob(pattern, path),
+        )

--- a/libs/agentcore-codeinterpreter/tests/unit_tests/test_sandbox.py
+++ b/libs/agentcore-codeinterpreter/tests/unit_tests/test_sandbox.py
@@ -925,6 +925,37 @@ def test_aexecute_handles_session_expiry() -> None:
     assert "expired" in result.output.lower()
 
 
+def test_als_routes_through_cwd_aware_sync_ls() -> None:
+    """als() must resolve the virtual path against the cwd."""
+    sandbox, _ = _make_sandbox(cwd="/opt/sandbox")
+
+    with patch.object(BaseSandbox, "ls", return_value=LsResult(entries=[])) as mock_ls:
+        asyncio.run(sandbox.als("/workspace"))
+        mock_ls.assert_called_once_with("/opt/sandbox/workspace")
+
+
+def test_agrep_routes_through_cwd_aware_sync_grep() -> None:
+    """agrep() must resolve the virtual path against the cwd (not literal)."""
+    sandbox, _ = _make_sandbox(cwd="/opt/sandbox")
+
+    with patch.object(
+        BaseSandbox, "grep", return_value=GrepResult(matches=[])
+    ) as mock_grep:
+        asyncio.run(sandbox.agrep("needle", "/workspace"))
+        mock_grep.assert_called_once_with("needle", "/opt/sandbox/workspace", None)
+
+
+def test_aglob_routes_through_cwd_aware_sync_glob() -> None:
+    """aglob() must resolve the virtual path against the cwd (not literal)."""
+    sandbox, _ = _make_sandbox(cwd="/opt/sandbox")
+
+    with patch.object(
+        BaseSandbox, "glob", return_value=GlobResult(matches=[])
+    ) as mock_glob:
+        asyncio.run(sandbox.aglob("*.py", "/workspace"))
+        mock_glob.assert_called_once_with("*.py", "/opt/sandbox/workspace")
+
+
 # ------------------------------------------------------------------
 # Executor configuration
 # ------------------------------------------------------------------


### PR DESCRIPTION
See: https://github.com/langchain-ai/langchain-aws/pull/1122#issuecomment-4776203737

Resolves compatibility issues related to [this change](https://github.com/langchain-ai/deepagents/pull/3996) in `deepagents==0.6.11`, which added native async `als`/`agrep`/`aglob` to `BaseSandbox`, bypassing our existing cwd-aware overrides in `AgentCoreSandbox`.

Fixing this by adding explicit`AgentCoreSandbox` `als`/`agrep`/`aglob` overrides to restore the original custom functionality. 