### PR TITLE
fix(aws): Omit per-tool-call suffix from AgentCore code interpreter tool checkpoint_ns

### DIFF
--- a/libs/aws/langchain_aws/tools/code_interpreter_toolkit.py
+++ b/libs/aws/langchain_aws/tools/code_interpreter_toolkit.py
@@ -754,7 +754,7 @@ async def create_code_interpreter_toolkit(
 
 def _get_thread_id(config: Optional[RunnableConfig] = None) -> str:
     """Extract session key, using checkpoint_ns for subagent isolation."""
-    return get_session_key(config)
+    return get_session_key(config, checkpoint_ns_scope="parent")
 
 
 def _extract_output_from_stream(response: Any) -> str:

--- a/libs/aws/langchain_aws/tools/utils.py
+++ b/libs/aws/langchain_aws/tools/utils.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Literal, Optional
 
 from langchain_core.runnables.config import RunnableConfig
 
@@ -11,6 +11,9 @@ if TYPE_CHECKING:
     from playwright.async_api import Page as AsyncPage
     from playwright.sync_api import Browser as SyncBrowser
     from playwright.sync_api import Page as SyncPage
+
+
+_CHECKPOINT_NS_SEP = "|"
 
 
 async def aget_current_page(browser: AsyncBrowser) -> AsyncPage:
@@ -54,21 +57,31 @@ def get_current_page(browser: SyncBrowser) -> SyncPage:
     return context.pages[-1]
 
 
-def get_session_key(config: Optional[RunnableConfig] = None) -> str:
+def get_session_key(
+    config: Optional[RunnableConfig] = None,
+    *,
+    checkpoint_ns_scope: Literal["full", "parent"] = "full",
+) -> str:
     """Build a session key from RunnableConfig.
 
-    Uses thread_id as the base key and appends checkpoint_ns
-    when present.  This ensures parallel LangGraph subgraphs get
-    separate sessions even when they share a thread_id.
+    ``checkpoint_ns_scope`` controls how much of ``checkpoint_ns`` is used:
+    - ``"full"`` (default): append the entire ``checkpoint_ns``, so every tool
+      call gets its own session.
+    - ``"parent"``: drop the innermost (per-tool-call) ``checkpoint_ns`` segment
+      and append only the enclosing scope.
 
     Examples::
 
-        Top-level agent:   "thread-001"
-        Subagent A:        "thread-001:research-acme:abc123"
-        Subagent B:        "thread-001:research-beta:def456"
+        Top-level agent (ns "tools:abc"):
+            full   -> "thread-001:tools:abc"
+            parent -> "thread-001"
+        Subagent (ns "sub-a:1|tools:xyz"):
+            full   -> "thread-001:sub-a:1|tools:xyz"
+            parent -> "thread-001:sub-a:1"
 
     Args:
         config: LangGraph ``RunnableConfig`` passed to tool invocations.
+        checkpoint_ns_scope: How much of ``checkpoint_ns`` to include in the key.
 
     Returns:
         String key for indexing session dictionaries.
@@ -79,6 +92,13 @@ def get_session_key(config: Optional[RunnableConfig] = None) -> str:
     configurable = config.get("configurable", {})
     thread_id = configurable.get("thread_id", "default")
     checkpoint_ns = configurable.get("checkpoint_ns", "")
+
+    if checkpoint_ns_scope == "parent":
+        checkpoint_ns = (
+            checkpoint_ns.rsplit(_CHECKPOINT_NS_SEP, 1)[0]
+            if _CHECKPOINT_NS_SEP in checkpoint_ns
+            else ""
+        )
 
     if checkpoint_ns:
         return f"{thread_id}:{checkpoint_ns}"

--- a/libs/aws/tests/integration_tests/tools/test_code_interpreter_toolkit.py
+++ b/libs/aws/tests/integration_tests/tools/test_code_interpreter_toolkit.py
@@ -1,0 +1,152 @@
+import concurrent.futures
+import os
+import uuid
+
+import pytest
+from langchain_core.runnables.config import RunnableConfig
+
+from langchain_aws.tools.code_interpreter_toolkit import (
+    CodeInterpreterToolkit,
+    _extract_output_from_stream,
+)
+
+REGION = os.environ.get("CODE_INTERPRETER_INTEG_REGION", "us-west-2")
+
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("AWS_DEFAULT_REGION")
+    and not os.environ.get("AWS_REGION")
+    and not os.environ.get("CODE_INTERPRETER_INTEG_REGION"),
+    reason="AWS credentials/region not configured",
+)
+
+
+def _run_code(
+    toolkit: CodeInterpreterToolkit, config: RunnableConfig, code: str
+) -> str:
+    interpreter = toolkit._get_or_create_interpreter(config)
+    response = interpreter.invoke(
+        method="executeCode", params={"language": "python", "code": code}
+    )
+    return _extract_output_from_stream(response)
+
+
+def test_session_persists_across_checkpoint_namespaces() -> None:
+    """Session state persists across differing checkpoint_ns in one thread."""
+    toolkit = CodeInterpreterToolkit(region=REGION)
+    thread_id = "integ-thread-1057"
+    ns_write = f"tools:{uuid.uuid4()}"
+    ns_read = f"tools:{uuid.uuid4()}"
+
+    try:
+        _run_code(
+            toolkit,
+            RunnableConfig(
+                configurable={"thread_id": thread_id, "checkpoint_ns": ns_write}
+            ),
+            "open('/tmp/persist_1057.txt', 'w').write('Hello World')",
+        )
+        output = _run_code(
+            toolkit,
+            RunnableConfig(
+                configurable={"thread_id": thread_id, "checkpoint_ns": ns_read}
+            ),
+            "print(open('/tmp/persist_1057.txt').read())",
+        )
+
+        assert list(toolkit._code_interpreters) == [thread_id]
+        assert "Hello World" in output
+    finally:
+        for interpreter in toolkit._code_interpreters.values():
+            try:
+                interpreter.stop()
+            except Exception:
+                pass
+
+
+def test_distinct_threads_get_distinct_sessions() -> None:
+    """Different ``thread_id`` values must not share a code interpreter session."""
+    toolkit = CodeInterpreterToolkit(region=REGION)
+
+    try:
+        _run_code(
+            toolkit,
+            RunnableConfig(configurable={"thread_id": "integ-thread-a"}),
+            "open('/tmp/thread_scope.txt', 'w').write('from-a')",
+        )
+        output = _run_code(
+            toolkit,
+            RunnableConfig(configurable={"thread_id": "integ-thread-b"}),
+            "import os; print(os.path.exists('/tmp/thread_scope.txt'))",
+        )
+
+        assert set(toolkit._code_interpreters) == {"integ-thread-a", "integ-thread-b"}
+        assert "False" in output
+    finally:
+        for interpreter in toolkit._code_interpreters.values():
+            try:
+                interpreter.stop()
+            except Exception:
+                pass
+
+
+def test_isolates_sessions_per_subagent() -> None:
+    """Parallel subagents (nested checkpoint_ns) get isolated sessions."""
+    toolkit = CodeInterpreterToolkit(region=REGION)
+    thread_id = "integ-thread-subagents"
+    sub_a = f"research-a:{uuid.uuid4()}|tools:{uuid.uuid4()}"
+    sub_b = f"research-b:{uuid.uuid4()}|tools:{uuid.uuid4()}"
+
+    try:
+        _run_code(
+            toolkit,
+            RunnableConfig(
+                configurable={"thread_id": thread_id, "checkpoint_ns": sub_a}
+            ),
+            "open('/tmp/subagent_scope.txt', 'w').write('from-a')",
+        )
+        output = _run_code(
+            toolkit,
+            RunnableConfig(
+                configurable={"thread_id": thread_id, "checkpoint_ns": sub_b}
+            ),
+            "import os; print(os.path.exists('/tmp/subagent_scope.txt'))",
+        )
+
+        assert len(toolkit._code_interpreters) == 2
+        assert "False" in output
+    finally:
+        for interpreter in toolkit._code_interpreters.values():
+            try:
+                interpreter.stop()
+            except Exception:
+                pass
+
+
+def test_concurrent_tool_calls_share_one_session() -> None:
+    """Concurrent tool calls in one thread reuse a single session safely."""
+    toolkit = CodeInterpreterToolkit(region=REGION)
+    thread_id = "integ-thread-concurrent"
+
+    def _call(i: int) -> str:
+        config = RunnableConfig(
+            configurable={
+                "thread_id": thread_id,
+                "checkpoint_ns": f"tools:{uuid.uuid4()}",
+            }
+        )
+        return _run_code(toolkit, config, f"print({i} * {i})")
+
+    try:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
+            results = list(executor.map(_call, range(5)))
+
+        assert list(toolkit._code_interpreters) == [thread_id]
+        for i, output in enumerate(results):
+            assert str(i * i) in output
+    finally:
+        for interpreter in toolkit._code_interpreters.values():
+            try:
+                interpreter.stop()
+            except Exception:
+                pass

--- a/libs/aws/tests/unit_tests/tools/test_browser_toolkit.py
+++ b/libs/aws/tests/unit_tests/tools/test_browser_toolkit.py
@@ -825,6 +825,40 @@ class TestGetSessionKey:
         config: RunnableConfig = cast(RunnableConfig, {"configurable": {}})
         assert get_session_key(config) == "default"
 
+    def test_parent_scope_drops_innermost_checkpoint_ns_segment(self) -> None:
+        """``parent`` scope drops the per-call segment, keeps enclosing scope."""
+        from langchain_aws.tools.utils import get_session_key
+
+        top_level: RunnableConfig = cast(
+            RunnableConfig,
+            {"configurable": {"thread_id": "thread-1", "checkpoint_ns": "tools:abc"}},
+        )
+        assert get_session_key(top_level, checkpoint_ns_scope="parent") == "thread-1"
+
+        # Nested ns (tool call inside a subagent) -> keeps the subagent segment.
+        nested: RunnableConfig = cast(
+            RunnableConfig,
+            {
+                "configurable": {
+                    "thread_id": "thread-1",
+                    "checkpoint_ns": "subagent-a:abc123|tools:xyz",
+                }
+            },
+        )
+        assert (
+            get_session_key(nested, checkpoint_ns_scope="parent")
+            == "thread-1:subagent-a:abc123"
+        )
+
+    def test_parent_scope_with_no_checkpoint_ns(self) -> None:
+        """``parent`` scope returns thread_id when there is no checkpoint_ns."""
+        from langchain_aws.tools.utils import get_session_key
+
+        config: RunnableConfig = cast(
+            RunnableConfig, {"configurable": {"thread_id": "thread-1"}}
+        )
+        assert get_session_key(config, checkpoint_ns_scope="parent") == "thread-1"
+
     def test_returns_default_when_no_configurable(self) -> None:
         """Test returns 'default' when config has no configurable key."""
         from langchain_aws.tools.utils import get_session_key

--- a/libs/aws/tests/unit_tests/tools/test_code_interpreter_toolkit.py
+++ b/libs/aws/tests/unit_tests/tools/test_code_interpreter_toolkit.py
@@ -390,8 +390,8 @@ class TestGetOrCreateInterpreter:
             assert interpreter is mock_interpreter
             assert "default" in toolkit._code_interpreters
 
-    def test_uses_checkpoint_ns_for_session_key(self) -> None:
-        """Test session key includes checkpoint_ns for subagent isolation."""
+    def test_drops_per_tool_checkpoint_ns_for_session_key(self) -> None:
+        """Top-level per-tool checkpoint_ns is dropped so state persists."""
         from langchain_aws.tools.code_interpreter_toolkit import CodeInterpreterToolkit
 
         toolkit = CodeInterpreterToolkit()
@@ -409,13 +409,84 @@ class TestGetOrCreateInterpreter:
                 {
                     "configurable": {
                         "thread_id": "thread-1",
-                        "checkpoint_ns": "research-acme:abc123",
+                        # Per-tool-call namespace LangGraph injects at top level.
+                        "checkpoint_ns": "tools:abc123",
                     }
                 },
             )
             toolkit._get_or_create_interpreter(config)
 
-            assert "thread-1:research-acme:abc123" in toolkit._code_interpreters
+            assert "thread-1" in toolkit._code_interpreters
+            assert "thread-1:tools:abc123" not in toolkit._code_interpreters
+
+    def test_reuses_interpreter_across_per_tool_namespaces(self) -> None:
+        """Sequential tool calls in one thread share one session."""
+        from langchain_aws.tools.code_interpreter_toolkit import CodeInterpreterToolkit
+
+        toolkit = CodeInterpreterToolkit()
+
+        with patch(
+            "langchain_aws.tools.code_interpreter_toolkit.CodeInterpreter"
+        ) as mock_class:
+            mock_class.side_effect = lambda *a, **k: MagicMock(
+                start=MagicMock(), session_id="s"
+            )
+
+            first: RunnableConfig = cast(
+                RunnableConfig,
+                {"configurable": {"thread_id": "thread-1", "checkpoint_ns": "tools:1"}},
+            )
+            second: RunnableConfig = cast(
+                RunnableConfig,
+                {"configurable": {"thread_id": "thread-1", "checkpoint_ns": "tools:2"}},
+            )
+
+            interp_first = toolkit._get_or_create_interpreter(first)
+            interp_second = toolkit._get_or_create_interpreter(second)
+
+            assert interp_first is interp_second
+            assert list(toolkit._code_interpreters) == ["thread-1"]
+
+    def test_isolates_sessions_per_subagent(self) -> None:
+        """Parallel subagents (nested checkpoint_ns) keep isolated sessions."""
+        from langchain_aws.tools.code_interpreter_toolkit import CodeInterpreterToolkit
+
+        toolkit = CodeInterpreterToolkit()
+
+        with patch(
+            "langchain_aws.tools.code_interpreter_toolkit.CodeInterpreter"
+        ) as mock_class:
+            mock_class.side_effect = lambda *a, **k: MagicMock(
+                start=MagicMock(), session_id="s"
+            )
+
+            sub_a: RunnableConfig = cast(
+                RunnableConfig,
+                {
+                    "configurable": {
+                        "thread_id": "thread-1",
+                        "checkpoint_ns": "research-acme:abc|tools:call1",
+                    }
+                },
+            )
+            sub_b: RunnableConfig = cast(
+                RunnableConfig,
+                {
+                    "configurable": {
+                        "thread_id": "thread-1",
+                        "checkpoint_ns": "research-beta:def|tools:call2",
+                    }
+                },
+            )
+
+            interp_a = toolkit._get_or_create_interpreter(sub_a)
+            interp_b = toolkit._get_or_create_interpreter(sub_b)
+
+            assert interp_a is not interp_b
+            assert set(toolkit._code_interpreters) == {
+                "thread-1:research-acme:abc",
+                "thread-1:research-beta:def",
+            }
 
 
 class TestGetThreadId:
@@ -449,8 +520,8 @@ class TestGetThreadId:
 
         assert thread_id == "default"
 
-    def test_includes_checkpoint_ns(self) -> None:
-        """Test includes checkpoint_ns in session key."""
+    def test_drops_per_tool_checkpoint_ns(self) -> None:
+        """Drops the per-tool-call checkpoint_ns segment."""
         from langchain_aws.tools.code_interpreter_toolkit import _get_thread_id
 
         config: RunnableConfig = cast(
@@ -458,13 +529,28 @@ class TestGetThreadId:
             {
                 "configurable": {
                     "thread_id": "thread-1",
-                    "checkpoint_ns": "subagent:xyz",
+                    "checkpoint_ns": "tools:xyz",
                 }
             },
         )
-        thread_id = _get_thread_id(config)
 
-        assert thread_id == "thread-1:subagent:xyz"
+        assert _get_thread_id(config) == "thread-1"
+
+    def test_preserves_subagent_checkpoint_ns(self) -> None:
+        """Keeps the enclosing subagent segment of a nested checkpoint_ns."""
+        from langchain_aws.tools.code_interpreter_toolkit import _get_thread_id
+
+        config: RunnableConfig = cast(
+            RunnableConfig,
+            {
+                "configurable": {
+                    "thread_id": "thread-1",
+                    "checkpoint_ns": "subagent:xyz|tools:call",
+                }
+            },
+        )
+
+        assert _get_thread_id(config) == "thread-1:subagent:xyz"
 
 
 class TestExtractOutputFromStream:


### PR DESCRIPTION
Fixes #1057 

Code interpreter sessions were keyed by the full `checkpoint_ns`, but LangGraph injects a distinct per-tool-call `checkpoint_ns` for every tool invocation. As a result, sequential tool calls in the same thread landed in separate session and lost state.

This PR drops the outmermost `tools:tool_id` `checkpoint_ns` segment when building the code interpreter session key, so that we can guarantee sequential tool calls in a thread will share the same session. Browser tools' `checkpoint_ns` will remain unchanged.