### PR TITLE
fix: use namespacePath for AgentCore memory search

### DIFF
--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/store/agentcore/store.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/store/agentcore/store.py
@@ -183,7 +183,7 @@ class AgentCoreMemoryStore(BaseStore):
 
         response = self.client.retrieve_memory_records(
             memoryId=self.memory_id,
-            namespace=namespace_str,
+            namespacePath=namespace_str,
             searchCriteria=search_criteria,
             maxResults=op.limit,
         )

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_store.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_store.py
@@ -263,7 +263,7 @@ class TestAgentCoreMemoryStore:
 
         mock_boto_client.retrieve_memory_records.assert_called_once_with(
             memoryId="test-memory-id",
-            namespace="/test_actor",
+            namespacePath="/test_actor",
             searchCriteria={"searchQuery": "test query", "topK": 5},
             maxResults=5,
         )
@@ -463,7 +463,8 @@ class TestAgentCoreMemoryStore:
         store.batch(ops)
 
         call_args = mock_boto_client.retrieve_memory_records.call_args[1]
-        assert call_args["namespace"] == "/single_actor"
+        assert call_args["namespacePath"] == "/single_actor"
+        assert "namespace" not in call_args
 
     def test_search_with_pagination_parameters(
         self, store, mock_boto_client, sample_memory_record


### PR DESCRIPTION
Fixes #1128

## Summary
- pass `namespacePath` to `retrieve_memory_records` in `AgentCoreMemoryStore._handle_search`
- update AgentCore store tests to assert the corrected request parameter
- add a regression assertion that the old `namespace` argument is not sent

## Testing
- `git diff --check`
- `python .github/scripts/check_diff.py 'libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/store/agentcore/store.py libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_store.py'`\n- `UV_HTTP_TIMEOUT=120 make lint_package`\n- `UV_HTTP_TIMEOUT=120 make lint_tests`\n- `UV_HTTP_TIMEOUT=120 make test`\n- `UV_HTTP_TIMEOUT=120 uv run pytest -m compile tests/integration_tests`\n- `AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=*** DYNAMODB_ENDPOINT=http://127.0.0.1:8000 UV_HTTP_TIMEOUT=120 uv run --group test pytest tests/integration_tests/checkpoint/dynamodb/test_conformance.py -xvs`