### PR TITLE
fix(aws): Make ChatBedrock streaming with Claude 5 produce consistent block content

### DIFF
--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -38,6 +38,7 @@ from langchain_aws.utils import (
     enforce_stop_tokens,
     get_num_tokens_anthropic,
     get_token_ids_anthropic,
+    thinking_disabled_in_params,
     thinking_in_params,
     thinking_on_by_default,
 )
@@ -1298,7 +1299,9 @@ class BedrockBase(BaseLanguageModel, ABC):
                 )
             elif thinking_in_params(params):
                 coerce_content_to_string = False
-            elif thinking_on_by_default(self._get_base_model()):
+            elif thinking_on_by_default(
+                self._get_base_model()
+            ) and not thinking_disabled_in_params(params):
                 coerce_content_to_string = False
             elif messages is not None and _citations_enabled(messages):
                 coerce_content_to_string = False

--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -39,6 +39,7 @@ from langchain_aws.utils import (
     get_num_tokens_anthropic,
     get_token_ids_anthropic,
     thinking_in_params,
+    thinking_on_by_default,
 )
 
 logger = logging.getLogger(__name__)
@@ -1296,6 +1297,8 @@ class BedrockBase(BaseLanguageModel, ABC):
                     temperature=self.temperature,
                 )
             elif thinking_in_params(params):
+                coerce_content_to_string = False
+            elif thinking_on_by_default(self._get_base_model()):
                 coerce_content_to_string = False
             elif messages is not None and _citations_enabled(messages):
                 coerce_content_to_string = False

--- a/libs/aws/langchain_aws/utils.py
+++ b/libs/aws/langchain_aws/utils.py
@@ -470,6 +470,11 @@ def thinking_in_params(params: dict) -> bool:
     return params.get("thinking", {}).get("type") in ("enabled", "adaptive")
 
 
+def thinking_on_by_default(model: str) -> bool:
+    """Check if the model runs adaptive thinking without a thinking parameter."""
+    return any(x in model for x in ("claude-sonnet-5", "claude-fable-5"))
+
+
 def thinking_forced_tool_use_unsupported(model: str) -> bool:
     """Check if the model rejects forced tool use while thinking is enabled."""
     if "claude-opus-4-8" in model:

--- a/libs/aws/langchain_aws/utils.py
+++ b/libs/aws/langchain_aws/utils.py
@@ -470,6 +470,11 @@ def thinking_in_params(params: dict) -> bool:
     return params.get("thinking", {}).get("type") in ("enabled", "adaptive")
 
 
+def thinking_disabled_in_params(params: dict) -> bool:
+    """Check if thinking is explicitly disabled in the request."""
+    return params.get("thinking", {}).get("type") == "disabled"
+
+
 def thinking_on_by_default(model: str) -> bool:
     """Check if the model runs adaptive thinking without a thinking parameter."""
     return any(x in model for x in ("claude-sonnet-5", "claude-fable-5"))

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
@@ -2148,6 +2148,54 @@ def test_system_prompt_string_format() -> None:
     assert isinstance(body["system"], str)
 
 
+def test_stream_thinking_on_by_default_returns_block_content() -> None:
+    """Sonnet/Fable 5 streams should not mix string and block content."""
+    mock_client = MagicMock()
+
+    def stream_gen():
+        events = [
+            {"type": "message_start", "message": {}},
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "thinking", "thinking": "", "signature": ""},
+            },
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "signature_delta", "signature": "sig-abc"},
+            },
+            {
+                "type": "content_block_delta",
+                "index": 1,
+                "delta": {"type": "text_delta", "text": "Hello!"},
+            },
+            {"type": "message_stop"},
+        ]
+        for e in events:
+            yield {"chunk": {"bytes": json.dumps(e).encode()}}
+
+    mock_response = MagicMock()
+    mock_response.get.return_value = stream_gen()
+    mock_client.invoke_model_with_response_stream.return_value = mock_response
+
+    llm = ChatBedrock(
+        client=mock_client,
+        model="us.anthropic.claude-sonnet-5",
+        region="us-west-2",
+    )
+    full = None
+    for chunk in llm.stream([HumanMessage(content="Hello")]):
+        full = chunk if full is None else full + chunk
+
+    assert isinstance(full.content, list)
+    assert not any(isinstance(b, str) for b in full.content), full.content
+    block_types = [b["type"] for b in full.content]
+    assert "text" in block_types
+    text_blocks = [b for b in full.content_blocks if b["type"] == "text"]
+    assert len(text_blocks) == 1
+
+
 def test_stream_system_prompt_cache_control() -> None:
     """Test that cache_control is preserved in streaming."""
     mock_client = MagicMock()

--- a/libs/aws/tests/unit_tests/test_utils.py
+++ b/libs/aws/tests/unit_tests/test_utils.py
@@ -13,6 +13,7 @@ from langchain_aws.utils import (
     create_aws_client,
     thinking_forced_tool_use_unsupported,
     thinking_in_params,
+    thinking_on_by_default,
     trim_message_whitespace,
 )
 
@@ -483,6 +484,21 @@ def test_thinking_forced_tool_use_unsupported(
     model_id: str, expected_result: bool
 ) -> None:
     assert thinking_forced_tool_use_unsupported(model_id) == expected_result
+
+
+@pytest.mark.parametrize(
+    "model_id,expected_result",
+    [
+        ("us.anthropic.claude-sonnet-5", True),
+        ("global.anthropic.claude-fable-5", True),
+        ("global.anthropic.claude-opus-4-8", False),
+        ("anthropic.claude-sonnet-4-6", False),
+        ("us.anthropic.claude-sonnet-4-5-20250929-v1:0", False),
+        ("us.anthropic.claude-haiku-4-5-20251001-v1:0", False),
+    ],
+)
+def test_thinking_on_by_default(model_id: str, expected_result: bool) -> None:
+    assert thinking_on_by_default(model_id) == expected_result
 
 
 def test_api_key_uses_token_provider(

--- a/libs/aws/tests/unit_tests/test_utils.py
+++ b/libs/aws/tests/unit_tests/test_utils.py
@@ -11,6 +11,7 @@ from pydantic import SecretStr
 from langchain_aws.utils import (
     count_tokens_api_supported_for_model,
     create_aws_client,
+    thinking_disabled_in_params,
     thinking_forced_tool_use_unsupported,
     thinking_in_params,
     thinking_on_by_default,
@@ -499,6 +500,19 @@ def test_thinking_forced_tool_use_unsupported(
 )
 def test_thinking_on_by_default(model_id: str, expected_result: bool) -> None:
     assert thinking_on_by_default(model_id) == expected_result
+
+
+@pytest.mark.parametrize(
+    "params,expected_result",
+    [
+        ({"thinking": {"type": "disabled"}}, True),
+        ({"thinking": {"type": "enabled", "budget_tokens": 1024}}, False),
+        ({"thinking": {"type": "adaptive"}}, False),
+        ({}, False),
+    ],
+)
+def test_thinking_disabled_in_params(params: dict, expected_result: bool) -> None:
+    assert thinking_disabled_in_params(params) == expected_result
 
 
 def test_api_key_uses_token_provider(


### PR DESCRIPTION
Fixing a stochastic (~75% success rate) failure with `TestBedrockStandard::test_astream` in live integ CI runs after #1154 (https://github.com/langchain-ai/langchain-aws/actions/runs/29048020685/job/86221390451):
```
          text_blocks = [b for b in full.content_blocks if b["type"] == "text"]
  >       assert len(text_blocks) == 1
  E       assert 0 == 1
```

As is, ChatBedrock's stream response processor will skip string coercion of text delta blocks if thinking is enabled, which it was able to positively determine with older models [by directly checking the request parameters](https://github.com/langchain-ai/langchain-aws/blob/main/libs/aws/langchain_aws/llms/bedrock.py#L1298-L1299). 

HOWEVER, for Claude 5 models, the presence of thinking is nondeterministic with the default adaptive thinking mode, which can't be disabled. So, as is, we might end up with mixed plain string and dict thinking blocks in the final processed stream content when these blocks dodge the check that's supposed to prevent this from happening.

Fixing this by adding an extra conditional to run the `thinking_on_by_default` util check for adaptive-thinking-only models, ensuring that Bedrock streaming with Claude 5 models always returns a consistent set of dict-format blocks.