### PR TITLE
fix(langgraph-checkpoint-aws): use `namespacePath` in `_handle_search` for hierarchical memory retrieval

### DIFF
--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/store/agentcore/store.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/store/agentcore/store.py
@@ -183,7 +183,7 @@ class AgentCoreMemoryStore(BaseStore):
 
         response = self.client.retrieve_memory_records(
             memoryId=self.memory_id,
-            namespace=namespace_str,
+            namespacePath=namespace_str,
             searchCriteria=search_criteria,
             maxResults=op.limit,
         )

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_store.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_store.py
@@ -263,7 +263,7 @@ class TestAgentCoreMemoryStore:
 
         mock_boto_client.retrieve_memory_records.assert_called_once_with(
             memoryId="test-memory-id",
-            namespace="/test_actor",
+            namespacePath="/test_actor",
             searchCriteria={"searchQuery": "test query", "topK": 5},
             maxResults=5,
         )
@@ -463,7 +463,7 @@ class TestAgentCoreMemoryStore:
         store.batch(ops)
 
         call_args = mock_boto_client.retrieve_memory_records.call_args[1]
-        assert call_args["namespace"] == "/single_actor"
+        assert call_args["namespacePath"] == "/single_actor"
 
     def test_search_with_pagination_parameters(
         self, store, mock_boto_client, sample_memory_record


### PR DESCRIPTION
Closes #1128

---

`AgentCoreMemoryStore._handle_search` called `retrieve_memory_records` with the `namespace` parameter, which performs only exact-match lookups. Actor-scoped prefix searches (e.g. `/actor/{actorId}/`) returned an empty `memoryRecordSummaries` list because no record was filed under that exact path.

The correct parameter is `namespacePath`, which the AgentCore API uses for hierarchical ranking — matching all memory records whose namespace falls under the given prefix. This aligns with how the Bedrock AgentCore SDK itself uses the parameter (see [reference](https://github.com/aws/bedrock-agentcore-sdk-python/blob/56b215dfcb398929e283bc0284f41aafab4fdf49/src/bedrock_agentcore/memory/client.py#L352-L372)).

**Change**: one-line swap of `namespace=` → `namespacePath=` in `_handle_search`, with the matching test assertions updated accordingly. No behavioral change for exact-match namespaces; actor-prefix searches now return results as documented.

This contribution was made with AI-agent assistance.