### PR TITLE
fix(aws): _tool_to_function marks falsy-default tool args as required

### DIFF
--- a/libs/aws/langchain_aws/agents/utils.py
+++ b/libs/aws/langchain_aws/agents/utils.py
@@ -312,7 +312,7 @@ def _tool_to_function(tool: BaseTool) -> dict:
                 "description", arg_details.get("title", arg_name)
             ),
             "type": arg_details.get("type", "string"),
-            "required": not bool(arg_details.get("default", None)),
+            "required": "default" not in arg_details,
         }
     return {
         "description": tool.description,

--- a/libs/aws/tests/unit_tests/agents/test_utils.py
+++ b/libs/aws/tests/unit_tests/agents/test_utils.py
@@ -1,8 +1,10 @@
 from botocore.config import Config
+from langchain_core.tools import tool
 
 from langchain_aws.agents.base import BedrockAgentFinish
 from langchain_aws.agents.utils import (
     SDK_USER_AGENT,
+    _tool_to_function,
     get_boto_session,
     parse_agent_response,
 )
@@ -81,3 +83,36 @@ class TestNonAsciiPreservation:
         assert isinstance(result.trace_log, str)
         assert self._CJK in result.trace_log
         assert "\\u" not in result.trace_log
+
+
+def test_tool_to_function_falsy_defaults_are_not_required() -> None:
+    """Args with a falsy-but-present default (0, False, "") must be optional.
+
+    _tool_to_function previously computed "required" via
+    `not bool(arg_details.get("default", None))`, which checks the
+    *truthiness* of the default value rather than its *presence*. An arg
+    whose default is a legitimate falsy value (0, False, "") was
+    indistinguishable from an arg with no default at all, and got
+    incorrectly marked "required": True in the Bedrock action-group
+    function schema.
+    """
+
+    @tool
+    def sample(
+        query: str,
+        limit: int = 0,
+        verbose: bool = False,
+        name: str = "",
+        threshold: float = 1.5,
+    ) -> str:
+        """A sample tool with a mix of required args and falsy defaults."""
+        return query
+
+    function = _tool_to_function(sample)
+    params = function["parameters"]
+
+    assert params["query"]["required"] is True  # no default -> required
+    assert params["limit"]["required"] is False  # default=0
+    assert params["verbose"]["required"] is False  # default=False
+    assert params["name"]["required"] is False  # default=""
+    assert params["threshold"]["required"] is False  # default=1.5


### PR DESCRIPTION
## Problem

`_tool_to_function` (`agents/utils.py:315`) computed the Bedrock action-group function schema's `"required"` flag as:

```python
"required": not bool(arg_details.get("default", None)),
```

This is a truthiness check on the default *value* rather than a presence check on the `"default"` *key*. Any LangChain tool argument whose default is a legitimate falsy value (`0`, `False`, `""`, `[]`) is indistinguishable from an argument with no default at all, and gets incorrectly reported as `"required": True` in the schema sent to `bedrock_client.create_agent_action_group`.

`_tool_to_function` is used by both `BedrockAgentsRunnable.create_agent` (via `_create_bedrock_action_groups`) and `BedrockInlineAgentsRunnable._get_action_groups`, so this affects the actual function schema registered with real Bedrock Agents for any tool with an optional falsy-default argument.

## Fix

Check for key presence instead of value truthiness: `"required": "default" not in arg_details`.

## Testing

- Verified independently that LangChain's tool-args schema does put a literal `"default": 0` key in `tool.args` for a param like `limit: int = 0` (confirmed via a standalone repro with `@tool`-decorated function).
- Added `test_tool_to_function_falsy_defaults_are_not_required` (`tests/unit_tests/agents/test_utils.py`) covering a tool with both a required arg (no default) and several falsy-default args.
- Confirmed red→green: reverting only `agents/utils.py` reproduces `assert True is False` for the falsy-default case; reapplying passes.
- Full `tests/unit_tests/`: 965 passed, 1 skipped, 1 xfailed.
- `ruff check` and `mypy` clean on changed files.
- xref: no open PR touches `agents/utils.py`.

## AI-Generated disclosure

Found via an AI-assisted code review pass (Claude Code) over `langchain_aws/agents/`. I personally reproduced the schema field's presence-vs-truthiness gap with a standalone repro, verified the fix, traced the reachability from both `BedrockAgentsRunnable.create_agent` and `BedrockInlineAgentsRunnable._get_action_groups`, and ran the full test suite plus lint/mypy before submitting.