### PR TITLE
fix(aws): Correctly handle omitted-display thinking blocks on Claude 4.7+

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -638,9 +638,16 @@ def _format_anthropic_messages(
                             )
                     elif item["type"] in ["thinking", "redacted_thinking"]:
                         # Store thinking blocks separately
-                        thinking_blocks.append(
-                            {k: v for k, v in item.items() if k != "index"}
-                        )
+                        thinking_block = {k: v for k, v in item.items() if k != "index"}
+                        # Adaptive-only thinking models (i.e. Claude 4.7+) stream
+                        # signature-only thinking blocks on "omitted" display mode.
+                        # Need to include thinking field or Invoke API throws an error
+                        if (
+                            thinking_block["type"] == "thinking"
+                            and "thinking" not in thinking_block
+                        ):
+                            thinking_block["thinking"] = ""
+                        thinking_blocks.append(thinking_block)
                     elif item["type"] == "text":
                         text = item.get("text", "")
                         # Only add non-empty strings for now as empty ones are not

--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock.py
@@ -609,6 +609,46 @@ def test_agent_loop_bedrock(output_version: Literal["v0", "v1"]) -> None:
     assert isinstance(response, AIMessage)
 
 
+def test_signature_only_thinking_block_roundtrip() -> None:
+    @tool
+    def get_weather(location: str) -> str:
+        """Get the weather for a location."""
+        return "It's sunny."
+
+    llm = ChatBedrock(
+        model="us.anthropic.claude-sonnet-5",
+        region="us-west-2",
+    )
+    llm_with_tools = llm.bind_tools([get_weather])
+    input_message = HumanMessage("What is the weather in San Francisco, CA?")
+
+    tool_call_message = AIMessage(
+        content=[
+            {"type": "thinking", "signature": "x" * 128, "index": 0},
+            {
+                "type": "tool_use",
+                "id": "toolu_01Aq9w938a90dw8q",
+                "name": "get_weather",
+                "input": {"location": "San Francisco, CA"},
+                "index": 1,
+            },
+        ],
+        tool_calls=[
+            {
+                "name": "get_weather",
+                "id": "toolu_01Aq9w938a90dw8q",
+                "args": {"location": "San Francisco, CA"},
+            }
+        ],
+    )
+    tool_message = get_weather.invoke(tool_call_message.tool_calls[0])
+
+    try:
+        llm_with_tools.invoke([input_message, tool_call_message, tool_message])
+    except Exception as e:
+        assert "Field required" not in str(e), e
+
+
 @pytest.mark.parametrize("output_version", ["v0", "v1"])
 def test_agent_loop_streaming_bedrock(output_version: Literal["v0", "v1"]) -> None:
     @tool

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
@@ -205,6 +205,70 @@ def test__format_anthropic_messages_strips_streaming_fields_on_invalid_tool() ->
     }
 
 
+def test__format_anthropic_messages_signature_only_thinking_block() -> None:
+    ai = AIMessage(
+        content=[
+            {
+                "type": "thinking",
+                "signature": "sig-abc",
+                "index": 0,
+            },
+            {
+                "type": "tool_use",
+                "id": "toolu_1",
+                "name": "get_weather",
+                "input": {"location": "SF"},
+                "index": 1,
+            },
+        ],
+        tool_calls=[
+            {"name": "get_weather", "id": "toolu_1", "args": {"location": "SF"}}
+        ],
+    )
+    _, formatted = _format_anthropic_messages([HumanMessage("go"), ai])
+    thinking_block = next(
+        b for b in formatted[1]["content"] if b.get("type") == "thinking"
+    )
+    assert thinking_block == {
+        "type": "thinking",
+        "signature": "sig-abc",
+        "thinking": "",
+    }
+
+    ai_with_text = AIMessage(
+        content=[
+            {
+                "type": "thinking",
+                "thinking": "step by step...",
+                "signature": "sig-def",
+                "index": 0,
+            },
+            {"type": "text", "text": "Answer."},
+        ]
+    )
+    _, formatted = _format_anthropic_messages([HumanMessage("go"), ai_with_text])
+    thinking_block = next(
+        b for b in formatted[1]["content"] if b.get("type") == "thinking"
+    )
+    assert thinking_block == {
+        "type": "thinking",
+        "thinking": "step by step...",
+        "signature": "sig-def",
+    }
+
+    ai_redacted = AIMessage(
+        content=[
+            {"type": "redacted_thinking", "data": "opaque", "index": 0},
+            {"type": "text", "text": "Answer."},
+        ]
+    )
+    _, formatted = _format_anthropic_messages([HumanMessage("go"), ai_redacted])
+    redacted_block = next(
+        b for b in formatted[1]["content"] if b.get("type") == "redacted_thinking"
+    )
+    assert redacted_block == {"type": "redacted_thinking", "data": "opaque"}
+
+
 def test__format_anthropic_messages_with_str_content_and_tool_calls() -> None:
     system = SystemMessage("fuzz")  # type: ignore[misc]
     human = HumanMessage("foo")  # type: ignore[misc]


### PR DESCRIPTION
While working on migrating `ChatBedrock` thinking integration tests from Claude 4.x to Claude 5, Invoke API would sometimes throw errors noting that the model returned empty thinking blocks:
```
`ValidationException: An error occurred (ValidationException) when calling the InvokeModel operation: messages.1.content.0.thinking.thinking: Field required`   
```

This is because adaptive-only thinking Claude models (specifically 4.7+) default to `omitted` [thinking display mode](https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking#summarized-thinking), which intentionally returns thinking blocks empty (except for the signature). However, we can't pass these empty thinking blocks back to Invoke API as-is, at it considers them invalid without the `thinking` field.

Fixing this by updating the thinking block processing logic in `_format_anthropic_messages` to ensure that we add a dummy `"thinking": ""` field to these empty thinking blocks before the round-trip back to Invoke API.