### PR TITLE
test(aws): Make integration test cassettes AWS region agnostic

### DIFF
--- a/libs/aws/tests/conftest.py
+++ b/libs/aws/tests/conftest.py
@@ -1,9 +1,28 @@
 import io
+import re
 from typing import Any
+from urllib.parse import urlparse
 
 import pytest
 from langchain_tests.conftest import CustomPersister, CustomSerializer, base_vcr_config
 from vcr import VCR  # type: ignore[import-untyped]
+
+_AWS_REGION = re.compile(r"^[a-z]{2,3}-(gov-)?[a-z]+-\d+$")
+
+
+def _uri_without_aws_region(uri: str) -> str:
+    parsed = urlparse(uri)
+    host = ".".join(
+        p for p in (parsed.hostname or "").split(".") if not _AWS_REGION.match(p)
+    )
+    return f"{host}{parsed.path}"
+
+
+def region_agnostic_uri_matcher(r1: Any, r2: Any) -> None:
+    """Match URIs while ignoring the AWS region segment of the endpoint host."""
+    assert _uri_without_aws_region(r1.uri) == _uri_without_aws_region(r2.uri), (
+        f"{r1.uri} != {r2.uri}"
+    )
 
 
 def remove_request_headers(request: Any) -> Any:
@@ -63,6 +82,7 @@ def vcr_config() -> dict:
     config["before_record_response"] = remove_response_headers
     config["serializer"] = "yaml.gz"
     config["path_transformer"] = VCR.ensure_suffix(".yaml.gz")
+    config["match_on"] = ["method", "region_agnostic_uri", "body"]
 
     return config
 
@@ -70,3 +90,4 @@ def vcr_config() -> dict:
 def pytest_recording_configure(config: dict, vcr: VCR) -> None:
     vcr.register_persister(CustomPersister())
     vcr.register_serializer("yaml.gz", CustomSerializer())
+    vcr.register_matcher("region_agnostic_uri", region_agnostic_uri_matcher)


### PR DESCRIPTION
Fixing some cassette errors seen in [live integ test runs](https://github.com/langchain-ai/langchain-aws/actions/runs/29048020685/job/86221390451) following the updates in https://github.com/langchain-ai/langchain-aws/pull/1154:
```
E               vcr.errors.CannotOverwriteExistingCassetteException: Can't overwrite existing cassette ('tests/cassettes/test_thinking[v0].yaml.gz') in your current record mode (<RecordMode.ONCE: 'once'>).
E               No match for the request (<Request (POST) https://bedrock-runtime.***.amazonaws.com/model/us.anthropic.claude-sonnet-5/converse-stream>) was found.
E               Found 1 similar requests with 1 different matcher(s) :
E               
E               1 - (<Request (POST) https://bedrock-runtime.us-west-2.amazonaws.com/model/us.anthropic.claude-sonnet-5/converse-stream>).
E               Matchers succeeded : ['method', 'body']
E               Matchers failed :
E               uri - assertion failure :
E               https://bedrock-runtime.***.amazonaws.com/model/us.anthropic.claude-sonnet-5/converse-stream != https://bedrock-runtime.us-west-2.amazonaws.com/model/us.anthropic.claude-sonnet-5/converse-stream
```

Basically, the new cassettes for the revised tests with Sonnet 5 were recorded from my local runs on `us-west-2`, while the CI actually runs on a different region (that's obfuscated by the `AWS_REGION` secret). VCR's default matcher requires the endpoint URIs to match exactly, so the replays fail.

To fix this, I've loosened the URI check by replacing VCR's default matcher with a custom `region_agnostic_uri` matcher, stripping the region ID from the host before performing the comparison. 

This has two advantages:
- It allows future cassettes to be recorded from any region.
- We can easily move integ CI to a different `AWS_REGION` without having to update the cassettes to do so.