### PR TITLE
fix(aws): Auto-downgrade ToolChoice to auto when adaptive thinking is unsupported with forced tools

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -1361,13 +1361,6 @@ class ChatBedrockConverse(BaseChatModel):
 
     # TODO: Add async support once there are async bedrock.converse methods.
 
-    def _is_thinking_enabled(self) -> bool:
-        """Check if extended thinking is enabled via additional_model_request_fields."""
-        thinking_params = (self.additional_model_request_fields or {}).get(
-            "thinking", {}
-        )
-        return thinking_params.get("type") == "enabled"
-
     def _resolve_tool_choice(
         self,
         tool_choice: Optional[Union[dict, str]],
@@ -1402,7 +1395,10 @@ class ChatBedrockConverse(BaseChatModel):
             return formatted
 
         # Thinking-enabled models: downgrade to auto instead of failing.
-        if self._is_thinking_enabled() and "auto" in supported:
+        if (
+            thinking_in_params(self.additional_model_request_fields or {})
+            and "auto" in supported
+        ):
             warnings.warn(
                 f"tool_choice={tool_choice!r} is not supported when thinking "
                 f"is enabled. Downgrading to tool_choice='auto'. The model "

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -228,14 +228,14 @@ def test_anthropic_adaptive_thinking_bind_tools_tool_choice(
     assert cast(RunnableBinding, chat_model_with_tools).kwargs["tool_choice"] == {
         "auto": {}
     }
-    with pytest.raises(ValueError):
-        chat_model.bind_tools([GetWeather], tool_choice="any")
-    with pytest.raises(ValueError):
-        chat_model.bind_tools([GetWeather], tool_choice="GetWeather")
-    with pytest.raises(ValueError):
-        chat_model.bind_tools(
-            [GetWeather], tool_choice={"tool": {"name": "GetWeather"}}
-        )
+    for tool_choice in ("any", "GetWeather", {"tool": {"name": "GetWeather"}}):
+        with pytest.warns(UserWarning, match="Downgrading to tool_choice='auto'"):
+            chat_model_with_tools = chat_model.bind_tools(
+                [GetWeather], tool_choice=tool_choice
+            )
+        assert cast(RunnableBinding, chat_model_with_tools).kwargs["tool_choice"] == {
+            "auto": {}
+        }
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes: #1150 

Adaptive thinking models that reject forced tool use (Claude ≤4.7) now get the same warn-and-downgrade to `tool_choice="auto"` that was already present for older models with manual extended thinking (i.e. `thinking.type: "enabled"`), instead of raising a hard ValueError.

Also cleaned up the redundant/responsible `is_thinking_enabled()` helper in ChatBedrockConverse in favor of the shared `thinking_in_params()` util, which should be better for maintainability.