### PR TITLE
fix(langgraph-checkpoint-aws): resolve actor_id for nested subgraph get_state (#733)

### DIFF
--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/agentcore/models.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/agentcore/models.py
@@ -48,13 +48,16 @@ class CheckpointerConfig(BaseModel):
             config: RunnableConfig whose ``configurable`` dict supplies
                 ``thread_id`` and (normally) ``actor_id``.
             default_actor_id: Fallback actor id used only when ``config`` omits
-                ``actor_id`` (e.g. a derived subgraph config). Not yet honored.
+                ``actor_id``. Lets a derived subgraph config, which carries
+                ``thread_id`` but not ``actor_id``, inherit the actor from the
+                saver instead of failing.
 
         Returns:
             The parsed CheckpointerConfig.
 
         Raises:
-            InvalidConfigError: If ``thread_id`` or ``actor_id`` is missing.
+            InvalidConfigError: If ``thread_id`` is missing, or if ``actor_id`` is
+                missing and no fallback resolves it.
         """
         from .constants import InvalidConfigError
 
@@ -65,15 +68,15 @@ class CheckpointerConfig(BaseModel):
                 "RunnableConfig must contain 'thread_id' for AgentCore Checkpointer"
             )
 
-        # TODO(#733): resolve a missing actor_id from default_actor_id.
-        if not configurable.get("actor_id"):
+        actor_id = configurable.get("actor_id") or default_actor_id
+        if not actor_id:
             raise InvalidConfigError(
                 "RunnableConfig must contain 'actor_id' for AgentCore Checkpointer"
             )
 
         return cls(
             thread_id=configurable["thread_id"],
-            actor_id=configurable["actor_id"],
+            actor_id=actor_id,
             checkpoint_ns=configurable.get("checkpoint_ns", ""),
             checkpoint_id=configurable.get("checkpoint_id"),
         )

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/agentcore/models.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/agentcore/models.py
@@ -39,8 +39,23 @@ class CheckpointerConfig(BaseModel):
         return self.thread_id
 
     @classmethod
-    def from_runnable_config(cls, config: dict[str, Any]) -> "CheckpointerConfig":
-        """Create CheckpointerConfig from RunnableConfig."""
+    def from_runnable_config(
+        cls, config: dict[str, Any], *, default_actor_id: str | None = None
+    ) -> "CheckpointerConfig":
+        """Create a CheckpointerConfig from a RunnableConfig.
+
+        Args:
+            config: RunnableConfig whose ``configurable`` dict supplies
+                ``thread_id`` and (normally) ``actor_id``.
+            default_actor_id: Fallback actor id used only when ``config`` omits
+                ``actor_id`` (e.g. a derived subgraph config). Not yet honored.
+
+        Returns:
+            The parsed CheckpointerConfig.
+
+        Raises:
+            InvalidConfigError: If ``thread_id`` or ``actor_id`` is missing.
+        """
         from .constants import InvalidConfigError
 
         configurable = config.get("configurable", {})
@@ -50,6 +65,7 @@ class CheckpointerConfig(BaseModel):
                 "RunnableConfig must contain 'thread_id' for AgentCore Checkpointer"
             )
 
+        # TODO(#733): resolve a missing actor_id from default_actor_id.
         if not configurable.get("actor_id"):
             raise InvalidConfigError(
                 "RunnableConfig must contain 'actor_id' for AgentCore Checkpointer"

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/agentcore/saver.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/agentcore/saver.py
@@ -4,7 +4,6 @@ AgentCore Memory Checkpoint Saver implementation.
 
 from __future__ import annotations
 
-import asyncio
 import random
 from collections.abc import AsyncIterator, Iterator, Sequence
 from contextvars import ContextVar
@@ -60,6 +59,29 @@ class AgentCoreMemorySaver(BaseCheckpointSaver[str]):
 
     This saver persists Checkpoints as serialized blob events in AgentCore Memory.
 
+    Every read and write requires an ``actor_id`` in the config's ``configurable``.
+    The one exception is a *subgraph* read: LangGraph's derived subgraph configs
+    (built during ``get_state(subgraphs=True)``) omit ``actor_id`` but carry a
+    non-empty ``checkpoint_ns``. Such a read inherits the ``actor_id`` captured —
+    for the same ``thread_id`` — from the current request's parent read. That
+    capture is request-scoped (a ``ContextVar`` isolated per thread / async task),
+    never stored on the saver, so a single saver instance can safely serve many
+    actors concurrently. Top-level reads (empty ``checkpoint_ns``) never inherit,
+    and writes never inherit; both always require an explicit ``actor_id``.
+
+    !!! warning "Thread-reusing synchronous servers"
+        The request-scoped capture is not reset at the end of a request. Under
+        asyncio each task runs in its own copied context, so requests do not
+        share captures. But a purely synchronous server that reuses an OS thread
+        across sequential requests keeps the last ``(thread_id, actor_id)`` in
+        that thread's context. Inheritance is gated on both a matching
+        ``thread_id`` and a non-empty ``checkpoint_ns``, so a stale capture can
+        only be picked up by a later *subgraph-shaped* read for the same
+        ``thread_id`` that is not first re-primed by its parent read — a very
+        narrow case that also requires reused (non-unique) thread ids across
+        actors. Use globally unique thread ids (or always pass ``actor_id`` on
+        reads) to avoid it.
+
     Args:
         memory_id: the ID of the memory resource created in AgentCore Memory
         serde: serialization protocol to be used. Defaults to JSONPlusSerializer
@@ -101,17 +123,46 @@ class AgentCoreMemorySaver(BaseCheckpointSaver[str]):
     def _resolve_actor_id(self, config: RunnableConfig | None) -> str | None:
         """Resolve the actor id for a read, scoped to the current request.
 
-        Will capture the (thread_id, actor_id) pair when present and let a later
-        derived subgraph read (which omits actor_id) inherit it. Not yet
-        implemented; returns ``None`` so behavior is unchanged for now.
+        When ``config`` supplies both ``thread_id`` and ``actor_id``, record the
+        pair for the current request context so a later read of a derived subgraph
+        config (which omits ``actor_id``) can inherit it. When ``config`` omits
+        ``actor_id``, fall back to the recorded actor only if it was captured for
+        the same ``thread_id`` **and** the current read is a derived subgraph read
+        (identified by a non-empty ``checkpoint_ns``); otherwise return ``None`` so
+        the caller fails closed.
+
+        Restricting inheritance to non-empty ``checkpoint_ns`` reads is what makes
+        this safe: LangGraph only omits ``actor_id`` on the per-subgraph configs it
+        derives during ``get_state(subgraphs=True)``, and those always carry a
+        non-empty namespace. A top-level read has an empty ``checkpoint_ns``, so an
+        actor-less top-level read (only possible if a caller omits ``actor_id``)
+        fails closed instead of inheriting a possibly stale actor.
+
+        The capture lives in a request-scoped ``ContextVar`` rather than on the
+        saver instance, so a shared multi-tenant saver never resolves a subgraph
+        read to another request's actor.
 
         Args:
             config: RunnableConfig for the current read.
 
         Returns:
-            The resolved actor id, or ``None``.
+            The resolved actor id, or ``None`` if it cannot be resolved from the
+            config or the current request context.
         """
-        # TODO(#733): capture on read and resolve for subgraph reads.
+        configurable = config.get("configurable", {}) if config else {}
+        thread_id = configurable.get("thread_id")
+        actor_id = configurable.get("actor_id")
+        if actor_id:
+            if thread_id:  # only record when we can key the capture by thread
+                _request_actor.set((thread_id, actor_id))
+            return actor_id
+        # Only derived subgraph reads (non-empty checkpoint_ns) may inherit; a
+        # top-level read (empty checkpoint_ns) must carry its own actor_id.
+        if not configurable.get("checkpoint_ns"):
+            return None
+        recorded = _request_actor.get()
+        if recorded is not None and thread_id is not None and recorded[0] == thread_id:
+            return recorded[1]  # returns actor ID as it is the 2nd element in the tuple
         return None
 
     def get_tuple(
@@ -434,6 +485,9 @@ class AgentCoreMemorySaver(BaseCheckpointSaver[str]):
 
     # ===== Async methods ( Running sync methods inside executor ) =====
     async def aget_tuple(self, config: RunnableConfig) -> CheckpointTuple | None:
+        # Capture the actor in the async context so a later async subgraph read
+        # inherits it; run_in_executor copies this context into the worker thread.
+        self._resolve_actor_id(config)
         return await run_in_executor(None, self.get_tuple, config)
 
     async def alist(
@@ -444,12 +498,14 @@ class AgentCoreMemorySaver(BaseCheckpointSaver[str]):
         before: RunnableConfig | None = None,
         limit: int | None = None,
     ) -> AsyncIterator[CheckpointTuple]:
-        loop = asyncio.get_running_loop()
+        # Capture the actor in the async context so a later async subgraph read
+        # inherits it; run_in_executor copies this context into the worker thread.
+        self._resolve_actor_id(config)
 
-        def _sync_list():
+        def _sync_list() -> list[CheckpointTuple]:
             return list(self.list(config, filter=filter, before=before, limit=limit))
 
-        items = await loop.run_in_executor(None, _sync_list)
+        items = await run_in_executor(None, _sync_list)
         for item in items:
             yield item
 

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/agentcore/saver.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/agentcore/saver.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import asyncio
 import random
 from collections.abc import AsyncIterator, Iterator, Sequence
+from contextvars import ContextVar
 from typing import Any, TypeAlias, cast
 
 from langchain_core.runnables import RunnableConfig, run_in_executor
@@ -44,6 +45,13 @@ from .models import (
 )
 
 RunnableConfigDict: TypeAlias = dict[str, Any]
+
+# Request-scoped (thread/async-task isolated) capture of the (thread_id, actor_id)
+# seen on a read. Lets nested subgraph reads, whose derived config omits actor_id,
+# inherit the actor from the current request's parent read instead of failing.
+_request_actor: ContextVar[tuple[str, str] | None] = ContextVar(
+    "_agentcore_request_actor", default=None
+)
 
 
 class AgentCoreMemorySaver(BaseCheckpointSaver[str]):
@@ -90,6 +98,22 @@ class AgentCoreMemorySaver(BaseCheckpointSaver[str]):
         )
         self.processor = EventProcessor()
 
+    def _resolve_actor_id(self, config: RunnableConfig | None) -> str | None:
+        """Resolve the actor id for a read, scoped to the current request.
+
+        Will capture the (thread_id, actor_id) pair when present and let a later
+        derived subgraph read (which omits actor_id) inherit it. Not yet
+        implemented; returns ``None`` so behavior is unchanged for now.
+
+        Args:
+            config: RunnableConfig for the current read.
+
+        Returns:
+            The resolved actor id, or ``None``.
+        """
+        # TODO(#733): capture on read and resolve for subgraph reads.
+        return None
+
     def get_tuple(
         self,
         config: RunnableConfig,
@@ -106,7 +130,8 @@ class AgentCoreMemorySaver(BaseCheckpointSaver[str]):
         # TODO: There is room for caching here on the client side
 
         checkpoint_config = CheckpointerConfig.from_runnable_config(
-            RunnableConfigDict(config)
+            RunnableConfigDict(config),
+            default_actor_id=self._resolve_actor_id(config),
         )
 
         events = self.checkpoint_event_client.get_events(
@@ -151,7 +176,8 @@ class AgentCoreMemorySaver(BaseCheckpointSaver[str]):
         # TODO: There is room for caching here on the client side
 
         checkpoint_config = CheckpointerConfig.from_runnable_config(
-            RunnableConfigDict(config) if config else {}
+            RunnableConfigDict(config) if config else {},
+            default_actor_id=self._resolve_actor_id(config),
         )
         config_checkpoint_id = get_checkpoint_id(config) if config else None
 

--- a/libs/langgraph-checkpoint-aws/tests/integration_tests/agentcore/test_saver.py
+++ b/libs/langgraph-checkpoint-aws/tests/integration_tests/agentcore/test_saver.py
@@ -2,15 +2,52 @@ import datetime
 import os
 import random
 import string
-from typing import Literal
+from typing import Literal, TypedDict
 
 import pytest
 from langchain.agents import create_agent
 from langchain_aws import ChatBedrock
 from langchain_core.tools import tool
 from langgraph.checkpoint.base import Checkpoint, uuid6
+from langgraph.graph import END, START, StateGraph
+from langgraph.types import interrupt
 
 from langgraph_checkpoint_aws.checkpoint.agentcore.saver import AgentCoreMemorySaver
+
+
+class _SubgraphState(TypedDict):
+    value: int
+
+
+def _build_nested_graph(checkpointer, *, subgraph_levels: int):
+    """Compile a parent graph containing ``subgraph_levels`` nested subgraphs.
+
+    The innermost subgraph node interrupts, so after invoking, the parent and
+    every nested subgraph hold persisted state. ``get_state(subgraphs=True)``
+    then walks into each subgraph with a derived config that omits ``actor_id``,
+    which is the exact path that regressed in issue #733.
+
+    LangGraph does not provide a prebuilt nested graph, so (as in the other
+    checkpointer integration tests) it is assembled here with ``StateGraph``.
+    """
+
+    def increment(state: _SubgraphState) -> _SubgraphState:
+        interrupt("pause inside subgraph")
+        return {"value": state["value"] + 1}
+
+    def single_node_graph(node):
+        builder = StateGraph(_SubgraphState)
+        builder.add_node("node", node)
+        builder.add_edge(START, "node")
+        builder.add_edge("node", END)
+        return builder
+
+    # Deepest (interrupting) subgraph, then wrap it into progressively higher
+    # subgraph levels; the parent finally wraps the stack with the checkpointer.
+    node: object = single_node_graph(increment).compile()
+    for _ in range(subgraph_levels - 1):
+        node = single_node_graph(node).compile()
+    return single_node_graph(node).compile(checkpointer=checkpointer)
 
 
 def generate_valid_session_id():
@@ -308,3 +345,74 @@ class TestAgentCoreMemorySaver:
 
         finally:
             memory_saver.delete_thread(thread_id, actor_id)
+
+    def test_get_state_with_subgraphs_resolves_actor_id(self, memory_saver):
+        """get_state(subgraphs=True) works on a nested graph (issue #733)."""
+        thread_id = generate_valid_session_id()
+        actor_id = generate_valid_actor_id()
+        config = {"configurable": {"thread_id": thread_id, "actor_id": actor_id}}
+
+        try:
+            graph = _build_nested_graph(memory_saver, subgraph_levels=1)
+            # Runs until the subgraph interrupts, persisting parent + subgraph state.
+            graph.invoke({"value": 0}, config)
+
+            # The derived subgraph config drops actor_id; pre-fix this raised
+            # InvalidConfigError. It must now resolve the actor from the parent
+            # read and return the nested state.
+            state = graph.get_state(config, subgraphs=True)
+
+            assert state.tasks, "expected a pending subgraph task"
+            subgraph_state = state.tasks[0].state
+            assert subgraph_state is not None
+            assert "value" in subgraph_state.values
+
+        finally:
+            memory_saver.delete_thread(thread_id, actor_id)
+
+    def test_get_state_with_deeply_nested_subgraphs_resolves_actor_id(
+        self, memory_saver
+    ):
+        """get_state(subgraphs=True) works across 3 nested subgraph levels."""
+        thread_id = generate_valid_session_id()
+        actor_id = generate_valid_actor_id()
+        config = {"configurable": {"thread_id": thread_id, "actor_id": actor_id}}
+
+        try:
+            graph = _build_nested_graph(memory_saver, subgraph_levels=3)
+            graph.invoke({"value": 0}, config)
+
+            # Walk all three nested levels; each derived config omits actor_id and
+            # must resolve it from the request rather than raising.
+            state = graph.get_state(config, subgraphs=True)
+            level_1 = state.tasks[0].state
+            level_2 = level_1.tasks[0].state
+            level_3 = level_2.tasks[0].state
+
+            assert level_3 is not None
+            assert "value" in level_3.values
+
+        finally:
+            memory_saver.delete_thread(thread_id, actor_id)
+
+    async def test_aget_state_with_subgraphs_resolves_actor_id(self, memory_saver):
+        """aget_state(subgraphs=True) resolves the actor across the executor hop."""
+        thread_id = generate_valid_session_id()
+        actor_id = generate_valid_actor_id()
+        config = {"configurable": {"thread_id": thread_id, "actor_id": actor_id}}
+
+        try:
+            graph = _build_nested_graph(memory_saver, subgraph_levels=1)
+            await graph.ainvoke({"value": 0}, config)
+
+            # Exercises the async path: the actor captured on the event loop must
+            # be copied into the executor thread that runs the sync get_tuple.
+            state = await graph.aget_state(config, subgraphs=True)
+
+            assert state.tasks, "expected a pending subgraph task"
+            subgraph_state = state.tasks[0].state
+            assert subgraph_state is not None
+            assert "value" in subgraph_state.values
+
+        finally:
+            await memory_saver.adelete_thread(thread_id, actor_id)

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_saver.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_saver.py
@@ -1081,6 +1081,40 @@ class TestCheckpointerConfig:
 
         assert "actor_id" in str(exc_info.value)
 
+    def test_from_runnable_config_resolves_default_actor_id(self):
+        """A config with thread_id but no actor_id resolves the fallback."""
+        config = RunnableConfig(configurable={"thread_id": "test_thread"})
+
+        checkpoint_config = CheckpointerConfig.from_runnable_config(
+            config, default_actor_id="test_actor"
+        )
+
+        assert checkpoint_config.actor_id == "test_actor"
+        assert checkpoint_config.thread_id == "test_thread"
+
+    def test_config_actor_id_takes_precedence_over_default(self):
+        """An explicit config actor_id wins over the fallback."""
+        config = RunnableConfig(
+            configurable={"thread_id": "test_thread", "actor_id": "test_actor"}
+        )
+
+        checkpoint_config = CheckpointerConfig.from_runnable_config(
+            config, default_actor_id="fallback_actor"
+        )
+
+        assert checkpoint_config.actor_id == "test_actor"
+
+    def test_missing_thread_id_checked_before_actor_id(self):
+        """thread_id is validated before actor_id when both are missing."""
+        config = RunnableConfig(configurable={})
+
+        with pytest.raises(InvalidConfigError) as exc_info:
+            CheckpointerConfig.from_runnable_config(config)
+
+        message = str(exc_info.value)
+        assert "thread_id" in message
+        assert "actor_id" not in message
+
 
 class TestEventSerializer:
     """Test suite for EventSerializer."""

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_saver.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_saver.py
@@ -5,8 +5,10 @@ Unit tests for AgentCore Memory Checkpoint Saver.
 import asyncio
 import hashlib
 import json
+import threading
 import time
 from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import ANY, MagicMock, Mock, call, patch
 
 import pytest
@@ -131,6 +133,16 @@ class TestAgentCoreMemorySaver:
         with patch("boto3.client") as mock_boto3_client:
             mock_boto3_client.return_value = mock_boto_client
             yield AgentCoreMemorySaver(memory_id=memory_id)
+
+    @pytest.fixture(autouse=True)
+    def _reset_request_actor(self):
+        from langgraph_checkpoint_aws.checkpoint.agentcore.saver import _request_actor
+
+        token = _request_actor.set(None)  # Clean slate + remember prior value
+        try:
+            yield  # Unit tests execute here
+        finally:
+            _request_actor.reset(token)
 
     @pytest.fixture
     def runnable_config(self):
@@ -367,6 +379,353 @@ class TestAgentCoreMemorySaver:
         result = saver.get_tuple(runnable_config)
 
         assert result is None
+
+    def test_get_tuple_resolves_fallback_actor_id(
+        self,
+        saver,
+        mock_boto_client,
+        sample_checkpoint_event,
+    ):
+        """A subgraph read inherits the actor_id captured by the parent read."""
+        mock_boto_client.list_events.return_value = {
+            "events": [
+                {
+                    "eventId": "event_1",
+                    "payload": [
+                        {
+                            "blob": saver.serializer.serialize_event(
+                                sample_checkpoint_event
+                            )
+                        }
+                    ],
+                }
+            ]
+        }
+
+        # Parent read primes the request context with (thread_id, actor_id).
+        saver.get_tuple(
+            RunnableConfig(
+                configurable={
+                    "thread_id": "test_thread_id",
+                    "actor_id": "test_actor_id",
+                }
+            )
+        )
+        # Derived subgraph read carries a namespace but omits actor_id, and
+        # inherits the actor from the request.
+        subgraph_config = RunnableConfig(
+            configurable={"thread_id": "test_thread_id", "checkpoint_ns": "sub"}
+        )
+        result = saver.get_tuple(subgraph_config)
+
+        assert isinstance(result, CheckpointTuple)
+        # "test_actor_id" is not stored on the saver; it is the actor captured
+        # for the current request by the parent read above (request-scoped
+        # ContextVar), which the subgraph read inherits because the thread_id
+        # matches.
+        assert result.config["configurable"]["actor_id"] == "test_actor_id"
+        mock_boto_client.list_events.assert_called()
+        assert (
+            mock_boto_client.list_events.call_args.kwargs["actorId"] == "test_actor_id"
+        )
+
+    def test_get_tuple_resolves_fallback_for_deeply_nested_subgraphs(
+        self,
+        saver,
+        mock_boto_client,
+        sample_checkpoint_event,
+    ):
+        """Each of three nested subgraph reads inherits the captured actor_id."""
+        mock_boto_client.list_events.return_value = {
+            "events": [
+                {
+                    "eventId": "event_1",
+                    "payload": [
+                        {
+                            "blob": saver.serializer.serialize_event(
+                                sample_checkpoint_event
+                            )
+                        }
+                    ],
+                }
+            ]
+        }
+
+        # Parent read primes the request context once.
+        saver.get_tuple(
+            RunnableConfig(
+                configurable={
+                    "thread_id": "test_thread_id",
+                    "actor_id": "test_actor_id",
+                }
+            )
+        )
+
+        nested_configs = [
+            RunnableConfig(
+                configurable={"thread_id": "test_thread_id", "checkpoint_ns": "lvl1"}
+            ),
+            RunnableConfig(
+                configurable={"thread_id": "test_thread_id", "checkpoint_ns": "sub"}
+            ),
+            RunnableConfig(
+                configurable={
+                    "thread_id": "test_thread_id",
+                    "checkpoint_ns": "sub:subsub",
+                }
+            ),
+        ]
+
+        for config in nested_configs:
+            result = saver.get_tuple(config)
+            assert isinstance(result, CheckpointTuple)
+            assert result.config["configurable"]["actor_id"] == "test_actor_id"
+
+    def test_get_tuple_session_mismatch_does_not_leak(
+        self,
+        saver,
+        mock_boto_client,
+        sample_checkpoint_event,
+    ):
+        """A read for a different thread_id never inherits another thread's actor."""
+        mock_boto_client.list_events.return_value = {
+            "events": [
+                {
+                    "eventId": "event_1",
+                    "payload": [
+                        {
+                            "blob": saver.serializer.serialize_event(
+                                sample_checkpoint_event
+                            )
+                        }
+                    ],
+                }
+            ]
+        }
+
+        # Prime: a normal read carrying an actor_id makes the saver remember the
+        # pair ("test_thread_id", "test_actor_id") for the current request.
+        saver.get_tuple(
+            RunnableConfig(
+                configurable={
+                    "thread_id": "test_thread_id",
+                    "actor_id": "test_actor_id",
+                }
+            )
+        )
+
+        # Now a read for a DIFFERENT conversation ("other_thread_id") that omits
+        # actor_id. It must NOT borrow the remembered "test_actor_id" — that
+        # would be a cross-tenant leak. Inheritance is keyed by thread_id, and
+        # the thread_ids differ, so the saver fails closed.
+        #
+        # checkpoint_ns="sub" is deliberate: it marks this as a subgraph-shaped
+        # read so it clears the empty-ns guard (which would otherwise reject it
+        # on its own). That forces the test to pass/fail purely on the
+        # thread_id-mismatch check — the actual security mechanism under test.
+        with pytest.raises(InvalidConfigError) as exc_info:
+            saver.get_tuple(
+                RunnableConfig(
+                    configurable={
+                        "thread_id": "other_thread_id",
+                        "checkpoint_ns": "sub",
+                    }
+                )
+            )
+
+        assert "actor_id" in str(exc_info.value)
+
+    async def test_aget_tuple_resolves_fallback_actor_id(
+        self,
+        saver,
+        mock_boto_client,
+        sample_checkpoint_event,
+    ):
+        """aget_tuple captures the actor so a later async subgraph read inherits it."""
+        mock_boto_client.list_events.return_value = {
+            "events": [
+                {
+                    "eventId": "event_1",
+                    "payload": [
+                        {
+                            "blob": saver.serializer.serialize_event(
+                                sample_checkpoint_event
+                            )
+                        }
+                    ],
+                }
+            ]
+        }
+
+        # Async parent read primes the request context.
+        await saver.aget_tuple(
+            RunnableConfig(
+                configurable={
+                    "thread_id": "test_thread_id",
+                    "actor_id": "test_actor_id",
+                }
+            )
+        )
+        # Async subgraph read carries a namespace, omits actor_id, and inherits it.
+        result = await saver.aget_tuple(
+            RunnableConfig(
+                configurable={"thread_id": "test_thread_id", "checkpoint_ns": "sub"}
+            )
+        )
+
+        assert isinstance(result, CheckpointTuple)
+        assert result.config["configurable"]["actor_id"] == "test_actor_id"
+        assert (
+            mock_boto_client.list_events.call_args.kwargs["actorId"] == "test_actor_id"
+        )
+
+    def test_request_actor_isolated_across_threads(
+        self,
+        saver,
+        mock_boto_client,
+        sample_checkpoint_event,
+    ):
+        """Concurrent requests on the same thread_id do not share captured actors."""
+        mock_boto_client.list_events.return_value = {
+            "events": [
+                {
+                    "eventId": "event_1",
+                    "payload": [
+                        {
+                            "blob": saver.serializer.serialize_event(
+                                sample_checkpoint_event
+                            )
+                        }
+                    ],
+                }
+            ]
+        }
+
+        barrier = threading.Barrier(2)
+
+        def worker(actor_id: str) -> str:
+            # Prime this thread's request context with its own actor.
+            saver.get_tuple(
+                RunnableConfig(
+                    configurable={
+                        "thread_id": "shared_thread_id",
+                        "actor_id": actor_id,
+                    }
+                )
+            )
+            # Wait until both threads have primed, maximizing leakage detection.
+            barrier.wait()
+            # Subgraph-style read (namespace set) lacks actor_id; must resolve
+            # THIS thread's actor.
+            result = saver.get_tuple(
+                RunnableConfig(
+                    configurable={
+                        "thread_id": "shared_thread_id",
+                        "checkpoint_ns": "sub",
+                    }
+                )
+            )
+            assert isinstance(result, CheckpointTuple)
+            return result.config["configurable"]["actor_id"]
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            future_a = executor.submit(worker, "actor_a")
+            future_b = executor.submit(worker, "actor_b")
+            resolved_a = future_a.result(timeout=5)
+            resolved_b = future_b.result(timeout=5)
+
+        assert resolved_a == "actor_a"
+        assert resolved_b == "actor_b"
+
+    def test_get_tuple_top_level_read_does_not_inherit_actor_id(
+        self,
+        saver,
+        mock_boto_client,
+        sample_checkpoint_event,
+    ):
+        """A top-level read (empty checkpoint_ns) never inherits a captured actor."""
+        mock_boto_client.list_events.return_value = {
+            "events": [
+                {
+                    "eventId": "event_1",
+                    "payload": [
+                        {
+                            "blob": saver.serializer.serialize_event(
+                                sample_checkpoint_event
+                            )
+                        }
+                    ],
+                }
+            ]
+        }
+
+        # Prime the request context for this thread with actor "test_actor_id".
+        saver.get_tuple(
+            RunnableConfig(
+                configurable={
+                    "thread_id": "test_thread_id",
+                    "actor_id": "test_actor_id",
+                }
+            )
+        )
+
+        # A top-level read (no checkpoint_ns) must not borrow the captured actor.
+        top_level_config = RunnableConfig(configurable={"thread_id": "test_thread_id"})
+        with pytest.raises(InvalidConfigError) as exc_info:
+            saver.get_tuple(top_level_config)
+
+        assert "actor_id" in str(exc_info.value)
+
+    def test_get_tuple_without_actor_id_raises(self, saver):
+        """get_tuple with no actor_id and nothing captured fails closed."""
+        config = RunnableConfig(configurable={"thread_id": "test_thread_id"})
+
+        with pytest.raises(InvalidConfigError) as exc_info:
+            saver.get_tuple(config)
+
+        assert "actor_id" in str(exc_info.value)
+
+    def test_list_without_actor_id_raises(self, saver):
+        """list with no actor_id and nothing captured fails closed."""
+        config = RunnableConfig(configurable={"thread_id": "test_thread_id"})
+
+        with pytest.raises(InvalidConfigError) as exc_info:
+            list(saver.list(config))
+
+        assert "actor_id" in str(exc_info.value)
+
+    def test_put_without_actor_id_raises(
+        self, saver, sample_checkpoint, sample_checkpoint_metadata
+    ):
+        """put with no actor_id fails closed (writes never inherit)."""
+        config = RunnableConfig(configurable={"thread_id": "test_thread_id"})
+
+        with pytest.raises(InvalidConfigError) as exc_info:
+            saver.put(config, sample_checkpoint, sample_checkpoint_metadata, {})
+
+        assert "actor_id" in str(exc_info.value)
+
+    def test_put_writes_without_actor_id_raises(self, saver):
+        """put_writes with no actor_id fails closed (writes never inherit)."""
+        config = RunnableConfig(configurable={"thread_id": "test_thread_id"})
+
+        with pytest.raises(InvalidConfigError) as exc_info:
+            saver.put_writes(config, [("channel", "value")], "task_id")
+
+        assert "actor_id" in str(exc_info.value)
+
+    def test_put_with_writes_without_actor_id_raises(
+        self, saver, sample_checkpoint, sample_checkpoint_metadata
+    ):
+        """put_with_writes with no actor_id fails closed (writes never inherit)."""
+        config = RunnableConfig(configurable={"thread_id": "test_thread_id"})
+
+        with pytest.raises(InvalidConfigError) as exc_info:
+            saver.put_with_writes(
+                config, sample_checkpoint, sample_checkpoint_metadata, {}, []
+            )
+
+        assert "actor_id" in str(exc_info.value)
 
     def test_list_success(
         self,


### PR DESCRIPTION
## Summary

`AgentCoreMemorySaver.get_state(config, subgraphs=True)` raised `InvalidConfigError: RunnableConfig must contain 'actor_id'` on any graph containing nested subgraphs, so subgraph state could not be inspected. LangGraph derives a per-subgraph `RunnableConfig` that carries `thread_id` (and `checkpoint_ns`) but **not** `actor_id`, and the saver required `actor_id` on every call. After this change, a subgraph read inherits the `actor_id` from the current request's parent read, so `get_state(subgraphs=True)` works on nested (and deeply nested) graphs.

Resolves #733.

## How it works

> **Terminology.** *Fail closed* means: if the identity (`actor_id`) can't be established, the operation is **refused** (raises `InvalidConfigError`) rather than proceeding with a guess.

Resolution order for a read is: explicit config `actor_id` → request-scoped captured actor (same `thread_id`) → raise.

1. `models.py` — `CheckpointerConfig.from_runnable_config` gains a keyword-only `default_actor_id`. It resolves `actor_id` as `configurable.get("actor_id") or default_actor_id`, still checking `thread_id` first. This is a pure parser mechanism; it does not decide where the fallback comes from.
2. `saver.py` — a module-level `ContextVar` (`_request_actor`) records the `(thread_id, actor_id)` seen on a read. `_resolve_actor_id` captures that pair when a read supplies both, and lets a later read that omits `actor_id` inherit it **only when** (a) the `thread_id` matches and (b) the read is a derived subgraph read (non-empty `checkpoint_ns`). Otherwise it returns `None` and the parser fails closed.
3. Reads (`get_tuple`, `list`) pass `default_actor_id=self._resolve_actor_id(config)`. Writes (`put`, `put_writes`, `put_with_writes`) pass no fallback — they stay fail-closed, exactly as in the released version.
4. Async reads (`aget_tuple`, `alist`) prime the capture on the event loop, then dispatch via `langchain_core`'s `run_in_executor`, which copies the context into the worker thread so the sync body resolves the captured actor.

## Design decision: request-scoped captures the `(thread_id, actor_id)` instead of a saver-level fallback

The capture lives in a `ContextVar` (isolated per thread / async task), never on the saver instance, so a single saver can serve many actors concurrently without one request's actor leaking into another's. Inheritance is gated on both a matching `thread_id` and a non-empty `checkpoint_ns`, so only genuine subgraph reads can inherit; a top-level read that omits `actor_id` fails closed.

**Alternatives considered.** The first approach added an `actor_id` argument to the saver's constructor and used it as the fallback whenever a config lacked one. It fixed the bug, but the fallback was stored on the saver *object*, so it was a single fixed value for
the life of that saver. That breaks down when one saver instance serves multiple users (a multi-tenant setup where the user is passed per request): the fixed value is only correct for one user, so a subgraph read for user B — which arrives without an `actor_id` — would fall back to whatever the saver was built with, potentially user A, and read user A's data. The request-scoped approach drops the constructor argument entirely and instead takes the fallback from the *current request* (captured per request via a `ContextVar`), so it is always the requesting user. And because nothing is stored on the saver, there is no saver-wide `actor_id` that a deployment could set once and have wrongly applied to every other user's requests (see the ccomments for further details).

## Scope

- Fixes the read path (`get_tuple` / `aget_tuple`, `list` / `alist`) — the path `get_state(subgraphs=True)` uses. Writes are unchanged from the release.

## Trade-offs / Areas needing careful review

- **Coupling to a LangGraph internal (please review):** the guard assumes "non-empty `checkpoint_ns` ⇒ derived subgraph read" (and that top-level reads carry their own `actor_id`). This matches how LangGraph derives per-subgraph configs today — [`_prepare_state_snapshot` always builds a non-empty `task_ns`](https://github.com/langchain-ai/langgraph/blob/1.2.5/libs/langgraph/langgraph/pregel/main.py#L1203-L1221) (langgraph 1.2.5). If a future LangGraph changed that convention, the failure mode is safe (a subgraph read would stop inheriting and fail closed, i.e. #733 would resurface) rather than a leak, but it's worth re-checking on LangGraph upgrades.

## Test coverage

**Unit tests** (`tests/unit_tests/agentcore/test_saver.py`, tests pass) :

Created:
- `TestCheckpointerConfig.test_from_runnable_config_resolves_default_actor_id` — fallback resolution
- `TestCheckpointerConfig.test_config_actor_id_takes_precedence_over_default` — explicit config wins
- `TestCheckpointerConfig.test_missing_thread_id_checked_before_actor_id` — validation order
- `test_get_tuple_resolves_fallback_actor_id` — subgraph read inherits the parent's actor
- `test_get_tuple_resolves_fallback_for_deeply_nested_subgraphs` — 3 levels
- `test_get_tuple_session_mismatch_does_not_leak` — different `thread_id` fails closed
- `test_get_tuple_top_level_read_does_not_inherit_actor_id` — empty-ns read fails closed
- `test_aget_tuple_resolves_fallback_actor_id` — async inheritance across the executor hop
- `test_request_actor_isolated_across_threads` — concurrent same-`thread_id` requests don't share actors
- `test_get_tuple/list/put/put_writes/put_with_writes_without_actor_id_raises` — fail-closed paths
- autouse fixture resetting the `ContextVar` between tests

**Integration tests** (`tests/integration_tests/agentcore/test_saver.py`; live AgentCore
Memory, skipped unless `AGENTCORE_MEMORY_ID` is set, tests pass):

Created:
- `test_get_state_with_subgraphs_resolves_actor_id` — end-to-end #733 repro, single level
- `test_get_state_with_deeply_nested_subgraphs_resolves_actor_id` — 3 nested levels
- `test_aget_state_with_subgraphs_resolves_actor_id` — async variant (skipif Python < 3.11, where LangGraph `interrupt()` is unsupported in an async context).

## Final callouts

`AgentCoreValkeySaver` has the same structural exposure (`actor_id` is a required field and part of every storage key) and should probably adopt the same mechanism. I'll do an additional offline analysis, and if warranted, I'll track it as a follow-up (out of scope here for now).