### PR TITLE
feat(langgraph-checkpoint-aws): allow deferred flush to skip writes

### DIFF
--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/deferred_saver.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/deferred_saver.py
@@ -99,6 +99,9 @@ class DeferredCheckpointSaver(BaseCheckpointSaver):
             ``SyncBatchFlushable`` or ``AsyncBatchFlushable``, flush uses
             a single ``put_with_writes`` call instead of 1 + N sequential
             calls.  Defaults to ``False`` for backward compatibility.
+        flush_writes: When ``True``, buffered writes are persisted during
+            flush.  Set to ``False`` to persist only the final checkpoint and
+            discard buffered writes on successful flush.
 
     Raises:
         ValueError: If *saver* is itself a ``DeferredCheckpointSaver``
@@ -114,7 +117,11 @@ class DeferredCheckpointSaver(BaseCheckpointSaver):
     """
 
     def __init__(
-        self, saver: BaseCheckpointSaver, *, batch_writes: bool = False
+        self,
+        saver: BaseCheckpointSaver,
+        *,
+        batch_writes: bool = False,
+        flush_writes: bool = True,
     ) -> None:
         if isinstance(saver, DeferredCheckpointSaver):
             msg = (
@@ -125,6 +132,7 @@ class DeferredCheckpointSaver(BaseCheckpointSaver):
         super().__init__()
         self._saver = saver
         self._batch_writes = batch_writes
+        self._flush_writes = flush_writes
         self._lock = threading.Lock()
         self._pending_checkpoint: _PendingCheckpoint | None = None
         self._pending_writes: list[_PendingWrite] = []
@@ -471,20 +479,24 @@ class DeferredCheckpointSaver(BaseCheckpointSaver):
             self._pending_writes.clear()
 
         if pending_cp is None:
-            if pending_writes:
+            if pending_writes and self._flush_writes:
                 with self._lock:
                     self._pending_writes = pending_writes + self._pending_writes
             return None
 
-        public_writes = [
-            PendingWrite(
-                config=w.config,
-                writes=w.writes,
-                task_id=w.task_id,
-                task_path=w.task_path,
-            )
-            for w in pending_writes
-        ]
+        public_writes = (
+            [
+                PendingWrite(
+                    config=w.config,
+                    writes=w.writes,
+                    task_id=w.task_id,
+                    task_path=w.task_path,
+                )
+                for w in pending_writes
+            ]
+            if self._flush_writes
+            else []
+        )
 
         try:
             result_config = self._saver.put_with_writes(  # type: ignore[attr-defined]
@@ -539,6 +551,11 @@ class DeferredCheckpointSaver(BaseCheckpointSaver):
                     if self._pending_checkpoint is None:
                         self._pending_checkpoint = pending_cp
                 raise
+
+        if not self._flush_writes:
+            with self._lock:
+                self._pending_writes.clear()
+            return result_config
 
         # --- Flush writes one at a time ---
         # Unlike the checkpoint, writes use a peek-then-pop pattern: we
@@ -597,20 +614,24 @@ class DeferredCheckpointSaver(BaseCheckpointSaver):
             self._pending_writes.clear()
 
         if pending_cp is None:
-            if pending_writes:
+            if pending_writes and self._flush_writes:
                 with self._lock:
                     self._pending_writes = pending_writes + self._pending_writes
             return None
 
-        public_writes = [
-            PendingWrite(
-                config=w.config,
-                writes=w.writes,
-                task_id=w.task_id,
-                task_path=w.task_path,
-            )
-            for w in pending_writes
-        ]
+        public_writes = (
+            [
+                PendingWrite(
+                    config=w.config,
+                    writes=w.writes,
+                    task_id=w.task_id,
+                    task_path=w.task_path,
+                )
+                for w in pending_writes
+            ]
+            if self._flush_writes
+            else []
+        )
 
         try:
             result_config = await self._saver.aput_with_writes(  # type: ignore[attr-defined]
@@ -659,6 +680,11 @@ class DeferredCheckpointSaver(BaseCheckpointSaver):
                     if self._pending_checkpoint is None:
                         self._pending_checkpoint = pending_cp
                 raise
+
+        if not self._flush_writes:
+            with self._lock:
+                self._pending_writes.clear()
+            return result_config
 
         # --- Flush writes one at a time ---
         while True:

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/test_batch_flush.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/test_batch_flush.py
@@ -145,6 +145,51 @@ class TestBatchFlushFastPath:
         payload = mock_boto_client.create_event.call_args[1]["payload"]
         assert len(payload) == 2
 
+    def test_flush_writes_false_fast_path_skips_writes(
+        self, agentcore_saver, mock_boto_client
+    ) -> None:
+        """Batch flush can persist only the checkpoint and discard pending writes."""
+        deferred = DeferredCheckpointSaver(
+            agentcore_saver, batch_writes=True, flush_writes=False
+        )
+        config = _make_config()
+
+        new_versions: ChannelVersions = {"messages": "v1"}
+        deferred.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), new_versions)
+        write_config = _make_config(checkpoint_id="ckpt-1")
+        deferred.put_writes(write_config, [("ch1", "v1")], "task-1")
+        deferred.put_writes(write_config, [("ch2", "v2")], "task-2")
+
+        result = deferred.flush()
+
+        assert deferred.is_empty
+        assert result is not None
+        mock_boto_client.create_event.assert_called_once()
+        # 1 channel + 1 checkpoint, no writes events
+        payload = mock_boto_client.create_event.call_args[1]["payload"]
+        assert len(payload) == 2
+
+    def test_flush_writes_false_fast_path_failure_restores_writes(
+        self, agentcore_saver, mock_boto_client
+    ) -> None:
+        deferred = DeferredCheckpointSaver(
+            agentcore_saver, batch_writes=True, flush_writes=False
+        )
+        config = _make_config()
+
+        new_versions: ChannelVersions = {"messages": "v1"}
+        deferred.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), new_versions)
+        write_config = _make_config(checkpoint_id="ckpt-1")
+        deferred.put_writes(write_config, [("ch1", "v1")], "task-1")
+
+        mock_boto_client.create_event.side_effect = RuntimeError("network error")
+
+        with pytest.raises(RuntimeError, match="network error"):
+            deferred.flush()
+
+        assert deferred.has_buffered_checkpoint
+        assert deferred.has_buffered_writes
+
     def test_flush_fast_path_multiple_channels_and_writes(
         self, agentcore_saver, mock_boto_client
     ) -> None:
@@ -304,6 +349,28 @@ class TestBatchFlushAsync:
         assert result is not None
         # Single API call for the batch
         mock_boto_client.create_event.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_aflush_writes_false_fast_path_skips_writes(
+        self, agentcore_saver, mock_boto_client
+    ) -> None:
+        deferred = DeferredCheckpointSaver(
+            agentcore_saver, batch_writes=True, flush_writes=False
+        )
+        config = _make_config()
+
+        new_versions: ChannelVersions = {"messages": "v1"}
+        deferred.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), new_versions)
+        write_config = _make_config(checkpoint_id="ckpt-1")
+        deferred.put_writes(write_config, [("ch1", "v1")], "task-1")
+
+        result = await deferred.aflush()
+
+        assert deferred.is_empty
+        assert result is not None
+        mock_boto_client.create_event.assert_called_once()
+        payload = mock_boto_client.create_event.call_args[1]["payload"]
+        assert len(payload) == 2
 
     @pytest.mark.asyncio
     async def test_aflush_fast_path_failure_restores_all(

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/test_deferred_saver.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/test_deferred_saver.py
@@ -74,6 +74,18 @@ class TestInit:
         assert not buffered.has_buffered_checkpoint
         assert not buffered.has_buffered_writes
 
+    def test_flush_writes_defaults_to_true(self, memory_saver: MemorySaver) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver)
+        config = _make_config(thread_id="t1")
+        buffered.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), {})
+        write_config = _make_config(thread_id="t1", checkpoint_id="ckpt-1")
+        buffered.put_writes(write_config, [("ch1", "v1")], "task-1")
+
+        with patch.object(memory_saver, "put_writes") as mock_put_writes:
+            buffered.flush()
+
+        mock_put_writes.assert_called_once()
+
 
 class TestBuffering:
     """put() and put_writes() buffer correctly."""
@@ -258,6 +270,24 @@ class TestFlush:
         assert buffered.is_empty
         assert not buffered.has_buffered_writes
 
+    def test_flush_writes_false_skips_and_clears_writes(
+        self, memory_saver: MemorySaver
+    ) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver, flush_writes=False)
+        config = _make_config(thread_id="t1")
+        buffered.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), {})
+        write_config = _make_config(thread_id="t1", checkpoint_id="ckpt-1")
+        buffered.put_writes(write_config, [("ch1", "v1")], "task-1")
+        buffered.put_writes(write_config, [("ch2", "v2")], "task-2")
+
+        with patch.object(memory_saver, "put_writes") as mock_put_writes:
+            result = buffered.flush()
+
+        assert result is not None
+        assert result["configurable"]["checkpoint_id"] == "ckpt-1"
+        assert buffered.is_empty
+        mock_put_writes.assert_not_called()
+
     def test_flush_returns_none_when_empty(self, memory_saver: MemorySaver) -> None:
         buffered = DeferredCheckpointSaver(memory_saver)
         result = buffered.flush()
@@ -278,6 +308,24 @@ class TestFlush:
                 buffered.flush()
 
         assert buffered.has_buffered_checkpoint
+
+    def test_flush_writes_false_checkpoint_failure_keeps_writes(
+        self, memory_saver: MemorySaver
+    ) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver, flush_writes=False)
+        config = _make_config(thread_id="t1")
+        buffered.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), {})
+        write_config = _make_config(thread_id="t1", checkpoint_id="ckpt-1")
+        buffered.put_writes(write_config, [("ch1", "v1")], "task-1")
+
+        with patch.object(
+            memory_saver, "put", side_effect=RuntimeError("network error")
+        ):
+            with pytest.raises(RuntimeError, match="network error"):
+                buffered.flush()
+
+        assert buffered.has_buffered_checkpoint
+        assert buffered.has_buffered_writes
 
     def test_flush_failure_does_not_clobber_new_checkpoint(
         self, memory_saver: MemorySaver
@@ -342,6 +390,20 @@ class TestFlush:
         result = buffered.flush()
         assert result is None
         assert buffered.is_empty
+
+    def test_flush_writes_false_only_writes_clears_without_persisting(
+        self, memory_saver: MemorySaver
+    ) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver, flush_writes=False)
+        write_config = _make_config(thread_id="t1", checkpoint_id="ckpt-1")
+        buffered.put_writes(write_config, [("ch1", "v1")], "task-1")
+
+        with patch.object(memory_saver, "put_writes") as mock_put_writes:
+            result = buffered.flush()
+
+        assert result is None
+        assert buffered.is_empty
+        mock_put_writes.assert_not_called()
 
 
 class TestContextManagers:
@@ -1040,6 +1102,28 @@ class TestConcurrentFlush:
 
 class TestAsyncFlushWriteFailure:
     """aflush() partial write failure must keep remaining writes in buffer."""
+
+    @pytest.mark.asyncio
+    async def test_aflush_writes_false_skips_and_clears_writes(
+        self, memory_saver: MemorySaver
+    ) -> None:
+        buffered = DeferredCheckpointSaver(memory_saver, flush_writes=False)
+        config = _make_config(thread_id="t1")
+        buffered.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), {})
+        write_config = _make_config(thread_id="t1", checkpoint_id="ckpt-1")
+        buffered.put_writes(write_config, [("ch1", "v1")], "task-1")
+
+        with patch.object(
+            memory_saver,
+            "aput_writes",
+            new_callable=AsyncMock,
+        ) as mock_aput_writes:
+            result = await buffered.aflush()
+
+        assert result is not None
+        assert result["configurable"]["checkpoint_id"] == "ckpt-1"
+        assert buffered.is_empty
+        mock_aput_writes.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_aflush_write_failure_keeps_remaining(


### PR DESCRIPTION
## Summary

Fixes #1015.

Adds an opt-in `flush_writes=False` option to `DeferredCheckpointSaver`. When disabled, `flush()` and `aflush()` persist the final checkpoint but discard buffered intermediate writes, avoiding the extra `put_writes()` calls for applications that only need final checkpoint state.

Default behavior is unchanged: buffered writes are still flushed unless users explicitly pass `flush_writes=False`.

## Why

`DeferredCheckpointSaver` already avoids writes during graph execution, but the default flush path still replays buffered writes. For request/response agents that only need session continuity from the final checkpoint, those intermediate writes add latency without being required for recovery.

## Implementation notes

- Adds kw-only `flush_writes: bool = True`.
- Applies the option to sync and async flush paths.
- Applies the option to sequential fallback and batch fast paths.
- Preserves failure restore behavior so buffered writes are not discarded if checkpoint persistence fails.
- Leaves backend savers unchanged.

## Testing

- `.venv/bin/python -m pytest tests/unit_tests/test_deferred_saver.py -q`
- `.venv/bin/python -m pytest tests/unit_tests/test_batch_flush.py -q`
- `.venv/bin/ruff check langgraph_checkpoint_aws/checkpoint/deferred_saver.py tests/unit_tests/test_deferred_saver.py tests/unit_tests/test_batch_flush.py`
- `.venv/bin/python -m py_compile langgraph_checkpoint_aws/checkpoint/deferred_saver.py tests/unit_tests/test_deferred_saver.py tests/unit_tests/test_batch_flush.py`
- `git diff --check`
- `uv run --group test pytest tests/unit_tests/test_deferred_saver.py tests/unit_tests/test_batch_flush.py -q`

## Areas for review

- Semantics of `flush_writes=False` for only-writes/no-checkpoint buffers.
- Batch fast path behavior: it still uses `put_with_writes`, but passes an empty pending writes list.