### PR TITLE
feat(aws): Support Claude Fable and Sonnet 5

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -803,6 +803,8 @@ class ChatBedrockConverse(BaseChatModel):
                         "claude-sonnet-4",
                         "claude-opus-4",
                         "claude-haiku-4",
+                        "claude-fable-5",
+                        "claude-sonnet-5",
                     ]
                 )
             )

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -765,6 +765,8 @@ def test_standard_tracing_params() -> None:
         ("us.anthropic.claude-sonnet-4-20250514-v1:0", False),
         ("us.anthropic.claude-opus-4-20250514-v1:0", False),
         ("us.anthropic.claude-sonnet-4-5-20250929-v1:0", False),
+        ("us.anthropic.claude-sonnet-5", False),
+        ("us.anthropic.claude-fable-5", False),
         ("us.anthropic.claude-3-haiku-20240307-v1:0", False),
         ("cohere.command-r-v1:0", False),
         ("meta.llama3-1-405b-instruct-v1:0", "tool_calling"),
@@ -2326,6 +2328,20 @@ def test__get_base_model() -> None:
         (
             "arn:aws:bedrock:us-west-2::foundation-model/anthropic.claude-3-sonnet-20240229-v1:0",
             "anthropic.claude-3-sonnet-20240229-v1:0",
+            "anthropic",
+            False,
+        ),
+        (
+            # Application inference profile over Claude Sonnet 5 must keep
+            # streaming enabled (GH#1139)
+            "arn:aws:bedrock:us-west-2:123456789012:application-inference-profile/my-profile",
+            "anthropic.claude-sonnet-5",
+            "anthropic",
+            False,
+        ),
+        (
+            "arn:aws:bedrock:us-west-2:123456789012:application-inference-profile/my-profile",
+            "anthropic.claude-fable-5",
             "anthropic",
             False,
         ),

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -2332,8 +2332,6 @@ def test__get_base_model() -> None:
             False,
         ),
         (
-            # Application inference profile over Claude Sonnet 5 must keep
-            # streaming enabled (GH#1139)
             "arn:aws:bedrock:us-west-2:123456789012:application-inference-profile/my-profile",
             "anthropic.claude-sonnet-5",
             "anthropic",

--- a/libs/aws/tests/unit_tests/test_utils.py
+++ b/libs/aws/tests/unit_tests/test_utils.py
@@ -447,6 +447,8 @@ def test_trim_message_whitespace_with_empty_messages() -> None:
         ("us.anthropic.claude-sonnet-4-20250514-v1:0", True),
         ("us.anthropic.claude-sonnet-4-20250514-v1:0", True),
         ("us.anthropic.claude-3-5-sonnet-20240620-v1:0", True),
+        ("us.anthropic.claude-fable-5", False),
+        ("us.anthropic.claude-sonnet-5", False),
         ("us.anthropic.claude-3-sonnet-20240229-v1:0", False),
         ("us.meta.llama4-scout-17b-instruct-v1:0", False),
         ("us.amazon.nova-pro-v1:0", False),


### PR DESCRIPTION
Fixes: #1139 

Updates `ChatBedrockConverse` to support Anthropic Claude Sonnet 5 and Fable 5 models, mainly to allowlist both models for streaming. 

Couple additional notes from testing Claude 5 against Bedrock:
- Bedrock's CountTokens API does not currently work with either Fable 5 or Sonnet 5. Therefore, will not be including these in the [`count_tokens_api_supported_for_model`](https://github.com/langchain-ai/langchain-aws/blob/main/libs/aws/langchain_aws/utils.py#L113) allowlist for now.
- Deprecated `top_p`/`temperature` parameters are not being auto-excluded for Claude 5, as the model profiles have not been updated yet. A PR is pending upstream in models.dev repo to resolve this: https://github.com/anomalyco/models.dev/pull/2977
- Forced tool choice is compatible with adaptive thinking mode on Claude 5, so will not be adding these model to the related block-lists. (Also seems to be applicable to Opus 4.8 - will open a separate PR to un-restrict it)