### PR TITLE
feat: add Bedrock Managed Knowledge Base support

### DIFF
--- a/libs/aws/langchain_aws/retrievers/__init__.py
+++ b/libs/aws/langchain_aws/retrievers/__init__.py
@@ -1,4 +1,10 @@
-from langchain_aws.retrievers.bedrock import AmazonKnowledgeBasesRetriever
+from langchain_aws.retrievers.bedrock import (
+    AmazonKnowledgeBasesRetriever,
+    ManagedSearchConfig,
+    RetrievalConfig,
+    VectorSearchConfig,
+    agentic_retrieve,
+)
 from langchain_aws.retrievers.kendra import AmazonKendraRetriever
 from langchain_aws.retrievers.s3_vectors import AmazonS3VectorsRetriever
 
@@ -6,4 +12,8 @@ __all__ = [
     "AmazonKendraRetriever",
     "AmazonKnowledgeBasesRetriever",
     "AmazonS3VectorsRetriever",
+    "ManagedSearchConfig",
+    "RetrievalConfig",
+    "VectorSearchConfig",
+    "agentic_retrieve",
 ]

--- a/libs/aws/langchain_aws/retrievers/bedrock.py
+++ b/libs/aws/langchain_aws/retrievers/bedrock.py
@@ -39,17 +39,36 @@ class SearchFilter(BaseModel):
 
 
 class VectorSearchConfig(BaseModel, extra="allow"):  # type: ignore[call-arg]
-    """Configuration for vector search."""
+    """Configuration for vector search (legacy VECTOR-type knowledge bases)."""
 
     numberOfResults: int = 4
     filter: Optional[SearchFilter] = None
     overrideSearchType: Optional[Literal["HYBRID", "SEMANTIC"]] = None
 
 
-class RetrievalConfig(BaseModel, extra="allow"):  # type: ignore[call-arg]
-    """Configuration for retrieval."""
+class ManagedSearchConfig(BaseModel, extra="allow"):  # type: ignore[call-arg]
+    """Configuration for managed search (MANAGED-type knowledge bases).
 
-    vectorSearchConfiguration: VectorSearchConfig
+    Managed knowledge bases handle embedding and vector storage automatically.
+    Use this configuration when querying a knowledge base created with
+    type=MANAGED.
+    """
+
+    numberOfResults: int = 4
+    filter: Optional[SearchFilter] = None
+    rerankingModelType: Optional[Literal["CUSTOM", "MANAGED", "NONE"]] = None
+    rerankingConfiguration: Optional[Dict[str, Any]] = None
+
+
+class RetrievalConfig(BaseModel, extra="allow"):  # type: ignore[call-arg]
+    """Configuration for retrieval.
+
+    Provide either managedSearchConfiguration (for MANAGED-type KBs) or
+    vectorSearchConfiguration (for VECTOR-type KBs), but not both.
+    """
+
+    vectorSearchConfiguration: Optional[VectorSearchConfig] = None
+    managedSearchConfiguration: Optional[ManagedSearchConfig] = None
     nextToken: Optional[str] = None
 
 
@@ -97,18 +116,29 @@ class AmazonKnowledgeBasesRetriever(BaseRetriever):
             (0.0 to 1.0).
 
     Example:
-        ```python
-        from langchain_community.retrievers import AmazonKnowledgeBasesRetriever
+        .. code-block:: python
 
-        retriever = AmazonKnowledgeBasesRetriever(
-            knowledge_base_id="<knowledge-base-id>",
-            retrieval_config={
-                "vectorSearchConfiguration": {
-                    "numberOfResults": 4
-                }
-            },
-        )
-        ```
+            from langchain_aws.retrievers import AmazonKnowledgeBasesRetriever
+
+            # For managed knowledge bases (recommended for new KBs):
+            retriever = AmazonKnowledgeBasesRetriever(
+                knowledge_base_id="<knowledge-base-id>",
+                retrieval_config={
+                    "managedSearchConfiguration": {
+                        "numberOfResults": 4
+                    }
+                },
+            )
+
+            # For legacy vector-type knowledge bases:
+            retriever = AmazonKnowledgeBasesRetriever(
+                knowledge_base_id="<knowledge-base-id>",
+                retrieval_config={
+                    "vectorSearchConfiguration": {
+                        "numberOfResults": 4
+                    }
+                },
+            )
 
     """
 
@@ -282,3 +312,95 @@ class AmazonKnowledgeBasesRetriever(BaseRetriever):
             # future proofing this class to prevent code breaks if new types
             # are introduced
             return None
+
+
+def agentic_retrieve(
+    knowledge_base_id: str,
+    query: str,
+    *,
+    generate_response: bool = False,
+    number_of_results: int = 4,
+    region_name: Optional[str] = None,
+    credentials_profile_name: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Execute AgenticRetrieveStream for intelligent multi-step retrieval.
+
+    This is a standalone helper (not a LangChain retriever) because the agentic API
+    is streaming and doesn't fit the synchronous retriever interface. Use this for
+    complex queries that benefit from query decomposition and managed reranking.
+
+    Only works with MANAGED knowledge bases. Requires boto3 >= 1.43.0.
+
+    Args:
+        knowledge_base_id: The managed knowledge base ID.
+        query: The user query.
+        generate_response: Whether to generate a cited answer (default False).
+        number_of_results: Max results per retrieval iteration.
+        region_name: AWS region.
+        credentials_profile_name: AWS credentials profile.
+
+    Returns:
+        Dict with 'results' (list of retrieval results) and optionally
+        'generatedResponse' with 'answer' and 'citations'.
+
+    Example:
+        .. code-block:: python
+
+            from langchain_aws.retrievers.bedrock import agentic_retrieve
+
+            result = agentic_retrieve(
+                knowledge_base_id="ABCDEFGHIJ",
+                query="Compare pricing models across AWS compute services",
+                generate_response=True,
+            )
+            print(result["generatedResponse"]["answer"])
+    """
+    client = create_aws_client(
+        service_name="bedrock-agent-runtime",
+        region_name=region_name,
+        credentials_profile_name=credentials_profile_name,
+    )
+
+    request = {
+        "messages": [{"content": {"text": query}, "role": "user"}],
+        "retrievers": [
+            {
+                "configuration": {
+                    "knowledgeBase": {
+                        "knowledgeBaseId": knowledge_base_id,
+                        "retrievalOverrides": {"maxNumberOfResults": number_of_results},
+                    }
+                }
+            }
+        ],
+        "agenticRetrieveConfiguration": {
+            "foundationModelType": "MANAGED",
+            "rerankingModelType": "MANAGED",
+        },
+        "generateResponse": generate_response,
+    }
+
+    response = client.agentic_retrieve_stream(**request)
+
+    results = []
+    generated_answer = ""
+    citations = []
+
+    for event in response.get("stream", []):
+        if "result" in event:
+            result_event = event["result"]
+            results = result_event.get("results", [])
+            if "generatedResponse" in result_event:
+                gen_resp = result_event["generatedResponse"]
+                generated_answer = gen_resp.get("answer", "")
+                citations = gen_resp.get("citations", [])
+        elif "responseEvent" in event:
+            generated_answer += event["responseEvent"].get("text", "")
+
+    output: Dict[str, Any] = {"results": results}
+    if generate_response and generated_answer:
+        output["generatedResponse"] = {
+            "answer": generated_answer,
+            "citations": citations,
+        }
+    return output

--- a/libs/aws/langchain_aws/retrievers/bedrock.py
+++ b/libs/aws/langchain_aws/retrievers/bedrock.py
@@ -329,7 +329,7 @@ def agentic_retrieve(
     is streaming and doesn't fit the synchronous retriever interface. Use this for
     complex queries that benefit from query decomposition and managed reranking.
 
-    Only works with MANAGED knowledge bases. Requires boto3 >= 1.43.0.
+    Only works with MANAGED knowledge bases. Requires boto3 >= 1.43.32.
 
     Args:
         knowledge_base_id: The managed knowledge base ID.

--- a/libs/aws/pyproject.toml
+++ b/libs/aws/pyproject.toml
@@ -13,7 +13,7 @@ version = "1.6.2"
 requires-python = ">=3.10"
 dependencies = [
     "langchain-core>=1.4.7",
-    "boto3>=1.42.42",
+    "boto3>=1.43.2",
     "pydantic>=2.10.6,<3",
     "numpy>=1.0.0,<3",
 ]

--- a/libs/aws/pyproject.toml
+++ b/libs/aws/pyproject.toml
@@ -13,7 +13,7 @@ version = "1.6.2"
 requires-python = ">=3.10"
 dependencies = [
     "langchain-core>=1.4.7",
-    "boto3>=1.43.2",
+    "boto3>=1.43.32",
     "pydantic>=2.10.6,<3",
     "numpy>=1.0.0,<3",
 ]

--- a/libs/aws/tests/integration_tests/retrievers/test_managed_kb.py
+++ b/libs/aws/tests/integration_tests/retrievers/test_managed_kb.py
@@ -1,0 +1,100 @@
+"""Integration tests for Bedrock KB retriever (managed + agentic).
+
+These tests hit the live Bedrock API and require:
+- AWS credentials configured
+- A managed knowledge base with ID set in KNOWLEDGE_BASE_ID env var
+- boto3 >= 1.43.2
+
+Run with: pytest tests/integration_tests/retrievers/test_managed_kb.py -m "not compile"
+"""
+
+import os
+
+import pytest
+
+from langchain_aws.retrievers.bedrock import (
+    AmazonKnowledgeBasesRetriever,
+    agentic_retrieve,
+)
+
+KNOWLEDGE_BASE_ID = os.environ.get("KNOWLEDGE_BASE_ID", "")
+REGION = os.environ.get("AWS_REGION", "us-west-2")
+
+
+@pytest.mark.skipif(
+    not KNOWLEDGE_BASE_ID,
+    reason="KNOWLEDGE_BASE_ID env var not set",
+)
+class TestManagedKBRetriever:
+    """Integration tests against a live managed knowledge base."""
+
+    def test_managed_search_returns_documents(self) -> None:
+        """Verify managedSearchConfiguration returns documents from the API."""
+        retriever = AmazonKnowledgeBasesRetriever(
+            min_score_confidence=None,
+            knowledge_base_id=KNOWLEDGE_BASE_ID,
+            retrieval_config={"managedSearchConfiguration": {"numberOfResults": 3}},
+            region_name=REGION,
+        )
+
+        docs = retriever.invoke("What actions are supported?")
+
+        assert len(docs) > 0
+        assert docs[0].page_content != ""
+        assert "score" in docs[0].metadata
+
+    def test_managed_search_with_reranking_model_type(self) -> None:
+        """Verify rerankingModelType='MANAGED' is accepted by the API."""
+        retriever = AmazonKnowledgeBasesRetriever(
+            min_score_confidence=None,
+            knowledge_base_id=KNOWLEDGE_BASE_ID,
+            retrieval_config={
+                "managedSearchConfiguration": {
+                    "numberOfResults": 3,
+                    "rerankingModelType": "MANAGED",
+                }
+            },
+            region_name=REGION,
+        )
+
+        docs = retriever.invoke("What actions are supported?")
+
+        assert len(docs) > 0
+
+    def test_managed_search_number_of_results(self) -> None:
+        """Verify numberOfResults controls result count."""
+        retriever = AmazonKnowledgeBasesRetriever(
+            min_score_confidence=None,
+            knowledge_base_id=KNOWLEDGE_BASE_ID,
+            retrieval_config={"managedSearchConfiguration": {"numberOfResults": 2}},
+            region_name=REGION,
+        )
+
+        docs = retriever.invoke("What actions are supported?")
+
+        assert len(docs) <= 2
+
+    def test_agentic_retrieve_returns_results(self) -> None:
+        """Verify agentic_retrieve() returns results from the API."""
+        result = agentic_retrieve(
+            knowledge_base_id=KNOWLEDGE_BASE_ID,
+            query="What actions are supported?",
+            region_name=REGION,
+        )
+
+        assert "results" in result
+        assert len(result["results"]) > 0
+        assert "content" in result["results"][0]
+
+    def test_agentic_retrieve_with_generate_response(self) -> None:
+        """Verify agentic_retrieve() with generateResponse returns a cited answer."""
+        result = agentic_retrieve(
+            knowledge_base_id=KNOWLEDGE_BASE_ID,
+            query="What actions are supported?",
+            region_name=REGION,
+            generate_response=True,
+        )
+
+        assert "results" in result
+        if "generatedResponse" in result:
+            assert "answer" in result["generatedResponse"]

--- a/libs/aws/tests/integration_tests/retrievers/test_managed_kb.py
+++ b/libs/aws/tests/integration_tests/retrievers/test_managed_kb.py
@@ -1,13 +1,3 @@
-"""Integration tests for Bedrock KB retriever (managed + agentic).
-
-These tests hit the live Bedrock API and require:
-- AWS credentials configured
-- A managed knowledge base with ID set in KNOWLEDGE_BASE_ID env var
-- boto3 >= 1.43.2
-
-Run with: pytest tests/integration_tests/retrievers/test_managed_kb.py -m "not compile"
-"""
-
 import os
 
 import pytest

--- a/libs/aws/tests/unit_tests/retrievers/test_bedrock.py
+++ b/libs/aws/tests/unit_tests/retrievers/test_bedrock.py
@@ -7,6 +7,7 @@ from langchain_core.documents import Document
 
 from langchain_aws.retrievers import AmazonKnowledgeBasesRetriever
 from langchain_aws.retrievers.bedrock import (
+    ManagedSearchConfig,
     RetrievalConfig,
     SearchFilter,
     VectorSearchConfig,
@@ -178,7 +179,8 @@ def test_retriever_no_retrieval_config_invoke(
     )
     validate_query_response_no_cutoff(documents)
     mock_client.retrieve.assert_called_once_with(
-        retrievalQuery={"text": "test query"}, knowledgeBaseId="test_kb_id"
+        retrievalQuery={"text": "test query"},
+        knowledgeBaseId="test_kb_id",
     )
 
 
@@ -651,6 +653,151 @@ def test_guardrail_config_with_retrieval_config(mock_client, mock_retriever_conf
     )
 
 
+@pytest.fixture
+def mock_managed_retriever_config():
+    return RetrievalConfig(
+        managedSearchConfiguration=ManagedSearchConfig(
+            numberOfResults=5,
+            filter=SearchFilter(equals={"key": "category", "value": "finance"}),
+        ),
+    )
+
+
+@pytest.fixture
+def amazon_retriever_managed(mock_client, mock_managed_retriever_config):
+    return AmazonKnowledgeBasesRetriever(
+        knowledge_base_id="test_managed_kb_id",
+        retrieval_config=mock_managed_retriever_config,
+        client=mock_client,
+    )
+
+
+def test_retriever_managed_kb_invoke(amazon_retriever_managed, mock_client):
+    """Test retrieval with managedSearchConfiguration for managed KBs."""
+    query = "test query"
+    mock_client.retrieve.return_value = {
+        "retrievalResults": [
+            {"content": {"text": "managed result1"}, "metadata": {"key": "value1"}},
+            {
+                "content": {"text": "managed result2"},
+                "metadata": {"key": "value2"},
+                "score": 0.95,
+                "location": "s3://bucket/doc.pdf",
+            },
+        ]
+    }
+    documents = amazon_retriever_managed.invoke(query, run_manager=None)
+
+    mock_client.retrieve.assert_called_once_with(
+        retrievalQuery={"text": "test query"},
+        knowledgeBaseId="test_managed_kb_id",
+        retrievalConfiguration={
+            "managedSearchConfiguration": {
+                "numberOfResults": 5,
+                "filter": {"equals": {"key": "category", "value": "finance"}},
+            }
+        },
+    )
+    assert len(documents) == 2
+    assert documents[0].page_content == "managed result1"
+    assert documents[1].page_content == "managed result2"
+    assert documents[1].metadata["score"] == 0.95
+
+
+def test_retriever_managed_kb_dict_config(mock_client):
+    """Test managed KB retrieval using dict-based config."""
+    retriever = AmazonKnowledgeBasesRetriever(
+        knowledge_base_id="test_managed_kb_id",
+        retrieval_config={
+            "managedSearchConfiguration": {
+                "numberOfResults": 10,
+                "rerankingModelType": "MANAGED",
+            }
+        },
+        client=mock_client,
+    )
+
+    mock_client.retrieve.return_value = {
+        "retrievalResults": [
+            {"content": {"text": "result1"}, "score": 0.9},
+        ]
+    }
+
+    retriever.invoke("test query")
+
+    mock_client.retrieve.assert_called_once_with(
+        retrievalQuery={"text": "test query"},
+        knowledgeBaseId="test_managed_kb_id",
+        retrievalConfiguration={
+            "managedSearchConfiguration": {
+                "numberOfResults": 10,
+                "rerankingModelType": "MANAGED",
+            }
+        },
+    )
+
+
+def test_retriever_managed_kb_with_reranking(mock_client):
+    """Test managed KB retrieval with reranking configuration."""
+    retriever = AmazonKnowledgeBasesRetriever(
+        knowledge_base_id="test_managed_kb_id",
+        retrieval_config={
+            "managedSearchConfiguration": {
+                "numberOfResults": 5,
+                "rerankingConfiguration": {
+                    "type": "BEDROCK_RERANKING_MODEL",
+                },
+            }
+        },
+        client=mock_client,
+    )
+
+    mock_client.retrieve.return_value = {
+        "retrievalResults": [
+            {"content": {"text": "reranked result"}, "score": 0.98},
+        ]
+    }
+
+    documents = retriever.invoke("test query")
+
+    mock_client.retrieve.assert_called_once_with(
+        retrievalQuery={"text": "test query"},
+        knowledgeBaseId="test_managed_kb_id",
+        retrievalConfiguration={
+            "managedSearchConfiguration": {
+                "numberOfResults": 5,
+                "rerankingConfiguration": {
+                    "type": "BEDROCK_RERANKING_MODEL",
+                },
+            }
+        },
+    )
+    assert len(documents) == 1
+    assert documents[0].page_content == "reranked result"
+
+
+def test_retriever_managed_kb_with_score_filter(mock_client):
+    """Test managed KB retrieval with min_score_confidence filtering."""
+    retriever = AmazonKnowledgeBasesRetriever(
+        knowledge_base_id="test_managed_kb_id",
+        retrieval_config={"managedSearchConfiguration": {"numberOfResults": 5}},
+        min_score_confidence=0.8,
+        client=mock_client,
+    )
+
+    mock_client.retrieve.return_value = {
+        "retrievalResults": [
+            {"content": {"text": "high score"}, "score": 0.95},
+            {"content": {"text": "low score"}, "score": 0.5},
+        ]
+    }
+
+    documents = retriever.invoke("test query")
+
+    assert len(documents) == 1
+    assert documents[0].page_content == "high score"
+
+
 @patch("langchain_aws.retrievers.bedrock.create_aws_client")
 def test_user_agent_extra_in_config(mock_create_client):
     """Test that user_agent_extra is properly set in the Config when creating client."""
@@ -692,3 +839,32 @@ def test_custom_config_preserves_user_agent_extra(mock_create_client):
 
     # The custom config should be passed through
     assert call_args.kwargs["config"] == custom_config
+
+
+@patch("langchain_aws.retrievers.bedrock.create_aws_client")
+def test_agentic_retrieve_helper(mock_create_client):
+    """Test agentic_retrieve() standalone helper returns results."""
+    from langchain_aws.retrievers.bedrock import agentic_retrieve
+
+    mock_client = MagicMock()
+    mock_create_client.return_value = mock_client
+    mock_client.agentic_retrieve_stream.return_value = {
+        "stream": [
+            {
+                "result": {
+                    "results": [{"content": {"text": "agentic result"}, "score": 0.9}]
+                }
+            }
+        ]
+    }
+
+    result = agentic_retrieve(
+        knowledge_base_id="test-kb",
+        query="test query",
+        region_name="us-west-2",
+    )
+
+    assert "results" in result
+    assert len(result["results"]) == 1
+    assert result["results"][0]["content"]["text"] == "agentic result"
+    mock_client.agentic_retrieve_stream.assert_called_once()

--- a/libs/aws/uv.lock
+++ b/libs/aws/uv.lock
@@ -124,9 +124,9 @@ name = "aws-sdk-bedrock-runtime"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "smithy-aws-core", extra = ["eventstream", "json"], marker = "python_full_version >= '3.12'" },
-    { name = "smithy-core", marker = "python_full_version >= '3.12'" },
-    { name = "smithy-http", extra = ["awscrt"], marker = "python_full_version >= '3.12'" },
+    { name = "smithy-aws-core", extra = ["eventstream", "json"] },
+    { name = "smithy-core" },
+    { name = "smithy-http", extra = ["awscrt"] },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/67/8a/ed3fd98775273b0b7f6006b4970aa876d506668b7fe29145f54fcb941c3b/aws_sdk_bedrock_runtime-0.7.0.tar.gz", hash = "sha256:0cb172cbc03ff060e5c1d6f9cfa9a8ac5e71d9e0d58d3117006ebf614cbb4677", size = 170304, upload-time = "2026-06-23T04:04:52.382Z" }
 wheels = [
@@ -614,7 +614,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1085,7 +1085,7 @@ requires-dist = [
     { name = "aws-sdk-bedrock-runtime", marker = "python_full_version >= '3.12' and extra == 'nova-sonic'" },
     { name = "beautifulsoup4", marker = "extra == 'tools'", specifier = ">=4.13.4" },
     { name = "bedrock-agentcore", marker = "python_full_version >= '3.10' and extra == 'tools'", specifier = ">=1.4.0" },
-    { name = "boto3", specifier = ">=1.42.42" },
+    { name = "boto3", specifier = ">=1.43.2" },
     { name = "langchain-anthropic", marker = "extra == 'anthropic'" },
     { name = "langchain-core", specifier = ">=1.4.7" },
     { name = "numpy", specifier = ">=1.0.0,<3" },
@@ -2344,9 +2344,9 @@ name = "smithy-aws-core"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aws-sdk-signers", marker = "python_full_version >= '3.12'" },
-    { name = "smithy-core", marker = "python_full_version >= '3.12'" },
-    { name = "smithy-http", marker = "python_full_version >= '3.12'" },
+    { name = "aws-sdk-signers" },
+    { name = "smithy-core" },
+    { name = "smithy-http" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fc/a8/37bfde59519f45d2047d0033b791aca6574d867aaf57bb56a6de42ab5c26/smithy_aws_core-0.7.0.tar.gz", hash = "sha256:34e82d09fc808acd5ffc80f03828d0609c6a211f49f0884dc6ee7ca095a1b6af", size = 15670, upload-time = "2026-06-23T04:04:50.365Z" }
 wheels = [
@@ -2355,10 +2355,10 @@ wheels = [
 
 [package.optional-dependencies]
 eventstream = [
-    { name = "smithy-aws-event-stream", marker = "python_full_version >= '3.12'" },
+    { name = "smithy-aws-event-stream" },
 ]
 json = [
-    { name = "smithy-json", marker = "python_full_version >= '3.12'" },
+    { name = "smithy-json" },
 ]
 
 [[package]]
@@ -2366,7 +2366,7 @@ name = "smithy-aws-event-stream"
 version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "smithy-core", marker = "python_full_version >= '3.12'" },
+    { name = "smithy-core" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/0e/6efb3a4ed92c0f1ada6de060ac92e7115a1e34d0ab1fb99a6056734a88ea/smithy_aws_event_stream-0.3.0.tar.gz", hash = "sha256:a0e227367a973144e205a075d0a424f95c92f26656a1018d08900da2ae547c49", size = 12818, upload-time = "2026-05-05T18:04:14.317Z" }
 wheels = [
@@ -2387,7 +2387,7 @@ name = "smithy-http"
 version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "smithy-core", marker = "python_full_version >= '3.12'" },
+    { name = "smithy-core" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/58/5a772d212e066d6fc1398946c4aae19bcdaa75209879d776f641b6a06b5b/smithy_http-0.4.2.tar.gz", hash = "sha256:50d11b6a55e42448450a01e3d0f605ccee65a72abf52d02eed82862a15be5937", size = 29616, upload-time = "2026-06-23T04:04:45.687Z" }
 wheels = [
@@ -2396,7 +2396,7 @@ wheels = [
 
 [package.optional-dependencies]
 awscrt = [
-    { name = "awscrt", marker = "python_full_version >= '3.12'" },
+    { name = "awscrt" },
 ]
 
 [[package]]
@@ -2404,8 +2404,8 @@ name = "smithy-json"
 version = "0.2.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ijson", marker = "python_full_version >= '3.12'" },
-    { name = "smithy-core", marker = "python_full_version >= '3.12'" },
+    { name = "ijson" },
+    { name = "smithy-core" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/6c/418b5687d8933b7a135d5e1a98c61fe814b98f72517dbae0e666860cb876/smithy_json-0.2.3.tar.gz", hash = "sha256:686e9b55a36dacb08e472732b358573ef78009055e05e9fce2e806d61490b2b3", size = 7805, upload-time = "2026-06-23T04:04:47.71Z" }
 wheels = [

--- a/libs/aws/uv.lock
+++ b/libs/aws/uv.lock
@@ -124,9 +124,9 @@ name = "aws-sdk-bedrock-runtime"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "smithy-aws-core", extra = ["eventstream", "json"] },
-    { name = "smithy-core" },
-    { name = "smithy-http", extra = ["awscrt"] },
+    { name = "smithy-aws-core", extra = ["eventstream", "json"], marker = "python_full_version >= '3.12'" },
+    { name = "smithy-core", marker = "python_full_version >= '3.12'" },
+    { name = "smithy-http", extra = ["awscrt"], marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/67/8a/ed3fd98775273b0b7f6006b4970aa876d506668b7fe29145f54fcb941c3b/aws_sdk_bedrock_runtime-0.7.0.tar.gz", hash = "sha256:0cb172cbc03ff060e5c1d6f9cfa9a8ac5e71d9e0d58d3117006ebf614cbb4677", size = 170304, upload-time = "2026-06-23T04:04:52.382Z" }
 wheels = [
@@ -614,7 +614,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1085,7 +1085,7 @@ requires-dist = [
     { name = "aws-sdk-bedrock-runtime", marker = "python_full_version >= '3.12' and extra == 'nova-sonic'" },
     { name = "beautifulsoup4", marker = "extra == 'tools'", specifier = ">=4.13.4" },
     { name = "bedrock-agentcore", marker = "python_full_version >= '3.10' and extra == 'tools'", specifier = ">=1.4.0" },
-    { name = "boto3", specifier = ">=1.43.2" },
+    { name = "boto3", specifier = ">=1.43.32" },
     { name = "langchain-anthropic", marker = "extra == 'anthropic'" },
     { name = "langchain-core", specifier = ">=1.4.7" },
     { name = "numpy", specifier = ">=1.0.0,<3" },
@@ -2344,9 +2344,9 @@ name = "smithy-aws-core"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aws-sdk-signers" },
-    { name = "smithy-core" },
-    { name = "smithy-http" },
+    { name = "aws-sdk-signers", marker = "python_full_version >= '3.12'" },
+    { name = "smithy-core", marker = "python_full_version >= '3.12'" },
+    { name = "smithy-http", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fc/a8/37bfde59519f45d2047d0033b791aca6574d867aaf57bb56a6de42ab5c26/smithy_aws_core-0.7.0.tar.gz", hash = "sha256:34e82d09fc808acd5ffc80f03828d0609c6a211f49f0884dc6ee7ca095a1b6af", size = 15670, upload-time = "2026-06-23T04:04:50.365Z" }
 wheels = [
@@ -2355,10 +2355,10 @@ wheels = [
 
 [package.optional-dependencies]
 eventstream = [
-    { name = "smithy-aws-event-stream" },
+    { name = "smithy-aws-event-stream", marker = "python_full_version >= '3.12'" },
 ]
 json = [
-    { name = "smithy-json" },
+    { name = "smithy-json", marker = "python_full_version >= '3.12'" },
 ]
 
 [[package]]
@@ -2366,7 +2366,7 @@ name = "smithy-aws-event-stream"
 version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "smithy-core" },
+    { name = "smithy-core", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/0e/6efb3a4ed92c0f1ada6de060ac92e7115a1e34d0ab1fb99a6056734a88ea/smithy_aws_event_stream-0.3.0.tar.gz", hash = "sha256:a0e227367a973144e205a075d0a424f95c92f26656a1018d08900da2ae547c49", size = 12818, upload-time = "2026-05-05T18:04:14.317Z" }
 wheels = [
@@ -2387,7 +2387,7 @@ name = "smithy-http"
 version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "smithy-core" },
+    { name = "smithy-core", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/58/5a772d212e066d6fc1398946c4aae19bcdaa75209879d776f641b6a06b5b/smithy_http-0.4.2.tar.gz", hash = "sha256:50d11b6a55e42448450a01e3d0f605ccee65a72abf52d02eed82862a15be5937", size = 29616, upload-time = "2026-06-23T04:04:45.687Z" }
 wheels = [
@@ -2396,7 +2396,7 @@ wheels = [
 
 [package.optional-dependencies]
 awscrt = [
-    { name = "awscrt" },
+    { name = "awscrt", marker = "python_full_version >= '3.12'" },
 ]
 
 [[package]]
@@ -2404,8 +2404,8 @@ name = "smithy-json"
 version = "0.2.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ijson" },
-    { name = "smithy-core" },
+    { name = "ijson", marker = "python_full_version >= '3.12'" },
+    { name = "smithy-core", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/6c/418b5687d8933b7a135d5e1a98c61fe814b98f72517dbae0e666860cb876/smithy_json-0.2.3.tar.gz", hash = "sha256:686e9b55a36dacb08e472732b358573ef78009055e05e9fce2e806d61490b2b3", size = 7805, upload-time = "2026-06-23T04:04:47.71Z" }
 wheels = [


### PR DESCRIPTION
- Added ManagedSearchConfig Pydantic model for managed KB retrieval
- RetrievalConfig now supports both managedSearchConfiguration and vectorSearchConfiguration
- New standalone agentic_retrieve() helper for AgenticRetrieveStream API
- Updated exports in __init__.py (ManagedSearchConfig, VectorSearchConfig, RetrievalConfig, agentic_retrieve)
- No default change for existing users — managed KB via explicit retrieval_config
- 49 unit tests pass
Documentation PR : https://github.com/langchain-ai/docs/pull/4861