### PR TITLE
fix(aws): Allow thinking + forced tool use on Claude Opus 4.8 and Claude 5

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -74,6 +74,7 @@ from langchain_aws.utils import (
     create_aws_client,
     get_num_tokens_anthropic,
     get_token_ids_anthropic,
+    thinking_forced_tool_use_unsupported,
     thinking_in_params,
     trim_message_whitespace,
 )
@@ -1354,15 +1355,9 @@ class ChatBedrock(BaseChatModel, BedrockBase):
             formatted_tools = [convert_to_anthropic_tool(tool) for tool in tools]
 
             base_model = self._get_base_model()
-            if any(
-                x in base_model
-                for x in (
-                    "claude-3-7-",
-                    "claude-opus-4-",
-                    "claude-sonnet-4-",
-                    "claude-haiku-4-",
-                )
-            ) and thinking_in_params(self.model_kwargs or {}):
+            if thinking_forced_tool_use_unsupported(base_model) and thinking_in_params(
+                self.model_kwargs or {}
+            ):
                 forced = False
                 if isinstance(tool_choice, bool):
                     forced = bool(tool_choice)
@@ -1545,14 +1540,8 @@ class ChatBedrock(BaseChatModel, BedrockBase):
         tool_name = convert_to_anthropic_tool(schema)["name"]
 
         base_model = self._get_base_model()
-        has_thinking = any(
-            x in base_model
-            for x in (
-                "claude-3-7-",
-                "claude-opus-4-",
-                "claude-sonnet-4-",
-                "claude-haiku-4-",
-            )
+        has_thinking = thinking_forced_tool_use_unsupported(
+            base_model
         ) and thinking_in_params(self.model_kwargs or {})
 
         if has_thinking:

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -79,6 +79,7 @@ from langchain_aws.tools.nova_tools import NovaSystemTool
 from langchain_aws.utils import (
     count_tokens_api_supported_for_model,
     create_aws_client,
+    thinking_forced_tool_use_unsupported,
     thinking_in_params,
     trim_message_whitespace,
 )
@@ -1002,15 +1003,9 @@ class ChatBedrockConverse(BaseChatModel):
             base_model = self._get_base_model()
             if "claude" in base_model:
                 # Tool choice not supported when thinking is enabled
-                thinking_claude_models = (
-                    "claude-3-7-sonnet",
-                    "claude-sonnet-4",
-                    "claude-opus-4",
-                    "claude-haiku-4",
-                )
                 thinking_params = self.additional_model_request_fields or {}
-                if any(
-                    model in base_model for model in thinking_claude_models
+                if thinking_forced_tool_use_unsupported(
+                    base_model
                 ) and thinking_in_params(thinking_params):
                     self.supports_tool_choice_values = ("auto",)
                 else:
@@ -1337,13 +1332,7 @@ class ChatBedrockConverse(BaseChatModel):
             "langchain_core.exceptions.OutputParserException if tool calls are not "
             "generated. Consider adjusting your prompt to ensure the tool is called."
         )
-        thinking_claude_models = (
-            "claude-3-7-sonnet",
-            "claude-sonnet-4",
-            "claude-opus-4",
-            "claude-haiku-4",
-        )
-        if any(model in self._get_base_model() for model in thinking_claude_models):
+        if thinking_forced_tool_use_unsupported(self._get_base_model()):
             additional_context = (
                 "For Claude 3/4 models, you can also support forced tool use "
                 "by disabling `thinking`."
@@ -1560,14 +1549,8 @@ class ChatBedrockConverse(BaseChatModel):
             tool_choice = "any"
         else:
             tool_choice = None
-        thinking_claude_models = (
-            "claude-3-7-sonnet",
-            "claude-sonnet-4",
-            "claude-opus-4",
-            "claude-haiku-4",
-        )
-        if tool_choice is None and any(
-            model in self._get_base_model() for model in thinking_claude_models
+        if tool_choice is None and thinking_forced_tool_use_unsupported(
+            self._get_base_model()
         ):
             # TODO: remove restriction to thinking Claude models. If a model does not
             # support forced tool calling, we we should raise an exception instead of

--- a/libs/aws/langchain_aws/utils.py
+++ b/libs/aws/langchain_aws/utils.py
@@ -470,6 +470,21 @@ def thinking_in_params(params: dict) -> bool:
     return params.get("thinking", {}).get("type") in ("enabled", "adaptive")
 
 
+def thinking_forced_tool_use_unsupported(model: str) -> bool:
+    """Check if the model rejects forced tool use while thinking is enabled."""
+    if "claude-opus-4-8" in model:
+        return False
+    return any(
+        x in model
+        for x in (
+            "claude-3-7-",
+            "claude-sonnet-4",
+            "claude-opus-4",
+            "claude-haiku-4",
+        )
+    )
+
+
 def trim_message_whitespace(messages: List[Any]) -> List[Any]:
     """Trim trailing whitespace from final AIMessage content."""
     if not messages or not isinstance(messages[-1], AIMessage):

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
@@ -632,6 +632,38 @@ def test_claude_thinking_forced_tool_raises(
         chat.bind_tools([GetWeather], tool_choice=tool_choice)
 
 
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "global.anthropic.claude-opus-4-8",
+        "us.anthropic.claude-sonnet-5",
+        "global.anthropic.claude-fable-5",
+    ],
+)
+@pytest.mark.parametrize(
+    "tool_choice",
+    [
+        "any",
+        "GetWeather",
+        {"type": "tool", "name": "GetWeather"},
+    ],
+)
+@mock.patch("langchain_aws.chat_models.bedrock.create_aws_client")
+def test_claude_5_thinking_forced_tool_allowed(
+    mock_create_aws_client, model_id, tool_choice
+) -> None:
+    mock_create_aws_client.return_value = MagicMock()
+    chat = ChatBedrock(
+        model=model_id,
+        region="us-west-2",
+        model_kwargs={
+            "thinking": {"type": "adaptive"},
+        },
+    )
+    chat_with_tools = chat.bind_tools([GetWeather], tool_choice=tool_choice)
+    assert "tool_choice" in cast(RunnableBinding, chat_with_tools).kwargs
+
+
 @mock.patch("langchain_aws.chat_models.bedrock.create_aws_client")
 def test_claude_thinking_tool_choice_auto_ok(mock_create_aws_client) -> None:
     mock_create_aws_client.return_value = MagicMock()

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -238,6 +238,37 @@ def test_anthropic_adaptive_thinking_bind_tools_tool_choice(
         )
 
 
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "global.anthropic.claude-opus-4-8",
+        "us.anthropic.claude-sonnet-5",
+        "global.anthropic.claude-fable-5",
+    ],
+)
+def test_claude_5_adaptive_thinking_forced_tool_choice_allowed(
+    model_id: str,
+) -> None:
+    chat_model = ChatBedrockConverse(
+        model=model_id,
+        region_name="us-west-2",
+        additional_model_request_fields={
+            "thinking": {"type": "adaptive"},
+        },
+    )
+    assert chat_model.supports_tool_choice_values == ("auto", "any", "tool")
+    chat_model_with_tools = chat_model.bind_tools([GetWeather], tool_choice="any")
+    assert cast(RunnableBinding, chat_model_with_tools).kwargs["tool_choice"] == {
+        "any": {}
+    }
+    chat_model_with_tools = chat_model.bind_tools(
+        [GetWeather], tool_choice="GetWeather"
+    )
+    assert cast(RunnableBinding, chat_model_with_tools).kwargs["tool_choice"] == {
+        "tool": {"name": "GetWeather"}
+    }
+
+
 def test_amazon_bind_tools_tool_choice() -> None:
     chat_model = ChatBedrockConverse(
         model="us.amazon.nova-lite-v1:0", region_name="us-east-1"

--- a/libs/aws/tests/unit_tests/test_utils.py
+++ b/libs/aws/tests/unit_tests/test_utils.py
@@ -11,6 +11,7 @@ from pydantic import SecretStr
 from langchain_aws.utils import (
     count_tokens_api_supported_for_model,
     create_aws_client,
+    thinking_forced_tool_use_unsupported,
     thinking_in_params,
     trim_message_whitespace,
 )
@@ -458,6 +459,28 @@ def test_count_tokens_api_supported_for_model(
     result = count_tokens_api_supported_for_model(model_id)
 
     assert result == expected_result
+
+
+@pytest.mark.parametrize(
+    "model_id,expected_result",
+    [
+        ("anthropic.claude-3-7-sonnet-20250219-v1:0", True),
+        ("us.anthropic.claude-sonnet-4-20250514-v1:0", True),
+        ("us.anthropic.claude-sonnet-4-5-20250929-v1:0", True),
+        ("anthropic.claude-sonnet-4-6", True),
+        ("us.anthropic.claude-opus-4-20250514-v1:0", True),
+        ("anthropic.claude-opus-4-6-v1", True),
+        ("global.anthropic.claude-opus-4-7", True),
+        ("us.anthropic.claude-haiku-4-5-20251001-v1:0", True),
+        ("global.anthropic.claude-opus-4-8", False),
+        ("us.anthropic.claude-sonnet-5", False),
+        ("global.anthropic.claude-fable-5", False),
+    ],
+)
+def test_thinking_forced_tool_use_unsupported(
+    model_id: str, expected_result: bool
+) -> None:
+    assert thinking_forced_tool_use_unsupported(model_id) == expected_result
 
 
 def test_api_key_uses_token_provider(


### PR DESCRIPTION
Follow up from #1140.

Bedrock appears to specifically allow Claude Fable 5, Sonnet 5, and Opus 4.8 to all use adaptive thinking with any forced ToolChoice modes. 

Updating the thinking + forced tool use model block-lists in `ChatBedrock` and `ChatBedrockConverse` to remove the existing restriction on Opus 4.8. 

