### PR TITLE
fix(aws): escape stop sequences before building regex in enforce_stop_tokens

### DIFF
--- a/libs/aws/langchain_aws/llms/sagemaker_endpoint.py
+++ b/libs/aws/langchain_aws/llms/sagemaker_endpoint.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 def enforce_stop_tokens(text: str, stop: List[str]) -> str:
     """Cut off the text as soon as any stop words occur."""
-    return re.split("|".join(stop), text, maxsplit=1)[0]
+    return re.split("|".join(re.escape(s) for s in stop), text, maxsplit=1)[0]
 
 
 class LineIterator:

--- a/libs/aws/langchain_aws/utils.py
+++ b/libs/aws/langchain_aws/utils.py
@@ -86,7 +86,7 @@ class ContentHandlerBase(Generic[INPUT_TYPE, OUTPUT_TYPE]):
 
 def enforce_stop_tokens(text: str, stop: List[str]) -> str:
     """Cut off the text as soon as any stop words occur."""
-    return re.split("|".join(stop), text, maxsplit=1)[0]
+    return re.split("|".join(re.escape(s) for s in stop), text, maxsplit=1)[0]
 
 
 def anthropic_tokens_supported() -> bool:

--- a/libs/aws/tests/unit_tests/llms/test_sagemaker_endpoint.py
+++ b/libs/aws/tests/unit_tests/llms/test_sagemaker_endpoint.py
@@ -1,0 +1,26 @@
+from langchain_aws.llms.sagemaker_endpoint import enforce_stop_tokens
+
+
+def test_enforce_stop_tokens_treats_stop_sequence_as_literal_text() -> None:
+    """Stop sequences containing regex metacharacters must not be treated as regex.
+
+    Special tokens like Llama 3's ``<|eot_id|>`` contain a literal ``|``, which is
+    the regex alternation operator. If the stop sequence isn't escaped before being
+    joined into the split pattern, text is truncated wherever any *character* of the
+    stop sequence appears, instead of only where the exact stop sequence occurs.
+    """
+    text = "Here is <content> you asked for, spanning multiple sentences."
+    result = enforce_stop_tokens(text, ["<|eot_id|>"])
+    assert result == text
+
+
+def test_enforce_stop_tokens_does_not_raise_on_regex_metacharacters() -> None:
+    """A stop sequence like ``AI)`` must not be interpreted as unbalanced regex."""
+    result = enforce_stop_tokens("Hello AI) world", ["AI)"])
+    assert result == "Hello "
+
+
+def test_enforce_stop_tokens_still_cuts_on_exact_match() -> None:
+    text = "Hello<|eot_id|>World"
+    result = enforce_stop_tokens(text, ["<|eot_id|>"])
+    assert result == "Hello"

--- a/libs/aws/tests/unit_tests/test_utils.py
+++ b/libs/aws/tests/unit_tests/test_utils.py
@@ -11,6 +11,7 @@ from pydantic import SecretStr
 from langchain_aws.utils import (
     count_tokens_api_supported_for_model,
     create_aws_client,
+    enforce_stop_tokens,
     thinking_disabled_in_params,
     thinking_forced_tool_use_unsupported,
     thinking_in_params,
@@ -1066,3 +1067,28 @@ def test_bedrock_runtime_session_region_fallback(
 
     call_kwargs = config_cls.call_args[1]
     assert call_kwargs["region"] == "sa-east-1"
+
+
+def test_enforce_stop_tokens_treats_stop_sequence_as_literal_text() -> None:
+    """Stop sequences containing regex metacharacters must not be treated as regex.
+
+    Special tokens like Llama 3's ``<|eot_id|>`` contain a literal ``|``, which is
+    the regex alternation operator. If the stop sequence isn't escaped before being
+    joined into the split pattern, text is truncated wherever any *character* of the
+    stop sequence appears, instead of only where the exact stop sequence occurs.
+    """
+    text = "Here is <content> you asked for, spanning multiple sentences."
+    result = enforce_stop_tokens(text, ["<|eot_id|>"])
+    assert result == text
+
+
+def test_enforce_stop_tokens_does_not_raise_on_regex_metacharacters() -> None:
+    """A stop sequence like ``AI)`` must not be interpreted as unbalanced regex."""
+    result = enforce_stop_tokens("Hello AI) world", ["AI)"])
+    assert result == "Hello "
+
+
+def test_enforce_stop_tokens_still_cuts_on_exact_match() -> None:
+    text = "Hello<|eot_id|>World"
+    result = enforce_stop_tokens(text, ["<|eot_id|>"])
+    assert result == "Hello"


### PR DESCRIPTION
## Problem

`enforce_stop_tokens()` (in both `langchain_aws/utils.py` and the duplicated copy in `langchain_aws/llms/sagemaker_endpoint.py`) joins raw stop strings into a regex alternation pattern without escaping them:

```python
return re.split("|".join(stop), text, maxsplit=1)[0]
```

Any stop sequence containing regex metacharacters is silently misinterpreted instead of matched literally. This is especially damaging because the most common real-world stop sequences are LLM special tokens containing `|`, e.g. Llama 3's `<|eot_id|>` or `<|im_end|>` — these get parsed as regex alternation instead of a literal string, so output can be truncated at the wrong position. Stop sequences containing unbalanced parentheses (e.g. `"AI)"`) raise `re.error: unbalanced parenthesis`, crashing the call outright.

`BedrockLLM._call` (`llms/bedrock.py:1199`) uses this as its **sole** stop-sequence enforcement mechanism for the non-streaming path, so this is reachable directly from `BedrockLLM.invoke()`. The identical bug is independently duplicated in `sagemaker_endpoint.py`.

## Fix

`re.escape()` each stop string before joining into the pattern. Fixed both copies since they're the same defect.

## Testing

- `tests/unit_tests/test_utils.py` and `tests/unit_tests/llms/test_sagemaker_endpoint.py`: added tests covering (a) a stop sequence containing regex metacharacters (`|`) truncating at the correct literal position rather than an earlier metacharacter match, and (b) a stop sequence with unbalanced parentheses no longer raising `re.error`.
- Confirmed red→green: reverting only the two source files reproduces both failure modes (wrong truncation point; `re.error: unbalanced parenthesis`); reapplying the fix passes.
- Full `tests/unit_tests/` suite: 970 passed, 1 skipped, 1 xfailed (matches baseline).
- `ruff check` and `mypy` clean on changed files.

## AI-Generated disclosure

Found via an AI-assisted code review pass (Claude Code) over `langchain_aws/`. I personally reproduced both failure modes with standalone repros, verified the fix, traced the reachability from `BedrockLLM.invoke()`, and ran the full unit test suite plus lint/mypy before submitting.