### PR TITLE
fix(aws): Improve provider identification for model IDs with dotted versions

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -79,6 +79,7 @@ from langchain_aws.tools.nova_tools import NovaSystemTool
 from langchain_aws.utils import (
     count_tokens_api_supported_for_model,
     create_aws_client,
+    parse_model_provider,
     thinking_forced_tool_use_unsupported,
     thinking_in_params,
     trim_message_whitespace,
@@ -874,10 +875,7 @@ class ChatBedrockConverse(BaseChatModel):
                     "Model provider should be supplied when passing a model ARN "
                     "as model_id."
                 )
-            model_parts = model_id.split(".")
-            values["provider"] = (
-                model_parts[-2] if len(model_parts) > 1 else model_parts[0]
-            )
+            values["provider"] = parse_model_provider(model_id)
 
         provider = values["provider"]
 

--- a/libs/aws/langchain_aws/embeddings/bedrock.py
+++ b/libs/aws/langchain_aws/embeddings/bedrock.py
@@ -13,7 +13,7 @@ from langchain_core.utils import secret_from_env
 from pydantic import BaseModel, ConfigDict, Field, SecretStr, model_validator
 from typing_extensions import Self
 
-from langchain_aws.utils import create_aws_client
+from langchain_aws.utils import create_aws_client, parse_model_provider
 
 logger = logging.getLogger(__name__)
 
@@ -153,9 +153,7 @@ class BedrockEmbeddings(BaseModel, Embeddings):
         if self.provider:
             return self.provider
 
-        regions = ("eu", "us", "us-gov", "apac", "sa", "amer", "global", "jp", "au")
-        parts = self.model_id.split(".")
-        return parts[1] if parts[0] in regions else parts[0]
+        return parse_model_provider(self.model_id)
 
     @property
     def _is_cohere_v4(self) -> bool:

--- a/libs/aws/langchain_aws/llms/bedrock.py
+++ b/libs/aws/langchain_aws/llms/bedrock.py
@@ -38,6 +38,7 @@ from langchain_aws.utils import (
     enforce_stop_tokens,
     get_num_tokens_anthropic,
     get_token_ids_anthropic,
+    parse_model_provider,
     thinking_disabled_in_params,
     thinking_in_params,
     thinking_on_by_default,
@@ -1028,16 +1029,7 @@ class BedrockBase(BaseLanguageModel, ABC):
         # If model_id has region prefixed to them,
         # for example eu.anthropic.claude-3-haiku-20240307-v1:0,
         # provider is the second part, otherwise, the first part
-        parts = self.model_id.split(".", maxsplit=2)
-        return (
-            parts[1]
-            if (
-                len(parts) > 1
-                and parts[0].lower()
-                in {"eu", "us", "us-gov", "apac", "sa", "amer", "global", "jp", "au"}
-            )
-            else parts[0]
-        )
+        return parse_model_provider(self.model_id)
 
     def _get_base_model(self) -> str:
         return (

--- a/libs/aws/langchain_aws/utils.py
+++ b/libs/aws/langchain_aws/utils.py
@@ -36,6 +36,10 @@ OUTPUT_TYPE = TypeVar(
     bound=Union[str, List[List[float]], MESSAGE_FORMAT, List[MESSAGE_FORMAT], Iterator],
 )
 
+MODEL_ID_GEO_PREFIXES = frozenset(
+    {"eu", "us", "us-gov", "apac", "sa", "amer", "global", "jp", "au"}
+)
+
 
 class ContentHandlerBase(Generic[INPUT_TYPE, OUTPUT_TYPE]):
     """A handler class to transform input from LLM and BaseChatModel to a
@@ -463,6 +467,14 @@ def create_aws_bedrock_runtime_client(
         aws_credentials_identity_resolver=credentials_resolver,
     )
     return BedrockRuntimeClient(config=config)
+
+
+def parse_model_provider(model_id: str) -> str:
+    """Extract the provider from a Bedrock model ID."""
+    parts = model_id.split(".", maxsplit=2)
+    if len(parts) > 1 and parts[0].lower() in MODEL_ID_GEO_PREFIXES:
+        return parts[1]
+    return parts[0]
 
 
 def thinking_in_params(params: dict) -> bool:

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -2332,6 +2332,16 @@ def test__get_provider() -> None:
     assert llm.provider == "anthropic"
 
     llm = ChatBedrockConverse(
+        model="us.anthropic.claude-sonnet-5", region_name="us-west-2"
+    )
+
+    assert llm.provider == "anthropic"
+
+    llm = ChatBedrockConverse(model="us.openai.gpt-5.6-sol", region_name="us-west-2")
+
+    assert llm.provider == "openai"
+
+    llm = ChatBedrockConverse(
         model="arn:aws:bedrock:us-west-2::foundation-model/anthropic.claude-3-sonnet-20240229-v1:0",
         provider="anthropic",
         region_name="us-west-2",

--- a/libs/aws/tests/unit_tests/test_utils.py
+++ b/libs/aws/tests/unit_tests/test_utils.py
@@ -11,6 +11,7 @@ from pydantic import SecretStr
 from langchain_aws.utils import (
     count_tokens_api_supported_for_model,
     create_aws_client,
+    parse_model_provider,
     thinking_disabled_in_params,
     thinking_forced_tool_use_unsupported,
     thinking_in_params,
@@ -710,6 +711,20 @@ def test_api_key_takes_precedence_over_creds(
 )
 def test_thinking_in_params(params: dict, expected: bool) -> None:
     assert thinking_in_params(params) == expected
+
+
+@pytest.mark.parametrize(
+    "model_id,expected_provider",
+    [
+        ("anthropic.claude-sonnet-5", "anthropic"),
+        ("global.anthropic.claude-fable-5", "anthropic"),
+        ("us-gov.anthropic.claude-haiku-4-5-20251001-v1:0", "anthropic"),
+        ("minimax.minimax-m2.5", "minimax"),
+        ("us.minimax.minimax-m2.5", "minimax"),
+    ],
+)
+def test_parse_model_provider(model_id: str, expected_provider: str) -> None:
+    assert parse_model_provider(model_id) == expected_provider
 
 
 @pytest.mark.parametrize("api_key", [SecretStr(""), None])


### PR DESCRIPTION
Addressing point 1 from #1158.

Updates `ChatBedrock` and `ChatBedrockConverse` to use a new `parse_model_provider` utility. 

This will now correctly handle base model IDs that contain non-demarcating `.` (ex. for model minor versions, like in ChatGPT 5.6: `us.openai.gpt-5.6-sol`)

