### PR TITLE
feat(aws): support Bedrock Guardrails in ChatAnthropicBedrock

### DIFF
--- a/libs/aws/langchain_aws/chat_models/anthropic.py
+++ b/libs/aws/langchain_aws/chat_models/anthropic.py
@@ -110,6 +110,19 @@ class ChatAnthropicBedrock(ChatAnthropic):
     If not provided, will be read from 'AWS_SESSION_TOKEN' environment variable.
     """
 
+    guardrail_config: dict[str, Any] | None = Field(default=None, alias="guardrails")
+    """Configuration for an Amazon Bedrock Guardrail applied to every request.
+
+    Same shape as `ChatBedrockConverse`, e.g.
+    `{"guardrailIdentifier": "gr-abc123", "guardrailVersion": "1", "trace": "enabled"}`.
+
+    The native Bedrock `InvokeModel` APIs used by the Anthropic SDK attach
+    guardrails as HTTP request headers rather than a request body field, so this
+    config is translated into the `X-Amzn-Bedrock-GuardrailIdentifier`,
+    `X-Amzn-Bedrock-GuardrailVersion` and `X-Amzn-Bedrock-Trace` headers and
+    merged over `default_headers` (guardrail values win on key conflicts).
+    """
+
     @property
     def _llm_type(self) -> str:
         """Return type of chat model."""
@@ -135,6 +148,40 @@ class ChatAnthropicBedrock(ChatAnthropic):
         """
         return ["langchain", "chat_models", "anthropic_bedrock"]
 
+    def _guardrail_headers(self) -> dict[str, str]:
+        """Translate `guardrail_config` into Bedrock guardrail request headers.
+
+        The native `InvokeModel` / `InvokeModelWithResponseStream` APIs attach
+        guardrails via HTTP headers instead of a request body field, so the
+        Converse-style config is mapped onto those headers here.
+
+        Returns:
+            Header dict to merge into the client's default headers; empty when
+            no guardrail is configured.
+
+        Raises:
+            ValueError: If `guardrail_config` is missing `guardrailIdentifier`
+                or `guardrailVersion` — failing loudly instead of silently
+                sending unguarded requests.
+        """
+        if not self.guardrail_config:
+            return {}
+        identifier = self.guardrail_config.get("guardrailIdentifier")
+        version = self.guardrail_config.get("guardrailVersion")
+        if not identifier or not version:
+            msg = (
+                "guardrail_config requires both 'guardrailIdentifier' and "
+                "'guardrailVersion'."
+            )
+            raise ValueError(msg)
+        headers = {
+            "X-Amzn-Bedrock-GuardrailIdentifier": str(identifier),
+            "X-Amzn-Bedrock-GuardrailVersion": str(version),
+        }
+        if trace := self.guardrail_config.get("trace"):
+            headers["X-Amzn-Bedrock-Trace"] = str(trace).upper()
+        return headers
+
     @cached_property
     def _client_params(self) -> dict[str, Any]:
         """Get client parameters for AnthropicBedrock."""
@@ -144,13 +191,16 @@ class ChatAnthropicBedrock(ChatAnthropic):
             or os.getenv("AWS_DEFAULT_REGION")
             or None  # let boto3 resolve
         )
+        default_headers = self.default_headers
+        if guardrail_headers := self._guardrail_headers():
+            default_headers = {**(self.default_headers or {}), **guardrail_headers}
         return _create_bedrock_client_params(
             region_name=region_name,
             aws_access_key_id=self.aws_access_key_id,
             aws_secret_access_key=self.aws_secret_access_key,
             aws_session_token=self.aws_session_token,
             max_retries=self.max_retries,
-            default_headers=self.default_headers,
+            default_headers=default_headers,
             timeout=self.default_request_timeout,
         )
 

--- a/libs/aws/tests/unit_tests/chat_models/test_anthropic.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_anthropic.py
@@ -291,3 +291,94 @@ def test_model_profile(model_name: str) -> None:
     )
     assert model.profile
     assert "max_input_tokens" in model.profile
+
+
+def test_chat_anthropic_bedrock_guardrail_config_sets_headers() -> None:
+    """Test guardrail_config is translated into Bedrock guardrail headers."""
+    model = ChatAnthropicBedrock(  # type: ignore[call-arg]
+        model=BEDROCK_MODEL_NAME,
+        region_name="us-east-1",
+        aws_access_key_id=SecretStr("test-key"),
+        aws_secret_access_key=SecretStr("test-secret"),
+        guardrail_config={
+            "guardrailIdentifier": "gr-abc123",
+            "guardrailVersion": "1",
+            "trace": "enabled",
+        },
+    )
+    headers = model._client_params["default_headers"]
+    assert headers["X-Amzn-Bedrock-GuardrailIdentifier"] == "gr-abc123"
+    assert headers["X-Amzn-Bedrock-GuardrailVersion"] == "1"
+    assert headers["X-Amzn-Bedrock-Trace"] == "ENABLED"
+
+
+def test_chat_anthropic_bedrock_guardrail_config_without_trace() -> None:
+    """Test the trace header is omitted when `trace` is not configured."""
+    model = ChatAnthropicBedrock(  # type: ignore[call-arg]
+        model=BEDROCK_MODEL_NAME,
+        region_name="us-east-1",
+        guardrail_config={
+            "guardrailIdentifier": "gr-abc123",
+            "guardrailVersion": "2",
+        },
+    )
+    headers = model._client_params["default_headers"]
+    assert headers["X-Amzn-Bedrock-GuardrailVersion"] == "2"
+    assert "X-Amzn-Bedrock-Trace" not in headers
+
+
+def test_chat_anthropic_bedrock_no_guardrail_config_no_headers() -> None:
+    """Test that without guardrail_config no guardrail headers are added."""
+    model = ChatAnthropicBedrock(  # type: ignore[call-arg]
+        model=BEDROCK_MODEL_NAME,
+        region_name="us-east-1",
+    )
+    headers = model._client_params["default_headers"] or {}
+    assert "X-Amzn-Bedrock-GuardrailIdentifier" not in headers
+    assert "X-Amzn-Bedrock-GuardrailVersion" not in headers
+
+
+def test_chat_anthropic_bedrock_guardrail_config_merges_default_headers() -> None:
+    """Test guardrail headers merge over user default_headers, keeping the rest."""
+    model = ChatAnthropicBedrock(  # type: ignore[call-arg]
+        model=BEDROCK_MODEL_NAME,
+        region_name="us-east-1",
+        default_headers={
+            "X-Custom": "keep-me",
+            "X-Amzn-Bedrock-GuardrailVersion": "stale",
+        },
+        guardrail_config={
+            "guardrailIdentifier": "gr-abc123",
+            "guardrailVersion": "3",
+        },
+    )
+    headers = model._client_params["default_headers"]
+    assert headers["X-Custom"] == "keep-me"
+    assert headers["X-Amzn-Bedrock-GuardrailIdentifier"] == "gr-abc123"
+    assert headers["X-Amzn-Bedrock-GuardrailVersion"] == "3"
+
+
+def test_chat_anthropic_bedrock_guardrail_config_requires_both_keys() -> None:
+    """Test incomplete guardrail_config fails instead of silently not guarding."""
+    model = ChatAnthropicBedrock(  # type: ignore[call-arg]
+        model=BEDROCK_MODEL_NAME,
+        region_name="us-east-1",
+        guardrail_config={"guardrailIdentifier": "gr-abc123"},
+    )
+    with pytest.raises(ValueError, match="guardrailVersion"):
+        _ = model._client_params
+
+
+def test_chat_anthropic_bedrock_guardrails_alias() -> None:
+    """Test the `guardrails` alias for parity with `ChatBedrockConverse`."""
+    model = ChatAnthropicBedrock(  # type: ignore[call-arg]
+        model=BEDROCK_MODEL_NAME,
+        region_name="us-east-1",
+        guardrails={
+            "guardrailIdentifier": "gr-abc123",
+            "guardrailVersion": "1",
+        },
+    )
+    assert model.guardrail_config is not None
+    headers = model._client_params["default_headers"]
+    assert headers["X-Amzn-Bedrock-GuardrailIdentifier"] == "gr-abc123"


### PR DESCRIPTION
## Why

`ChatAnthropicBedrock` wraps the Anthropic SDK's `AnthropicBedrock` client, which calls Bedrock's **native `InvokeModel` APIs** — where guardrails are attached via HTTP request headers, not a request body field. The class exposes no parameter for them, so Amazon Bedrock Guardrails cannot be attached through the class API at all. This also interacts badly with IAM-enforced guardrails (`bedrock:GuardrailIdentifier` condition key on `InvokeModel`): under such a policy, all traffic from this class is denied with no way to comply.

Fixes #1177

## What

- New `guardrail_config` field — same shape and `guardrails` alias as `ChatBedrockConverse`, for parity:
  `{"guardrailIdentifier": "...", "guardrailVersion": "...", "trace": "enabled"}`
- `_guardrail_headers()` translates it into `X-Amzn-Bedrock-GuardrailIdentifier` / `X-Amzn-Bedrock-GuardrailVersion` / `X-Amzn-Bedrock-Trace`, merged over `default_headers`.
- Incomplete config (missing identifier or version) raises a `ValueError` instead of silently sending unguarded requests.
- 6 hermetic unit tests. `make format` / `make lint` (ruff + mypy) / full unit suite (986 passed) are green.

## Verified end-to-end against live Bedrock

Using this branch's code (us-east-1, Claude Sonnet 4.5, disposable guardrail with a word filter):

| Case | Result |
|---|---|
| No `guardrail_config`, trigger word | Model answers normally |
| `guardrail_config`, benign prompt | Normal answer, `guardrailAction: NONE` in `response_metadata` |
| `guardrail_config`, trigger word | Guardrail's blocked message returned, `guardrailAction: INTERVENED` |
| `guardrails=` alias, trigger word | Same intervention — alias works |
| `.stream()` with `guardrail_config`, trigger word | Intervention arrives as regular stream chunks (blocked message), no exception |
| `.ainvoke()` (async client) with `guardrail_config`, trigger word | `guardrailAction: INTERVENED` — async client inherits the headers |

The intervened response parses as a normal message through the Anthropic SDK — no shape issues, on both the sync and streaming paths.

## Review notes

- **Merge precedence**: explicit `guardrail_config` wins over conflicting keys in a user-supplied `default_headers`. Flagging in case the reverse is preferred.
- `trace` is upper-cased to the header enum (`"enabled"` → `ENABLED`).
- Headers are applied at client construction (`_client_params`), so the sync, async and streaming clients all inherit them — no streaming-specific handling needed (verified empirically for streaming and async, see table above).

---

*Disclaimer (per the repo's contribution guidelines): this contribution was developed with the assistance of an AI coding agent, with human direction and review, and validated end-to-end against a live Bedrock guardrail.*
