### PR TITLE
feat(aws): Log helpful warning when ChatBedrockConverse auto-disables streaming for unsupported models

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -888,23 +888,41 @@ class ChatBedrockConverse(BaseChatModel):
             raise ValueError("base_model_id, base_model, or model_id must be specified")
         model_id_lower = base_model_value.lower()
 
-        streaming_support = cls._get_streaming_support(provider, model_id_lower)
+        if "disable_streaming" not in values:
+            values["disable_streaming"] = cls._resolve_disable_streaming(
+                provider,
+                model_id_lower,
+                warn="application-inference-profile" not in model_id,
+            )
 
+        return values
+
+    @classmethod
+    def _resolve_disable_streaming(
+        cls, provider: str, model_id_lower: str, *, warn: bool = True
+    ) -> Union[bool, Literal["tool_calling"]]:
+        streaming_support = cls._get_streaming_support(provider, model_id_lower)
         # Set the disable_streaming flag accordingly:
         # - If streaming is supported (plain streaming),
         #       we want streaming enabled (i.e. disable_streaming == False).
         # - If the model supports streaming only in non-tool mode ("no_tools"),
         #       then we must force disable streaming when tools are used.
         # - Otherwise, if streaming is not supported, we set disable_streaming to True.
-        if "disable_streaming" not in values:
-            if not streaming_support:
-                values["disable_streaming"] = True
-            elif streaming_support == "no_tools":
-                values["disable_streaming"] = "tool_calling"
-            else:
-                values["disable_streaming"] = False
-
-        return values
+        if not streaming_support:
+            if warn:
+                logger.warning(
+                    "Streaming disabled for model '%s': provider '%s' is not "
+                    "verified as streaming-capable with ChatBedrockConverse, "
+                    "so calls will fall back to the non-streaming Converse "
+                    "API. If this model does support streaming, pass "
+                    "disable_streaming=False to override.",
+                    model_id_lower,
+                    provider,
+                )
+            return True
+        if streaming_support == "no_tools":
+            return "tool_calling"
+        return False
 
     def _get_effective_config(self) -> Any:
         """Merge timeout/max_retries into botocore Config if set."""
@@ -1081,15 +1099,9 @@ class ChatBedrockConverse(BaseChatModel):
         base_model = self._get_base_model()
         model_id_lower = base_model.lower()
 
-        streaming_support = self._get_streaming_support(self.provider, model_id_lower)
-
-        # Set the disable_streaming flag accordingly
-        if not streaming_support:
-            self.disable_streaming = True
-        elif streaming_support == "no_tools":
-            self.disable_streaming = "tool_calling"
-        else:
-            self.disable_streaming = False
+        self.disable_streaming = self._resolve_disable_streaming(
+            self.provider, model_id_lower
+        )
 
     def _validate_nova_reasoning_config(self) -> None:
         """Validate reasoning configuration for Nova 2 models.

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -2,6 +2,7 @@
 
 import base64
 import json
+import logging
 import os
 import warnings
 from typing import (
@@ -817,6 +818,30 @@ def test_set_disable_streaming(
 ) -> None:
     llm = ChatBedrockConverse(model=model_id, region_name="us-west-2")
     assert llm.disable_streaming == disable_streaming
+
+
+@pytest.mark.parametrize(
+    "model_id, model_kwargs, expect_warning",
+    [
+        ("us.amazon.nonstreaming-model-v1:0", {}, True),
+        ("us.anthropic.claude-sonnet-5", {}, False),
+        ("us.amazon.nonstreaming-model-v1:0", {"disable_streaming": False}, False),
+    ],
+)
+def test_set_disable_streaming_warning(
+    model_id: str,
+    model_kwargs: dict,
+    expect_warning: bool,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.WARNING, logger="langchain_aws"):
+        ChatBedrockConverse(model=model_id, region_name="us-west-2", **model_kwargs)
+    warnings_emitted = [
+        r
+        for r in caplog.records
+        if "Streaming disabled" in r.message and "disable_streaming=False" in r.message
+    ]
+    assert bool(warnings_emitted) == expect_warning
 
 
 def test_streaming_init_param() -> None:
@@ -3002,6 +3027,7 @@ def test_configure_streaming_for_resolved_model_no_tools(
 @mock.patch("langchain_aws.chat_models.bedrock_converse.create_aws_client")
 def test_configure_streaming_for_resolved_model_no_streaming(
     mock_create_client: mock.Mock,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test _configure_streaming_for_resolved_model method with no streaming support."""
     mock_bedrock_client = mock.Mock()
@@ -3028,14 +3054,20 @@ def test_configure_streaming_for_resolved_model_no_streaming(
 
     mock_create_client.side_effect = side_effect
 
-    chat_model = ChatBedrockConverse(
-        model="arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/test-profile",
-        region_name="us-west-2",
-        provider="stability",
-    )
+    with caplog.at_level(logging.WARNING, logger="langchain_aws"):
+        chat_model = ChatBedrockConverse(
+            model="arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/test-profile",
+            region_name="us-west-2",
+            provider="stability",
+        )
 
     # The streaming should be disabled for models with no streaming support
     assert chat_model.disable_streaming is True
+
+    # Also check that the no-streaming warning uses the base model, not the raw AIP ARN
+    warnings_emitted = [r for r in caplog.records if "Streaming disabled" in r.message]
+    assert len(warnings_emitted) == 1
+    assert "stability.stable-image-core-v1:0" in warnings_emitted[0].message
 
 
 def test_nova_provider_extraction() -> None:


### PR DESCRIPTION
Addresses point 2 from #1158.

Updating `ChatBedrockConverse` to add a clarifying logger warning when streaming is auto-disabled for models that haven't been whitelisted. The warning will also point users towards the `disable_streaming=False` override parameter (which should reduce the need to manually provide this guidance on issues related to new model release support).

As part of this, also refactored the streaming configuration logic to have both regular model IDs and AIPs use a shared `_resolve_disable_streaming` helper method to set the final support level.
