### PR TITLE
fix(aws): map search_result blocks for Bedrock Converse

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -2671,6 +2671,23 @@ def _lc_content_to_bedrock(
                     }
                 }
             )
+        elif block["type"] == "search_result":
+            search_result_content = _lc_content_to_bedrock(block["content"])
+            if not all(
+                set(search_result_content_block) == {"text"}
+                for search_result_content_block in search_result_content
+            ):
+                msg = "search_result content blocks must be text-only"
+                raise ValueError(msg)
+
+            search_result: Dict[str, Any] = {
+                "source": block["source"],
+                "title": block["title"],
+                "content": search_result_content,
+            }
+            if block.get("citations") is not None:
+                search_result["citations"] = block["citations"]
+            bedrock_content.append({"searchResult": search_result})
         # Only needed for tool_result content blocks.
         elif block["type"] == "json":
             bedrock_content.append({"json": block["json"]})

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -639,6 +639,53 @@ def test_messages_to_bedrock_with_cache_point() -> None:
     assert [] == actual_system
 
 
+def test_messages_to_bedrock_with_tool_message_search_result() -> None:
+    messages = [
+        ToolMessage(
+            content=[
+                {
+                    "type": "search_result",
+                    "source": "web",
+                    "title": "Weather report",
+                    "content": [{"type": "text", "text": "It is sunny in Seattle."}],
+                    "citations": {"enabled": True},
+                }
+            ],
+            tool_call_id="tool-123",
+            status="success",
+        )
+    ]
+
+    actual_messages, actual_system = _messages_to_bedrock(messages)
+
+    assert actual_messages == [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "toolResult": {
+                        "content": [
+                            {
+                                "searchResult": {
+                                    "source": "web",
+                                    "title": "Weather report",
+                                    "content": [
+                                        {"text": "It is sunny in Seattle."}
+                                    ],
+                                    "citations": {"enabled": True},
+                                }
+                            }
+                        ],
+                        "status": "success",
+                        "toolUseId": "tool-123",
+                    }
+                }
+            ],
+        }
+    ]
+    assert [] == actual_system
+
+
 def test__messages_to_bedrock_empty_list() -> None:
     messages: List[BaseMessage] = []
     actual_messages, actual_system = _messages_to_bedrock(messages)
@@ -2286,6 +2333,54 @@ def test__lc_content_to_bedrock_mixed_types_with_empty_content() -> None:
 
     assert len(bedrock_content) == 3
     assert bedrock_content == expected
+
+
+def test__lc_content_to_bedrock_search_result() -> None:
+    content: List[Union[str, Dict[str, Any]]] = [
+        {
+            "type": "search_result",
+            "source": "web",
+            "title": "Weather report",
+            "content": [{"type": "text", "text": "It is sunny in Seattle."}],
+            "citations": {"enabled": True},
+        }
+    ]
+
+    bedrock_content = _lc_content_to_bedrock(content)
+
+    assert bedrock_content == [
+        {
+            "searchResult": {
+                "source": "web",
+                "title": "Weather report",
+                "content": [{"text": "It is sunny in Seattle."}],
+                "citations": {"enabled": True},
+            }
+        }
+    ]
+
+
+def test__lc_content_to_bedrock_search_result_rejects_non_text_content() -> None:
+    content: List[Union[str, Dict[str, Any]]] = [
+        {
+            "type": "search_result",
+            "source": "web",
+            "title": "Weather report",
+            "content": [
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/jpeg",
+                        "data": "data",
+                    },
+                }
+            ],
+        }
+    ]
+
+    with pytest.raises(ValueError, match="search_result content blocks"):
+        _lc_content_to_bedrock(content)
 
 
 def test__lc_content_to_bedrock_non_standard_unwrap() -> None:

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -640,7 +640,7 @@ def test_messages_to_bedrock_with_cache_point() -> None:
 
 
 def test_messages_to_bedrock_with_tool_message_search_result() -> None:
-    messages = [
+    messages: List[BaseMessage] = [
         ToolMessage(
             content=[
                 {

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -669,9 +669,7 @@ def test_messages_to_bedrock_with_tool_message_search_result() -> None:
                                 "searchResult": {
                                     "source": "web",
                                     "title": "Weather report",
-                                    "content": [
-                                        {"text": "It is sunny in Seattle."}
-                                    ],
+                                    "content": [{"text": "It is sunny in Seattle."}],
                                     "citations": {"enabled": True},
                                 }
                             }


### PR DESCRIPTION
## Summary

- Map Anthropic-style `search_result` content blocks to Bedrock Converse `searchResult` blocks.
- Preserve `source`, `title`, text-only `content`, and optional `citations` in the request payload.
- Add unit coverage for direct conversion, ToolMessage nesting, and rejection of non-text search result content.

Fixes #1159

## Testing

- `libs/aws/.venv/bin/python -m pytest libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py -q -k "search_result"`
- `python -m py_compile libs/aws/langchain_aws/chat_models/bedrock_converse.py libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py`
- `git diff --check`
