### PR TITLE
feat(langgraph-checkpoint-aws): Support hierarchical namespace search in AgentCoreMemoryStore

### DIFF
--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/store/agentcore/store.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/store/agentcore/store.py
@@ -44,6 +44,11 @@ class AgentCoreMemoryStore(BaseStore):
 
     Args:
         memory_id: The AgentCore Memory resource ID
+        hierarchical_search: Perform memory record retrieval using hierarchical
+            search (i.e. sets `namespacePath`), returning the memory records whose
+            namespace falls under the specified path. Defaults to True. If set to
+            False, will instead perform an exact match search (i.e. sets
+            `namespace`) for memory records stored at that precise path.
         **boto3_kwargs: Additional arguments passed to boto3.client()
 
     Example:
@@ -67,8 +72,15 @@ class AgentCoreMemoryStore(BaseStore):
     supports_ttl: bool = False
     ttl_config = None
 
-    def __init__(self, *, memory_id: str, **boto3_kwargs: Any):
+    def __init__(
+        self,
+        *,
+        memory_id: str,
+        hierarchical_search: bool = True,
+        **boto3_kwargs: Any,
+    ):
         self.memory_id = memory_id
+        self.hierarchical_search = hierarchical_search
 
         config = Config(
             user_agent_extra="x-client-framework:langgraph_agentcore_memory_store",
@@ -181,11 +193,16 @@ class AgentCoreMemoryStore(BaseStore):
 
         search_criteria = {"searchQuery": op.query, "topK": op.limit}
 
+        if self.hierarchical_search:
+            namespace_param = {"namespacePath": namespace_str}
+        else:
+            namespace_param = {"namespace": namespace_str}
+
         response = self.client.retrieve_memory_records(
             memoryId=self.memory_id,
-            namespace=namespace_str,
             searchCriteria=search_criteria,
             maxResults=op.limit,
+            **namespace_param,
         )
 
         memory_records = response.get("memoryRecordSummaries", [])

--- a/libs/langgraph-checkpoint-aws/pyproject.toml
+++ b/libs/langgraph-checkpoint-aws/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">=3.10,<4.0"
 dependencies = [
     "langgraph-checkpoint>=3.0.0,<5.0.0",
     "langgraph>=1.0.0",
-    "boto3>=1.40.19",
+    "boto3>=1.42.90",
     "typing_extensions>=4.0.0; python_version<'3.11'",
 ]
 name = "langgraph-checkpoint-aws"

--- a/libs/langgraph-checkpoint-aws/tests/integration_tests/agentcore/test_store.py
+++ b/libs/langgraph-checkpoint-aws/tests/integration_tests/agentcore/test_store.py
@@ -187,6 +187,40 @@ class TestAgentCoreMemoryStoreIntegration:
 
         assert isinstance(found_results, bool)
 
+    def test_hierarchical_vs_exact_match(self, store, memory_id, actor_id):
+        """Test hierarchical search matches a parent prefix but exact match does not."""
+        session = generate_valid_session_id()
+
+        exact_match_store = AgentCoreMemoryStore(
+            memory_id=memory_id, region_name="us-west-2", hierarchical_search=False
+        )
+
+        messages = [
+            HumanMessage("I really love Croatian food, especially cevapi"),
+            AIMessage("Great choice! Cevapi is a classic Balkan grilled dish"),
+            HumanMessage("I also enjoy Croatian wine, particularly Plavac Mali"),
+            AIMessage("Plavac Mali pairs wonderfully with Dalmatian cuisine"),
+        ]
+        for i, msg in enumerate(messages):
+            store.put(
+                namespace=(actor_id, session), key=f"summ_{i}", value={"message": msg}
+            )
+            time.sleep(1)
+
+        # Extra time for extraction since summaries are generated async
+        time.sleep(120)
+
+        parent_prefix = ("summaries", "actors", actor_id)
+        query = "food preferences Croatian cuisine"
+
+        hierarchical_results = store.search(parent_prefix, query=query, limit=5)
+        exact_match_results = exact_match_store.search(
+            parent_prefix, query=query, limit=5
+        )
+
+        assert hierarchical_results, "namespacePath should match the parent prefix"
+        assert not exact_match_results, "namespace should not match a parent prefix"
+
     def test_batch_operations(self, store, actor_id, session_id):
         """Test batch operations with multiple put and search operations."""
         messages = [

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_store.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_store.py
@@ -263,10 +263,41 @@ class TestAgentCoreMemoryStore:
 
         mock_boto_client.retrieve_memory_records.assert_called_once_with(
             memoryId="test-memory-id",
+            namespacePath="/test_actor",
+            searchCriteria={"searchQuery": "test query", "topK": 5},
+            maxResults=5,
+        )
+        call_kwargs = mock_boto_client.retrieve_memory_records.call_args.kwargs
+        assert "namespace" not in call_kwargs
+
+    def test_batch_search_op_exact_match(
+        self, mock_boto_client, memory_id, sample_memory_record
+    ):
+        """Test SearchOp uses the exact-match namespace when hierarchical_search
+        is disabled."""
+        with patch("boto3.client") as mock_boto3_client:
+            mock_boto3_client.return_value = mock_boto_client
+            store = AgentCoreMemoryStore(memory_id=memory_id, hierarchical_search=False)
+
+        mock_boto_client.retrieve_memory_records.return_value = {
+            "memoryRecordSummaries": [sample_memory_record]
+        }
+
+        ops = [
+            SearchOp(
+                namespace_prefix=("test_actor",), query="test query", limit=5, offset=0
+            )
+        ]
+        store.batch(ops)
+
+        mock_boto_client.retrieve_memory_records.assert_called_once_with(
+            memoryId="test-memory-id",
             namespace="/test_actor",
             searchCriteria={"searchQuery": "test query", "topK": 5},
             maxResults=5,
         )
+        call_kwargs = mock_boto_client.retrieve_memory_records.call_args.kwargs
+        assert "namespacePath" not in call_kwargs
 
     def test_batch_search_op_no_query(self, store, mock_boto_client):
         """Test SearchOp without query returns empty results."""
@@ -463,7 +494,7 @@ class TestAgentCoreMemoryStore:
         store.batch(ops)
 
         call_args = mock_boto_client.retrieve_memory_records.call_args[1]
-        assert call_args["namespace"] == "/single_actor"
+        assert call_args["namespacePath"] == "/single_actor"
 
     def test_search_with_pagination_parameters(
         self, store, mock_boto_client, sample_memory_record

--- a/libs/langgraph-checkpoint-aws/uv.lock
+++ b/libs/langgraph-checkpoint-aws/uv.lock
@@ -649,7 +649,7 @@ typing = [
 
 [package.metadata]
 requires-dist = [
-    { name = "boto3", specifier = ">=1.40.19" },
+    { name = "boto3", specifier = ">=1.42.90" },
     { name = "langgraph", specifier = ">=1.0.0" },
     { name = "langgraph-checkpoint", specifier = ">=3.0.0,<5.0.0" },
     { name = "orjson", marker = "extra == 'valkey'", specifier = ">=3.11.3" },


### PR DESCRIPTION
Related: #1128

Bedrock AgentCore Memory [recently added](https://awsapichanges.com/archive/changes/8cde7c-bedrock-agentcore.html) a new `namespacePath` field to its memory record retrieval APIs ([RetrieveMemoryRecords](https://docs.aws.amazon.com/bedrock-agentcore/latest/APIReference/API_RetrieveMemoryRecords.html#API_RetrieveMemoryRecords_RequestSyntax) and [ListMemoryRecords](https://docs.aws.amazon.com/bedrock-agentcore/latest/APIReference/API_ListMemoryRecords.html)). This field allows for a hierarchical lookup returning every record whose namespace falls under a given path, rather than the exact match required by the older `namespace` field.

Updating `AgentCoreMemoryStore` with a new `hierarchical_search` field that sets `namespacePath` by default (as recommended in the launch blogpost: https://aws.amazon.com/blogs/machine-learning/organizing-agents-memory-at-scale-namespace-design-patterns-in-agentcore-memory/)

If needed, users can still toggle this off and revert to the original `namespace` behavior:

```python
store = AgentCoreMemoryStore(
  memory_id="mem-123",
  region_name="us-west-2",
  hierarchical_search=False,
)
```

This will also update boto3 to the [minimum version](https://github.com/boto/botocore/blob/41126095ddd74050a815d39d6f052c0feb22f553/CHANGELOG.rst#L652) implementing AgentCore Memory `namespacePath` support.


