### PR TITLE
fix(langgraph-checkpoint-aws): put→get round-trip for AgentCoreMemoryStore (#708)

### DIFF
--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/store/agentcore/store.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/store/agentcore/store.py
@@ -146,16 +146,61 @@ class AgentCoreMemoryStore(BaseStore):
         logger.debug(f"Created event for message in namespace {op.namespace}")
 
     def _handle_get(self, op: GetOp) -> Result:
-        """Handle GetOp by retrieving a stored event from AgentCore Memory.
+        """Handle GetOp by retrieving a stored event from AgentCore Memory."""
+        actor_id, session_id = self._unpack_namespace(op.namespace)
 
-        Uses list_events with an eventMetadata EQUALS_TO filter on the
-        user-provided key (stored via STORE_KEY_METADATA on put).
-        """
-        # TODO: validate namespace via _unpack_namespace
-        # TODO: call list_events with metadata filter on STORE_KEY_METADATA
-        # TODO: select most recent event (last-write-wins) via _parse_timestamp
-        # TODO: convert to Item via _convert_event_to_item
-        raise NotImplementedError
+        try:
+            response = self.client.list_events(
+                memoryId=self.memory_id,
+                actorId=actor_id,
+                sessionId=session_id,
+                includePayloads=True,
+                maxResults=100,
+                filter={
+                    "eventMetadata": [
+                        {
+                            "left": {"metadataKey": STORE_KEY_METADATA},
+                            "operator": "EQUALS_TO",
+                            "right": {"metadataValue": {"stringValue": op.key}},
+                        }
+                    ]
+                },
+            )
+
+            events = response.get("events", [])
+            if not events:
+                return None
+
+            # ListEvents does not guarantee ordering and put is append-only, so a
+            # re-put of the same key yields multiple matching events. Return the most
+            # recent (last-write-wins) by eventTimestamp.
+            latest_event = max(
+                events,
+                key=lambda event: (
+                    event.get("eventTimestamp")
+                    # Fallback for events missing a timestamp: an oldest-possible,
+                    # UTC-aware value so they never win and comparisons stay typed.
+                    or datetime.min.replace(tzinfo=timezone.utc)
+                ),
+            )
+            return self._convert_event_to_item(latest_event, op.namespace, op.key)
+
+        except ClientError as e:
+            error_code = e.response["Error"]["Code"]
+            if error_code == "ResourceNotFoundException":
+                # Memory resource, actor, or session not found — treat as absent key
+                logger.error(
+                    f"Failed to get event: {e} - "
+                    f"memory_id={self.memory_id}, actor_id={actor_id}, session_id={session_id}"
+                )
+                return None
+            else:
+                # Re-raise other client errors
+                logger.error(f"Failed to get event: {e}")
+                raise
+        except Exception as e:
+            logger.error(f"Failed to get event: {e}")
+            raise
 
     def _handle_search(self, op: SearchOp) -> Result:
         """Handle SearchOp by retrieving memory records from AgentCore Memory."""
@@ -265,38 +310,7 @@ class AgentCoreMemoryStore(BaseStore):
             return "/"
         return "/" + "/".join(namespace_tuple)
 
-    def _convert_memory_record_to_item(
-        self, memory_record: dict, namespace: tuple[str, ...]
-    ) -> Item:
-        """Convert a single AgentCore memory record to an Item object."""
-        # Extract content
-        content = memory_record.get("content", {})
-        text = content.get("text", "") if isinstance(content, dict) else str(content)
 
-        # Extract metadata
-        memory_record_id = memory_record.get("memoryRecordId", str(uuid.uuid4()))
-        created_at = memory_record.get("createdAt")
-
-        # Parse timestamp - API only provides createdAt, use it for both created_at and updated_at # noqa: E501
-        if isinstance(created_at, str):
-            try:
-                created_at = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
-            except (ValueError, AttributeError):
-                created_at = datetime.now(timezone.utc)
-        elif created_at is None:
-            created_at = datetime.now(timezone.utc)
-
-        return Item(
-            namespace=namespace,
-            key=memory_record_id,
-            value={
-                "content": text,
-                "memory_strategy_id": memory_record.get("memoryStrategyId"),
-                "namespaces": memory_record.get("namespaces", []),
-            },
-            created_at=created_at,
-            updated_at=created_at,  # Memory records are not updated
-        )
 
     def _convert_memory_records_to_search_items(
         self, memory_records: list, namespace: tuple[str, ...]

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/store/agentcore/store.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/store/agentcore/store.py
@@ -135,13 +135,13 @@ class AgentCoreMemoryStore(BaseStore):
                 {"conversational": {"content": {"text": text}, "role": role}}
             )
 
-        # TODO: attach op.key as event metadata for round-trip retrieval
         self.client.create_event(
             memoryId=self.memory_id,
             actorId=actor_id,
             sessionId=session_id,
             eventTimestamp=datetime.now(timezone.utc),
             payload=conversational_payloads,
+            metadata={STORE_KEY_METADATA: {"stringValue": op.key}},
         )
         logger.debug(f"Created event for message in namespace {op.namespace}")
 

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/store/agentcore/store.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/store/agentcore/store.py
@@ -191,7 +191,8 @@ class AgentCoreMemoryStore(BaseStore):
                 # Memory resource, actor, or session not found — treat as absent key
                 logger.error(
                     f"Failed to get event: {e} - "
-                    f"memory_id={self.memory_id}, actor_id={actor_id}, session_id={session_id}"
+                    f"memory_id={self.memory_id}, "
+                    f"actor_id={actor_id}, session_id={session_id}"
                 )
                 return None
             else:
@@ -309,8 +310,6 @@ class AgentCoreMemoryStore(BaseStore):
         if not namespace_tuple:
             return "/"
         return "/" + "/".join(namespace_tuple)
-
-
 
     def _convert_memory_records_to_search_items(
         self, memory_records: list, namespace: tuple[str, ...]

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/store/agentcore/store.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/store/agentcore/store.py
@@ -33,6 +33,8 @@ from ...checkpoint.agentcore.helpers import (
 
 logger = logging.getLogger(__name__)
 
+STORE_KEY_METADATA = "langgraph_store_key"
+
 
 class AgentCoreMemoryStore(BaseStore):
     """
@@ -136,6 +138,7 @@ class AgentCoreMemoryStore(BaseStore):
                 {"conversational": {"content": {"text": text}, "role": role}}
             )
 
+        # TODO: attach op.key as event metadata for round-trip retrieval
         self.client.create_event(
             memoryId=self.memory_id,
             actorId=actor_id,
@@ -146,30 +149,16 @@ class AgentCoreMemoryStore(BaseStore):
         logger.debug(f"Created event for message in namespace {op.namespace}")
 
     def _handle_get(self, op: GetOp) -> Result:
-        """Handle GetOp by retrieving a specific memory record from AgentCore Memory."""
-        try:
-            response = self.client.get_memory_record(
-                memoryId=self.memory_id, memoryRecordId=op.key
-            )
+        """Handle GetOp by retrieving a stored event from AgentCore Memory.
 
-            memory_record = response.get("memoryRecord")
-            if not memory_record:
-                return None
-
-            return self._convert_memory_record_to_item(memory_record, op.namespace)
-
-        except ClientError as e:
-            error_code = e.response["Error"]["Code"]
-            if error_code == "ResourceNotFoundException":
-                # Memory record not found
-                return None
-            else:
-                # Re-raise other client errors
-                logger.error(f"Failed to get memory record: {e}")
-                raise
-        except Exception as e:
-            logger.error(f"Failed to get memory record: {e}")
-            raise
+        Uses list_events with an eventMetadata EQUALS_TO filter on the
+        user-provided key (stored via STORE_KEY_METADATA on put).
+        """
+        # TODO: validate namespace via _unpack_namespace
+        # TODO: call list_events with metadata filter on STORE_KEY_METADATA
+        # TODO: select most recent event (last-write-wins) via _parse_timestamp
+        # TODO: convert to Item via _convert_event_to_item
+        raise NotImplementedError
 
     def _handle_search(self, op: SearchOp) -> Result:
         """Handle SearchOp by retrieving memory records from AgentCore Memory."""
@@ -192,6 +181,49 @@ class AgentCoreMemoryStore(BaseStore):
         return self._convert_memory_records_to_search_items(
             memory_records, op.namespace_prefix
         )
+
+    def _unpack_namespace(self, namespace: tuple[str, ...]) -> tuple[str, str]:
+        """Unpack a store namespace into AgentCore actor and session identifiers.
+
+        Args:
+            namespace: The store namespace, expected to be a 2-tuple of
+                ``(actor_id, session_id)``.
+
+        Returns:
+            The ``(actor_id, session_id)`` pair.
+
+        Raises:
+            ValueError: If the namespace is not a 2-tuple.
+        """
+        raise NotImplementedError
+
+    def _parse_timestamp(self, value: Any) -> datetime:
+        """Parse an AgentCore timestamp value into a datetime.
+
+        Args:
+            value: The raw timestamp from an event or memory record.
+
+        Returns:
+            A timezone-aware datetime; the current UTC time if `value` is
+            missing or unparseable.
+        """
+        raise NotImplementedError
+
+    def _convert_event_to_item(
+        self, event: dict, namespace: tuple[str, ...], key: str
+    ) -> Item:
+        """Convert a stored AgentCore event to an Item object.
+
+        Args:
+            event: An event returned by ``list_events`` with payloads included.
+            namespace: The store namespace the event was retrieved under.
+            key: The user-provided key the event was looked up by.
+
+        Returns:
+            The reconstructed Item, keyed by `key`, whose value preserves the
+            stored conversational content.
+        """
+        raise NotImplementedError
 
     def _convert_namespace_to_string(self, namespace_tuple: tuple[str, ...]) -> str:
         """Convert namespace tuple to AgentCore namespace string."""

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/store/agentcore/store.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/store/agentcore/store.py
@@ -236,7 +236,26 @@ class AgentCoreMemoryStore(BaseStore):
             The reconstructed Item, keyed by `key`, whose value preserves the
             stored conversational content.
         """
-        raise NotImplementedError
+        messages = []
+        for entry in event.get("payload", []):
+            conversational = entry.get("conversational", {})
+            text = conversational.get("content", {}).get("text", "")
+            messages.append({"text": text, "role": conversational.get("role")})
+
+        content = "\n".join(message["text"] for message in messages)
+
+        event_timestamp = self._parse_timestamp(event.get("eventTimestamp"))
+
+        return Item(
+            namespace=namespace,
+            key=key,
+            value={
+                "content": content,
+                "messages": messages,
+            },
+            created_at=event_timestamp,
+            updated_at=event_timestamp,
+        )
 
     def _convert_namespace_to_string(self, namespace_tuple: tuple[str, ...]) -> str:
         """Convert namespace tuple to AgentCore namespace string."""

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/store/agentcore/store.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/store/agentcore/store.py
@@ -200,6 +200,12 @@ class AgentCoreMemoryStore(BaseStore):
     def _parse_timestamp(self, value: Any) -> datetime:
         """Parse an AgentCore timestamp value into a datetime.
 
+        AgentCore returns timestamps as datetimes via boto3. As a defensive
+        fallback, a string ISO-8601 value is parsed (normalizing a trailing
+        "Z" to the "+00:00" UTC offset that ``datetime.fromisoformat`` accepts
+        on Python 3.10), and any value that is not a datetime defaults to the
+        current UTC time.
+
         Args:
             value: The raw timestamp from an event or memory record.
 
@@ -207,7 +213,14 @@ class AgentCoreMemoryStore(BaseStore):
             A timezone-aware datetime; the current UTC time if `value` is
             missing or unparseable.
         """
-        raise NotImplementedError
+        if isinstance(value, str):
+            try:
+                value = datetime.fromisoformat(value.replace("Z", "+00:00"))
+            except (ValueError, AttributeError):
+                value = None
+        if not isinstance(value, datetime):
+            value = datetime.now(timezone.utc)
+        return value
 
     def _convert_event_to_item(
         self, event: dict, namespace: tuple[str, ...], key: str

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/store/agentcore/store.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/store/agentcore/store.py
@@ -120,10 +120,7 @@ class AgentCoreMemoryStore(BaseStore):
             )
 
         # Convert namespace tuple to actor_id and session_id
-        if len(op.namespace) != 2:
-            raise ValueError("Namespace must be a tuple of (actor_id, session_id)")
-
-        actor_id, session_id = op.namespace
+        actor_id, session_id = self._unpack_namespace(op.namespace)
         event_messages = convert_langchain_messages_to_event_messages([message])
 
         if not event_messages:
@@ -195,7 +192,10 @@ class AgentCoreMemoryStore(BaseStore):
         Raises:
             ValueError: If the namespace is not a 2-tuple.
         """
-        raise NotImplementedError
+        if len(namespace) != 2:
+            raise ValueError("Namespace must be a tuple of (actor_id, session_id)")
+        actor_id, session_id = namespace
+        return actor_id, session_id
 
     def _parse_timestamp(self, value: Any) -> datetime:
         """Parse an AgentCore timestamp value into a datetime.

--- a/libs/langgraph-checkpoint-aws/tests/integration_tests/agentcore/test_store.py
+++ b/libs/langgraph-checkpoint-aws/tests/integration_tests/agentcore/test_store.py
@@ -378,63 +378,54 @@ class TestAgentCoreMemoryStoreIntegration:
 
     def test_batch_operations_with_get(self, store, actor_id, session_id):
         """Test batch operations including GetOp operations."""
-        # First, search for existing memory records to get valid IDs for GetOp
-        search_results = store.search(("facts", actor_id), query="preferences", limit=2)
+        # Put a message with a known key so we can retrieve it via GetOp
+        hiking_key = f"hiking-{uuid.uuid4().hex[:8]}"
+        store.put(
+            namespace=(actor_id, session_id),
+            key=hiking_key,
+            value={"message": HumanMessage("Trail running is also fun")},
+        )
 
         # Create batch operations including GetOp
-        batch_ops = []
-
-        # Add some PutOp operations
-        messages = [
-            HumanMessage("I enjoy hiking in the mountains"),
-            AIMessage(
-                "Mountain hiking is a great way to stay active and enjoy nature!"
+        batch_ops = [
+            PutOp(
+                namespace=(actor_id, session_id),
+                key=f"hiking_extra_{uuid.uuid4().hex[:8]}",
+                value={"message": HumanMessage("I also enjoy rock climbing")},
             ),
-        ]
-
-        for i, message in enumerate(messages):
-            batch_ops.append(
-                PutOp(
-                    namespace=(actor_id, session_id),
-                    key=f"hiking_msg_{i}",
-                    value={"message": message},
-                )
-            )
-
-        # Add SearchOp
-        batch_ops.append(
             SearchOp(
                 namespace_prefix=("facts", actor_id),
                 query="outdoor activities",
                 limit=3,
-            )
-        )
-
-        if search_results:
-            for result in search_results[:2]:  # Test up to 2 GetOps
-                batch_ops.append(GetOp(namespace=result.namespace, key=result.key))
-        else:
-            batch_ops.append(
-                GetOp(
-                    namespace=("facts", actor_id),
-                    key=f"mem-nonexistent-{uuid.uuid4().hex}",
-                )
-            )
+            ),
+            GetOp(namespace=(actor_id, session_id), key=hiking_key),
+        ]
 
         results = store.batch(batch_ops)
 
-        assert len(results) == len(batch_ops)
+        assert len(results) == 3
+        assert results[0] is None  # PutOp
+        assert isinstance(results[1], list)  # SearchOp
+        # GetOp should return the item we put earlier
+        get_result = results[2]
+        assert get_result is not None
+        assert get_result.key == hiking_key
+        assert get_result.value["content"] == "Trail running is also fun"
 
-        # PutOp results should be None
-        assert results[0] is None  # First PutOp
-        assert results[1] is None  # Second PutOp
+    def test_put_get_roundtrip_by_key(self, store, actor_id, session_id):
+        """Test that put→get round-trips correctly by user-supplied key (#708)."""
+        key = f"roundtrip-{uuid.uuid4().hex[:8]}"
+        message_text = "I enjoy reading science fiction novels"
+        message = HumanMessage(message_text)
 
-        # SearchOp result should be a list
-        assert isinstance(results[2], list)
+        store.put(
+            namespace=(actor_id, session_id),
+            key=key,
+            value={"message": message},
+        )
 
-        # GetOp results should be Item objects or None
-        for i in range(3, len(results)):
-            result = results[i]
-            assert result is None or hasattr(result, "key"), (
-                f"GetOp result should be Item or None, got {type(result)}"
-            )
+        item = store.get((actor_id, session_id), key)
+
+        assert item is not None, "get() should return a non-None Item after put()"
+        assert item.key == key
+        assert item.value["content"] == message_text

--- a/libs/langgraph-checkpoint-aws/tests/integration_tests/agentcore/test_store.py
+++ b/libs/langgraph-checkpoint-aws/tests/integration_tests/agentcore/test_store.py
@@ -452,3 +452,11 @@ class TestAgentCoreMemoryStoreIntegration:
         assert item is not None, "get() should return a non-None Item"
         assert item.key == key
         assert item.value["content"] == "Second version of the message"
+
+    def test_get_absent_key_returns_none(self, store, actor_id, session_id):
+        """Test that get() for a never-stored key returns None."""
+        absent_key = f"never-put-key-{uuid.uuid4().hex[:8]}"
+
+        item = store.get((actor_id, session_id), absent_key)
+
+        assert item is None

--- a/libs/langgraph-checkpoint-aws/tests/integration_tests/agentcore/test_store.py
+++ b/libs/langgraph-checkpoint-aws/tests/integration_tests/agentcore/test_store.py
@@ -429,3 +429,26 @@ class TestAgentCoreMemoryStoreIntegration:
         assert item is not None, "get() should return a non-None Item after put()"
         assert item.key == key
         assert item.value["content"] == message_text
+
+    def test_put_get_last_write_wins(self, store, actor_id, session_id):
+        """Test that re-putting the same key returns the most recent value."""
+        key = f"lww-{uuid.uuid4().hex[:8]}"
+        msg_a = HumanMessage("First version of the message")
+        msg_b = HumanMessage("Second version of the message")
+
+        store.put(
+            namespace=(actor_id, session_id),
+            key=key,
+            value={"message": msg_a},
+        )
+        store.put(
+            namespace=(actor_id, session_id),
+            key=key,
+            value={"message": msg_b},
+        )
+
+        item = store.get((actor_id, session_id), key)
+
+        assert item is not None, "get() should return a non-None Item"
+        assert item.key == key
+        assert item.value["content"] == "Second version of the message"

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_store.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_store.py
@@ -34,6 +34,7 @@ class TestAgentCoreMemoryStore:
         mock_client.create_event = MagicMock()
         mock_client.retrieve_memory_records = MagicMock()
         mock_client.get_memory_record = MagicMock()
+        mock_client.list_events = MagicMock()
         return mock_client
 
     @pytest.fixture
@@ -87,31 +88,60 @@ class TestAgentCoreMemoryStore:
         with pytest.raises(TypeError):
             AgentCoreMemoryStore()
 
-    def test_batch_get_op_success(self, store, mock_boto_client, sample_memory_record):
-        """Test successful GetOp operation."""
-        mock_boto_client.get_memory_record.return_value = {
-            "memoryRecord": sample_memory_record
+    def test_batch_get_op_success(self, store, mock_boto_client):
+        """Test successful GetOp operation via list_events."""
+        event_timestamp = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+        mock_boto_client.list_events.return_value = {
+            "events": [
+                {
+                    "payload": [
+                        {
+                            "conversational": {
+                                "content": {"text": "Hello, world!"},
+                                "role": "USER",
+                            }
+                        }
+                    ],
+                    "eventTimestamp": event_timestamp,
+                }
+            ]
         }
 
-        ops = [GetOp(namespace=("test_actor", "test_session"), key="test-key")]
+        op_key = "test-key"
+        ops = [GetOp(namespace=("test_actor", "test_session"), key=op_key)]
         results = store.batch(ops)
 
         assert len(results) == 1
         result = results[0]
         assert isinstance(result, Item)
         assert result.namespace == ("test_actor", "test_session")
-        assert result.key == sample_memory_record["memoryRecordId"]
+        assert result.key == op_key
         assert result.value["content"] == "Hello, world!"
+        assert result.value["messages"] == [{"text": "Hello, world!", "role": "USER"}]
 
-        mock_boto_client.get_memory_record.assert_called_once_with(
-            memoryId="test-memory-id", memoryRecordId="test-key"
+        # Pin the exact API call shape to protect against regressions in _handle_get
+        mock_boto_client.list_events.assert_called_once_with(
+            memoryId="test-memory-id",
+            actorId="test_actor",
+            sessionId="test_session",
+            includePayloads=True,
+            maxResults=100,
+            filter={
+                "eventMetadata": [
+                    {
+                        "left": {"metadataKey": STORE_KEY_METADATA},
+                        "operator": "EQUALS_TO",
+                        "right": {"metadataValue": {"stringValue": op_key}},
+                    }
+                ]
+            },
         )
 
     def test_batch_get_op_not_found(self, store, mock_boto_client):
-        """Test GetOp when record not found."""
-        mock_boto_client.get_memory_record.side_effect = ClientError(
+        """Test GetOp when list_events raises ResourceNotFoundException."""
+        mock_boto_client.list_events.side_effect = ClientError(
             error_response={"Error": {"Code": "ResourceNotFoundException"}},
-            operation_name="GetMemoryRecord",
+            operation_name="ListEvents",
         )
 
         ops = [GetOp(namespace=("test_actor", "test_session"), key="nonexistent")]
@@ -121,10 +151,10 @@ class TestAgentCoreMemoryStore:
         assert results[0] is None
 
     def test_batch_get_op_other_error(self, store, mock_boto_client):
-        """Test GetOp with other boto3 errors."""
-        mock_boto_client.get_memory_record.side_effect = ClientError(
+        """Test GetOp with other boto3 errors on list_events."""
+        mock_boto_client.list_events.side_effect = ClientError(
             error_response={"Error": {"Code": "AccessDeniedException"}},
-            operation_name="GetMemoryRecord",
+            operation_name="ListEvents",
         )
 
         ops = [GetOp(namespace=("test_actor", "test_session"), key="test-key")]
@@ -330,8 +360,21 @@ class TestAgentCoreMemoryStore:
         self, store, mock_boto_client, sample_memory_record, sample_item_data
     ):
         """Test batch with mixed operation types."""
-        mock_boto_client.get_memory_record.return_value = {
-            "memoryRecord": sample_memory_record
+        event_timestamp = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+        mock_boto_client.list_events.return_value = {
+            "events": [
+                {
+                    "payload": [
+                        {
+                            "conversational": {
+                                "content": {"text": "Hello, world!"},
+                                "role": "USER",
+                            }
+                        }
+                    ],
+                    "eventTimestamp": event_timestamp,
+                }
+            ]
         }
         mock_boto_client.retrieve_memory_records.return_value = {
             "memoryRecordSummaries": [sample_memory_record]
@@ -379,20 +422,6 @@ class TestAgentCoreMemoryStore:
                 await store.abatch(ops)
 
         asyncio.run(test_async())
-
-    def test_convert_memory_record_to_item(self, store, sample_memory_record):
-        """Test conversion of memory record to Item."""
-        namespace = ("test_actor", "test_session")
-
-        item = store._convert_memory_record_to_item(sample_memory_record, namespace)
-
-        assert isinstance(item, Item)
-        assert item.namespace == namespace
-        assert item.key == sample_memory_record["memoryRecordId"]
-        assert item.value["content"] == "Hello, world!"
-        assert item.value["memory_strategy_id"] == "strategy-123"
-        assert isinstance(item.created_at, datetime)
-        assert isinstance(item.updated_at, datetime)
 
     def test_convert_memory_records_to_search_items(self, store, sample_memory_record):
         """Test conversion of memory records to SearchItem objects."""
@@ -529,6 +558,109 @@ class TestAgentCoreMemoryStore:
         assert result_none.tzinfo == timezone.utc
         assert isinstance(result_invalid, datetime)
         assert result_invalid.tzinfo == timezone.utc
+
+    def test_put_get_roundtrip(self, store, mock_boto_client):
+        """Regression test for #708: put→get round-trip returns stored value."""
+        mock_boto_client.create_event.return_value = {
+            "event": {"eventId": "event-123", "memoryId": "test-memory-id"}
+        }
+
+        put_op = PutOp(
+            namespace=("user1", "session1"),
+            key="k1",
+            value={"message": HumanMessage(content="I love hot chocolate!")},
+        )
+        store.batch([put_op])
+
+        call_args = mock_boto_client.create_event.call_args[1]
+        assert call_args["metadata"] == {STORE_KEY_METADATA: {"stringValue": "k1"}}
+
+        event_timestamp = datetime(2024, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+        mock_boto_client.list_events.return_value = {
+            "events": [
+                {
+                    "payload": [
+                        {
+                            "conversational": {
+                                "content": {"text": "I love hot chocolate!"},
+                                "role": "USER",
+                            }
+                        }
+                    ],
+                    "eventTimestamp": event_timestamp,
+                }
+            ]
+        }
+
+        get_op = GetOp(namespace=("user1", "session1"), key="k1")
+        results = store.batch([get_op])
+
+        assert len(results) == 1
+        item = results[0]
+        assert isinstance(item, Item)
+        assert item.key == "k1"
+        assert "I love hot chocolate!" in item.value["content"]
+        assert item.namespace == ("user1", "session1")
+
+    def test_batch_get_op_no_events_returns_none(self, store, mock_boto_client):
+        """Test GetOp returns None when list_events returns empty events list."""
+        mock_boto_client.list_events.return_value = {"events": []}
+
+        ops = [GetOp(namespace=("test_actor", "test_session"), key="absent-key")]
+        results = store.batch(ops)
+
+        assert len(results) == 1
+        assert results[0] is None
+
+    def test_batch_get_op_selects_latest_event(self, store, mock_boto_client):
+        """Test GetOp selects the most recent event (last-write-wins)."""
+        older_timestamp = datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+        newer_timestamp = datetime(2024, 1, 2, 15, 0, 0, tzinfo=timezone.utc)
+
+        mock_boto_client.list_events.return_value = {
+            "events": [
+                {
+                    "payload": [
+                        {
+                            "conversational": {
+                                "content": {"text": "old message"},
+                                "role": "USER",
+                            }
+                        }
+                    ],
+                    "eventTimestamp": newer_timestamp,
+                },
+                {
+                    "payload": [
+                        {
+                            "conversational": {
+                                "content": {"text": "even older message"},
+                                "role": "USER",
+                            }
+                        }
+                    ],
+                    "eventTimestamp": older_timestamp,
+                },
+            ]
+        }
+
+        ops = [GetOp(namespace=("test_actor", "test_session"), key="shared-key")]
+        results = store.batch(ops)
+
+        assert len(results) == 1
+        result = results[0]
+        assert isinstance(result, Item)
+        assert result.value["content"] == "old message"
+        assert result.key == "shared-key"
+
+    def test_get_op_invalid_namespace(self, store, mock_boto_client):
+        """Test GetOp with invalid namespace raises ValueError."""
+        ops = [GetOp(namespace=("single_element",), key="test-key")]
+
+        with pytest.raises(
+            ValueError, match="Namespace must be a tuple of \\(actor_id, session_id\\)"
+        ):
+            store.batch(ops)
 
     def test_convert_event_to_item_single_payload(self, store):
         """Test _convert_event_to_item with a normal single-entry payload."""

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_store.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_store.py
@@ -501,3 +501,23 @@ class TestAgentCoreMemoryStore:
             ValueError, match="Namespace must be a tuple of \\(actor_id, session_id\\)"
         ):
             store.batch(ops)
+
+    def test_parse_timestamp_string_with_z(self, store):
+        """Test _parse_timestamp with ISO string ending in Z."""
+        result = store._parse_timestamp("2024-01-01T12:00:00Z")
+        assert result == datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+    def test_parse_timestamp_datetime_passthrough(self, store):
+        """Test _parse_timestamp returns the same datetime object."""
+        dt = datetime(2025, 6, 15, 9, 30, 0, tzinfo=timezone.utc)
+        result = store._parse_timestamp(dt)
+        assert result is dt  # identity check: no copy or reconstruction, same object returned
+
+    def test_parse_invalid_timestamp_returns_now(self, store):
+        """Test _parse_timestamp with invalid inputs returns a UTC datetime."""
+        result_none = store._parse_timestamp(None)
+        result_invalid = store._parse_timestamp("not-a-date")
+        assert isinstance(result_none, datetime)
+        assert result_none.tzinfo == timezone.utc
+        assert isinstance(result_invalid, datetime)
+        assert result_invalid.tzinfo == timezone.utc

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_store.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_store.py
@@ -521,3 +521,67 @@ class TestAgentCoreMemoryStore:
         assert result_none.tzinfo == timezone.utc
         assert isinstance(result_invalid, datetime)
         assert result_invalid.tzinfo == timezone.utc
+
+    def test_convert_event_to_item_single_payload(self, store):
+        """Test _convert_event_to_item with a normal single-entry payload."""
+        event = {
+            "payload": [
+                {
+                    "conversational": {
+                        "content": {"text": "Hello there"},
+                        "role": "USER",
+                    }
+                }
+            ],
+            "eventTimestamp": datetime(2024, 3, 10, 8, 0, 0, tzinfo=timezone.utc),
+        }
+
+        item = store._convert_event_to_item(event, ("actor1", "sess1"), "my-key")
+
+        assert isinstance(item, Item)
+        assert item.key == "my-key"
+        assert item.namespace == ("actor1", "sess1")
+        assert item.value["content"] == "Hello there"
+        assert item.value["messages"] == [{"text": "Hello there", "role": "USER"}]
+        assert item.created_at == datetime(2024, 3, 10, 8, 0, 0, tzinfo=timezone.utc)
+        assert item.updated_at == datetime(2024, 3, 10, 8, 0, 0, tzinfo=timezone.utc)
+
+    def test_convert_event_to_item_multiple_payloads(self, store):
+        """Test _convert_event_to_item joins multiple payload entries."""
+        event = {
+            "payload": [
+                {
+                    "conversational": {
+                        "content": {"text": "First line"},
+                        "role": "USER",
+                    }
+                },
+                {
+                    "conversational": {
+                        "content": {"text": "Second line"},
+                        "role": "ASSISTANT",
+                    }
+                },
+            ],
+            "eventTimestamp": datetime(2024, 5, 1, 12, 0, 0, tzinfo=timezone.utc),
+        }
+
+        item = store._convert_event_to_item(event, ("a", "b"), "k2")
+
+        assert item.value["content"] == "First line\nSecond line"
+        assert item.value["messages"] == [
+            {"text": "First line", "role": "USER"},
+            {"text": "Second line", "role": "ASSISTANT"},
+        ]
+
+    def test_convert_event_to_item_empty_payload(self, store):
+        """Test _convert_event_to_item with an empty payload list."""
+        event = {
+            "payload": [],
+            "eventTimestamp": datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+        }
+
+        item = store._convert_event_to_item(event, ("x", "y"), "k3")
+
+        assert item.value["content"] == ""
+        assert item.value["messages"] == []

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_store.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_store.py
@@ -548,7 +548,7 @@ class TestAgentCoreMemoryStore:
         """Test _parse_timestamp returns the same datetime object."""
         dt = datetime(2025, 6, 15, 9, 30, 0, tzinfo=timezone.utc)
         result = store._parse_timestamp(dt)
-        assert result is dt  # identity check: no copy or reconstruction, same object returned
+        assert result is dt  # identity: same object returned, no copy
 
     def test_parse_invalid_timestamp_returns_now(self, store):
         """Test _parse_timestamp with invalid inputs returns a UTC datetime."""

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_store.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_store.py
@@ -18,7 +18,10 @@ from langgraph.store.base import (
     SearchOp,
 )
 
-from langgraph_checkpoint_aws.store.agentcore.store import AgentCoreMemoryStore
+from langgraph_checkpoint_aws.store.agentcore.store import (
+    STORE_KEY_METADATA,
+    AgentCoreMemoryStore,
+)
 
 
 class TestAgentCoreMemoryStore:
@@ -154,6 +157,11 @@ class TestAgentCoreMemoryStore:
         assert call_args["sessionId"] == "test_session"
         assert len(call_args["payload"]) == 1
         assert call_args["payload"][0]["conversational"]["role"] == "USER"
+
+        # Verify metadata carries the user key
+        assert call_args["metadata"] == {
+            STORE_KEY_METADATA: {"stringValue": "test-key"}
+        }
 
     def test_batch_put_op_delete(self, store, mock_boto_client):
         """Test PutOp with None value (delete operation)."""


### PR DESCRIPTION
## Summary

Fixes the broken `put` → `get` round-trip in `AgentCoreMemoryStore`. After this change, storing a value with `put(namespace, key, value)` and retrieving it with `get(namespace, key)` returns the stored value.

Resolves #708


### What changed

- `_handle_put` now attaches `op.key` to the event as metadata (`STORE_KEY_METADATA`).
- `_handle_get` replaces the broken `get_memory_record(memoryRecordId=op.key)` call with `list_events` filtered by that metadata key, selecting the most recent matching event (last-write-wins by `eventTimestamp`).

New helpers:
- `_unpack_namespace` — centralized 2-tuple namespace validation (shared by put and get)
- `_parse_timestamp` — defensive timestamp parser (boto3 datetime passthrough, ISO-8601 string with Z, fallback to UTC now)
- `_convert_event_to_item` — reconstructs an `Item` from an event's payload

Removed dead code:
- `_convert_memory_record_to_item` — the old get-path converter; replaced by `_convert_event_to_item`


### Design decision: events layer over memory records

The fix stores and retrieves on the AgentCore Memory **events** layer (attaching `op.key` as event `metadata` and reading it back via `list_events` with an `eventMetadata` `EQUALS_TO` filter) instead of the **memory records** layer.

- [Events (short-term memory)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/using-memory-short-term.html) — raw conversational events, immediately consistent, addressed by actor/session/metadata
- [Memory records (long-term memory)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/long-term-memory-long-term.html) — asynchronously extracted, semantically retrieved, addressed by service-generated IDs

**Why events**: Events are the correct abstraction for deterministic key-value CRUD — they are immediately consistent, support exact lookup by a caller-chosen key, and preserve stored content without loss. Memory records serve a fundamentally different purpose: they are asynchronously extracted semantic summaries designed for retrieval-augmented generation, not for storing and retrieving user-supplied data by key. Semantic `search(..., query=...)` intentionally still uses memory records.


### Alternatives considered: memory records

A memory-records implementation was indeed evaluated first via the synchronous `BatchCreateMemoryRecords` API. However, after consideration a decision was made to use events instead because:
1. From a use-case standpoint, memory records are not the appropriate storage-layer for the use-case of deterministic key-value CRUD 
2. `BatchCreateMemoryRecords` has no caller-supplied record ID (service generates `memoryRecordId`), so it would require the same store-key-as-metadata + filtered-lookup trick
3. The store's semantic `search` uses `retrieve_memory_records`. Writing raw key-value blobs as memory records would pollute the semantic-search space. Events keep deterministic CRUD cleanly separated
4. `_handle_put` already calls `create_event`, so the events fix is a one-kwarg change vs. a larger rewrite (minimal-change principle)


### Limitations

**Time-bounded retention (up to 365 days)**: Stored keys/values are NOT permanent. They live in the event and expire per the memory resource's `eventExpiryDuration` (configurable up to 365 days, applied per event at write time, not retroactively extendable). This store is durable-but-time-bounded, not a permanent datastore.


### Areas needing careful review

- The `_handle_get` metadata filter shape — must match what `_handle_put` writes.
- **Behavioral change:** get(namespace, key) previously called get_memory_record(memoryRecordId=key). If anyone was passing a service-generated memoryRecordId (from a search result) as the key argument to get(), that would have (sometimes, unreliably) returned a result before, and now returns None. However, in defence of this PR's change, that usage was already broken/undocumented — the method was supposed to round-trip with put, not look up memory records by their service ID.

### Test coverage (all pass)
**Unit tests**:

Created:
- `test_put_get_roundtrip` — #708 regression test
- `test_batch_get_op_no_events_returns_none` — empty events → `None`
- `test_batch_get_op_selects_latest_event` — last-write-wins
- `test_get_op_invalid_namespace` — `ValueError` via `_unpack_namespace` on get
- `test_convert_event_to_item_single_payload` — payload parsing
- `test_convert_event_to_item_multiple_payloads` — newline-joined content
- `test_convert_event_to_item_empty_payload` — empty payload graceful handling
- `test_parse_timestamp_string_with_z` — ISO string with Z suffix
- `test_parse_timestamp_datetime_passthrough` — identity passthrough
- `test_parse_invalid_timestamp_returns_now` — None/garbage → UTC datetime

Modified:
- `test_batch_get_op_success` — rewired from `get_memory_record` to `list_events`; verifies filter shape
- `test_batch_get_op_not_found` — `ResourceNotFoundException` now on `list_events`
- `test_batch_get_op_other_error` — other `ClientError` now on `list_events`
- `test_batch_put_op_success` — added `metadata` assertion
- `test_batch_mixed_operations` — GetOp branch uses `list_events`, returns `Item`

**Integration tests** (validated against live AgentCore Memory resource):

Created:
- `test_put_get_roundtrip_by_key` — exact content round-trip
- `test_put_get_last_write_wins` — re-put returns latest
- `test_get_absent_key_returns_none` — never-put key → `None`

Modified:
- `test_batch_operations_with_get` — rewired to use self-put keys instead of search-result `memoryRecordId`s

**Removed tests** (stale after fix):
- Unit: `test_convert_memory_record_to_item` — tested deleted helper; coverage replaced by `test_convert_event_to_item_*`
- Integration: `test_get_memory_record_success` — relied on old memory-record get path; replaced by `test_put_get_roundtrip_by_key`