### PR TITLE
fix(aws): AmazonKendraRetriever.min_score_confidence has no default, crashes on construction

### DIFF
--- a/libs/aws/langchain_aws/retrievers/kendra.py
+++ b/libs/aws/langchain_aws/retrievers/kendra.py
@@ -422,7 +422,9 @@ class AmazonKendraRetriever(BaseRetriever):
     attribute_filter: Optional[Dict] = None
     page_content_formatter: Callable[[ResultItem], str] = combined_text
     user_context: Optional[Dict] = None
-    min_score_confidence: Annotated[Optional[float], Field(ge=0.0, le=1.0)]
+    min_score_confidence: Annotated[
+        Optional[float], Field(ge=0.0, le=1.0, default=None)
+    ]
 
     @field_validator("top_k")
     def validate_top_k(cls, value: int) -> int:

--- a/libs/aws/tests/unit_tests/retrievers/test_kendra.py
+++ b/libs/aws/tests/unit_tests/retrievers/test_kendra.py
@@ -1,0 +1,15 @@
+# type: ignore
+from unittest.mock import MagicMock
+
+from langchain_aws.retrievers.kendra import AmazonKendraRetriever
+
+
+def test_construct_without_min_score_confidence() -> None:
+    """min_score_confidence must be optional, as documented in the class's own
+    Example (`AmazonKendraRetriever(index_id=...)`), which omits it entirely.
+
+    The field previously had no `default=`, so `Optional[float]` alone did not
+    make it optional under Pydantic v2 and construction raised a ValidationError.
+    """
+    retriever = AmazonKendraRetriever(index_id="test-index-id", client=MagicMock())
+    assert retriever.min_score_confidence is None


### PR DESCRIPTION
## Problem

`min_score_confidence: Annotated[Optional[float], Field(ge=0.0, le=1.0)]` (`retrievers/kendra.py:425`) had no `default=`. Under Pydantic v2, `Optional[float]` alone does not make a field optional — a default must be given explicitly, or the field is required.

As a result, the class's own documented `Example`:

```python
retriever = AmazonKendraRetriever(
    index_id="c0806df7-e76b-4bce-9b5c-d5582f6b1a03"
)
```

raises:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for AmazonKendraRetriever
min_score_confidence
  Field required [type=missing]
```

(Note: in a bare environment with no AWS credentials configured at all, an earlier credentials-derivation validator error masks this one — I confirmed the missing-field error surfaces once valid-shaped credentials are present, which is the normal case for anyone actually using this retriever, and is also what the added unit test exercises directly via a mocked `client=`.)

The sibling class `AmazonKnowledgeBasesRetriever` (`retrievers/bedrock.py:132`) declares the equivalent field correctly with `default=None`, and both classes' `_filter_by_score_confidence` already treat a falsy/`None` `min_score_confidence` as "no filtering" — so `default=None` is the correct, already-supported value; no downstream changes needed.

## Fix

Add `default=None` to match the sibling implementation.

## Testing

- Added `test_construct_without_min_score_confidence` (`tests/unit_tests/retrievers/test_kendra.py`), constructing with a mocked `client=` to avoid needing real AWS credentials, asserting the class's own documented no-arg-besides-`index_id` example works.
- Confirmed red→green: reverting only `kendra.py` reproduces the exact `ValidationError: Field required`; reapplying passes.
- Full `tests/unit_tests/retrievers/`: 48 passed. Full `tests/unit_tests/`: 965 passed, 1 skipped, 1 xfailed.
- `ruff check` and `mypy` clean on changed files.

## AI-Generated disclosure

Found via an AI-assisted code review pass (Claude Code) over `langchain_aws/retrievers/`. I personally reproduced the crash (confirming the credentials-masking nuance above), verified the fix, checked the sibling implementation for the correct default value, and ran the relevant test suites plus lint/mypy before submitting.