### PR TITLE
fix(langgraph-checkpoint-aws): make ValkeySaver writes atomic and deduped

### DIFF
--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/valkey/async_saver.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/valkey/async_saver.py
@@ -18,7 +18,7 @@ from langgraph.checkpoint.base import (
 )
 from langgraph.checkpoint.serde.base import SerializerProtocol
 
-from .base import BaseValkeySaver
+from .base import _PUT_WRITES_MAX_ATTEMPTS, BaseValkeySaver
 from .utils import aset_client_info, aset_client_name
 
 # Conditional imports for optional dependencies
@@ -33,7 +33,7 @@ except ImportError as e:
 try:
     from valkey.asyncio import Valkey as AsyncValkey
     from valkey.asyncio.connection import ConnectionPool as AsyncConnectionPool
-    from valkey.exceptions import ValkeyError
+    from valkey.exceptions import ValkeyError, WatchError
 except ImportError as e:
     raise ImportError(
         "The 'valkey' package is required to use AsyncValkeySaver. "
@@ -513,43 +513,33 @@ class AsyncValkeySaver(BaseValkeySaver):
             checkpoint_id = str(configurable["checkpoint_id"])
 
             writes_key = self._make_writes_key(thread_id, checkpoint_ns, checkpoint_id)
-
-            # Get existing writes first
-            existing_data = await self.client.get(writes_key)
-
-            existing_writes = []
-            if existing_data:
-                try:
-                    # Handle string vs bytes for orjson
-                    if isinstance(existing_data, str):
-                        existing_data = existing_data.encode("utf-8")
-                    elif not isinstance(existing_data, (bytes, bytearray, memoryview)):
-                        # Handle other types (like Mock objects) by converting to
-                        # JSON string first
-                        try:
-                            existing_data = orjson.dumps(existing_data)
-                        except (TypeError, ValueError):
-                            existing_data = b"[]"  # Default to empty array
-
-                    parsed_data = orjson.loads(existing_data)
-                    # Ensure we have a list
-                    if isinstance(parsed_data, list):
-                        existing_writes = parsed_data
-                    else:
-                        existing_writes = []
-                except (orjson.JSONDecodeError, TypeError, ValueError):
-                    existing_writes = []
-
-            # Add new writes
             new_writes = self._serialize_writes_data(writes, task_id)
-            existing_writes.extend(new_writes)
 
-            # Store updated writes atomically
-            pipe = self.client.pipeline()
-            pipe.set(writes_key, orjson.dumps(existing_writes))
-            if self.ttl:
-                pipe.expire(writes_key, int(self.ttl))
-            await pipe.execute()
+            # Read-modify-write the shared writes blob inside a WATCH/MULTI/EXEC
+            # transaction so concurrent tasks writing to the same checkpoint cannot
+            # clobber each other's writes (a lost update). WATCH aborts EXEC if the
+            # key changed since it was read, so we retry on the stale snapshot.
+            async with self.client.pipeline() as pipe:
+                for _ in range(_PUT_WRITES_MAX_ATTEMPTS):
+                    try:
+                        await pipe.watch(writes_key)
+                        existing_writes = self._parse_writes_blob(
+                            await pipe.get(writes_key)
+                        )
+                        merged_writes = self._merge_writes(existing_writes, new_writes)
+                        pipe.multi()
+                        pipe.set(writes_key, orjson.dumps(merged_writes))
+                        if self.ttl:
+                            pipe.expire(writes_key, int(self.ttl))
+                        await pipe.execute()
+                        return
+                    except WatchError:
+                        continue
+            msg = (
+                f"aput_writes could not commit after {_PUT_WRITES_MAX_ATTEMPTS} "
+                "attempts due to contention on the checkpoint writes key"
+            )
+            raise ValkeyError(msg)
 
         except (ValkeyError, orjson.JSONEncodeError, KeyError) as e:
             logger.error(f"Error in aput_writes: {e}")

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/valkey/base.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/valkey/base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import json
+import logging
 import random
 from collections.abc import Sequence
 from typing import Any, cast
@@ -26,6 +27,8 @@ from .utils import set_client_info, set_client_name
 # before giving up. Contention is bounded by the number of tasks flushing writes
 # for the same checkpoint concurrently, so this is only ever reached pathologically.
 _PUT_WRITES_MAX_ATTEMPTS = 100
+
+logger = logging.getLogger(__name__)
 
 
 class BaseValkeySaver(BaseCheckpointSaver[str]):
@@ -254,8 +257,18 @@ class BaseValkeySaver(BaseCheckpointSaver[str]):
         try:
             parsed = orjson.loads(existing_data)
         except (orjson.JSONDecodeError, TypeError, ValueError):
+            logger.warning(
+                "Discarding un-decodable checkpoint writes blob; existing "
+                "writes for this checkpoint will be replaced."
+            )
             return []
-        return parsed if isinstance(parsed, list) else []
+        if not isinstance(parsed, list):
+            logger.warning(
+                "Checkpoint writes blob was not a JSON list; existing "
+                "writes for this checkpoint will be replaced."
+            )
+            return []
+        return parsed
 
     @staticmethod
     def _merge_writes(

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/valkey/base.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/valkey/base.py
@@ -8,6 +8,7 @@ import random
 from collections.abc import Sequence
 from typing import Any, cast
 
+import orjson
 from langchain_core.runnables import RunnableConfig
 from langgraph.checkpoint.base import (
     WRITES_IDX_MAP,
@@ -20,6 +21,11 @@ from langgraph.checkpoint.base import (
 )
 
 from .utils import set_client_info, set_client_name
+
+# Number of optimistic-lock attempts for the writes read-modify-write transaction
+# before giving up. Contention is bounded by the number of tasks flushing writes
+# for the same checkpoint concurrently, so this is only ever reached pathologically.
+_PUT_WRITES_MAX_ATTEMPTS = 100
 
 
 class BaseValkeySaver(BaseCheckpointSaver[str]):
@@ -223,6 +229,64 @@ class BaseValkeySaver(BaseCheckpointSaver[str]):
             }
             serialized_writes.append(write_data)
         return serialized_writes
+
+    @staticmethod
+    def _parse_writes_blob(existing_data: Any) -> list[dict[str, Any]]:
+        """Parse the stored writes blob into a list, tolerating legacy/foreign shapes.
+
+        Args:
+            existing_data: Raw value read back from Valkey for a writes key. May be
+                `None`, `str`, `bytes`, or (in tests) another type.
+
+        Returns:
+            The decoded list of write records, or an empty list if the value is
+            missing or not a JSON list.
+        """
+        if not existing_data:
+            return []
+        if isinstance(existing_data, str):
+            existing_data = existing_data.encode("utf-8")
+        elif not isinstance(existing_data, (bytes, bytearray, memoryview)):
+            try:
+                existing_data = orjson.dumps(existing_data)
+            except (TypeError, ValueError):
+                return []
+        try:
+            parsed = orjson.loads(existing_data)
+        except (orjson.JSONDecodeError, TypeError, ValueError):
+            return []
+        return parsed if isinstance(parsed, list) else []
+
+    @staticmethod
+    def _merge_writes(
+        existing_writes: list[dict[str, Any]],
+        new_writes: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        """Merge new writes into existing ones, deduped by `(task_id, idx)`.
+
+        Mirrors `InMemorySaver.put_writes`: a positional write (`idx >= 0`) is only
+        recorded once, so replaying a task around an `interrupt()`/resume does not
+        duplicate its writes, while special channels (`idx < 0`, e.g. error/interrupt/
+        resume) overwrite in place.
+
+        Args:
+            existing_writes: Writes already stored for the checkpoint.
+            new_writes: Writes to add.
+
+        Returns:
+            The merged list.
+        """
+        merged = list(existing_writes)
+        index = {(w["task_id"], w["idx"]): i for i, w in enumerate(merged)}
+        for write in new_writes:
+            key = (write["task_id"], write["idx"])
+            position = index.get(key)
+            if position is None:
+                index[key] = len(merged)
+                merged.append(write)
+            elif write["idx"] < 0:
+                merged[position] = write
+        return merged
 
     def _should_include_checkpoint(
         self,

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/valkey/saver.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/valkey/saver.py
@@ -18,7 +18,7 @@ from langgraph.checkpoint.base import (
 )
 from langgraph.checkpoint.serde.base import SerializerProtocol
 
-from .base import BaseValkeySaver
+from .base import _PUT_WRITES_MAX_ATTEMPTS, BaseValkeySaver
 
 # Conditional imports for optional dependencies
 try:
@@ -33,7 +33,7 @@ try:
     from valkey import Valkey
     from valkey.asyncio import Valkey as AsyncValkey
     from valkey.connection import ConnectionPool
-    from valkey.exceptions import ValkeyError
+    from valkey.exceptions import ValkeyError, WatchError
 except ImportError as e:
     raise ImportError(
         "The 'valkey' package is required to use ValkeySaver. "
@@ -485,27 +485,31 @@ class ValkeySaver(BaseValkeySaver):
             checkpoint_id = str(configurable["checkpoint_id"])
 
             writes_key = self._make_writes_key(thread_id, checkpoint_ns, checkpoint_id)
-
-            # Use atomic operation to update writes
-            pipe = self.client.pipeline()
-
-            # Get existing writes
-            pipe.get(writes_key)
-            results = pipe.execute()
-            existing_data = results[0]
-
-            existing_writes = orjson.loads(existing_data) if existing_data else []
-
-            # Use base class method to serialize new writes
             new_writes = self._serialize_writes_data(writes, task_id)
-            existing_writes.extend(new_writes)
 
-            # Store updated writes atomically
-            pipe = self.client.pipeline()
-            pipe.set(writes_key, orjson.dumps(existing_writes))
-            if self.ttl:
-                pipe.expire(writes_key, int(self.ttl))
-            pipe.execute()
+            # Read-modify-write the shared writes blob inside a WATCH/MULTI/EXEC
+            # transaction so concurrent tasks writing to the same checkpoint cannot
+            # clobber each other's writes (a lost update). WATCH aborts EXEC if the
+            # key changed since it was read, so we retry on the stale snapshot.
+            with self.client.pipeline() as pipe:
+                for _ in range(_PUT_WRITES_MAX_ATTEMPTS):
+                    try:
+                        pipe.watch(writes_key)
+                        existing_writes = self._parse_writes_blob(pipe.get(writes_key))
+                        merged_writes = self._merge_writes(existing_writes, new_writes)
+                        pipe.multi()
+                        pipe.set(writes_key, orjson.dumps(merged_writes))
+                        if self.ttl:
+                            pipe.expire(writes_key, int(self.ttl))
+                        pipe.execute()
+                        return
+                    except WatchError:
+                        continue
+            msg = (
+                f"put_writes could not commit after {_PUT_WRITES_MAX_ATTEMPTS} "
+                "attempts due to contention on the checkpoint writes key"
+            )
+            raise ValkeyError(msg)
 
         except (ValkeyError, orjson.JSONEncodeError, KeyError) as e:
             logger.error(f"Error in put_writes: {e}")

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/checkpoint/valkey/test_async_valkey_saver.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/checkpoint/valkey/test_async_valkey_saver.py
@@ -11,11 +11,13 @@ pytest.importorskip("valkey")
 pytest.importorskip("orjson")
 pytest.importorskip("fakeredis")
 
+import fakeredis
 import orjson
 from langchain_core.runnables import RunnableConfig
 from valkey.exceptions import ValkeyError
 
 from langgraph_checkpoint_aws import AsyncValkeySaver
+from langgraph_checkpoint_aws.checkpoint.valkey.base import BaseValkeySaver
 
 
 # Create dummy objects for serialization tests
@@ -541,57 +543,71 @@ class TestAsyncValkeySaverPut:
         # Pipeline expire should have been called (via the pipeline mock)
 
 
+@pytest.fixture
+def fake_async_client():
+    """In-memory async Valkey fake that models WATCH/MULTI/EXEC transactions."""
+    return fakeredis.FakeAsyncValkey(decode_responses=False)
+
+
 class TestAsyncValkeySaverPutWrites:
-    """Test aput_writes method."""
+    """Test aput_writes storing, merging, and concurrency behavior."""
 
     @pytest.mark.asyncio
-    async def test_aput_writes_basic(
-        self, mock_valkey_client, mock_serializer, sample_config
-    ):
-        """Test putting writes."""
+    async def test_aput_writes_basic(self, fake_async_client, sample_config):
+        """Writes are stored under the checkpoint's writes key."""
+        saver = AsyncValkeySaver(client=fake_async_client)
         writes = [("channel1", "value1"), ("channel2", "value2")]
-        task_id = "test-task"
 
-        mock_valkey_client.get.return_value = orjson.dumps([])  # existing writes
+        await saver.aput_writes(sample_config, writes, "test-task")
 
-        saver = AsyncValkeySaver(client=mock_valkey_client, serde=mock_serializer)
-
-        await saver.aput_writes(sample_config, writes, task_id)
-
-        mock_valkey_client.get.assert_called()
+        writes_key = saver._make_writes_key("test-thread-123", "", "test-checkpoint-id")
+        stored = orjson.loads(await fake_async_client.get(writes_key))
+        assert [w["channel"] for w in stored] == ["channel1", "channel2"]
+        assert {w["task_id"] for w in stored} == {"test-task"}
 
     @pytest.mark.asyncio
-    async def test_aput_writes_with_task_path(
-        self, mock_valkey_client, mock_serializer, sample_config
-    ):
-        """Test putting writes with task path."""
-        writes = [("channel", "value")]
-        task_id = "test-task"
-        task_path = "path/to/task"
+    async def test_aput_writes_empty_writes(self, fake_async_client, sample_config):
+        """Empty writes leave an empty list rather than erroring."""
+        saver = AsyncValkeySaver(client=fake_async_client)
 
-        mock_valkey_client.get.return_value = orjson.dumps([])  # existing writes
+        await saver.aput_writes(sample_config, [], "test-task")
 
-        saver = AsyncValkeySaver(client=mock_valkey_client, serde=mock_serializer)
-
-        await saver.aput_writes(sample_config, writes, task_id, task_path)
-
-        mock_valkey_client.get.assert_called()
+        writes_key = saver._make_writes_key("test-thread-123", "", "test-checkpoint-id")
+        assert orjson.loads(await fake_async_client.get(writes_key)) == []
 
     @pytest.mark.asyncio
-    async def test_aput_writes_empty_writes(
-        self, mock_valkey_client, mock_serializer, sample_config
+    async def test_aput_writes_concurrent_tasks_keep_all_writes(
+        self, fake_async_client, sample_config
     ):
-        """Test putting empty writes."""
-        writes = []
-        task_id = "test-task"
+        """Parallel tool calls fan out into separate tasks writing the same
+        checkpoint concurrently; none of their writes may be lost (issue #1174)."""
+        saver = AsyncValkeySaver(client=fake_async_client)
 
-        mock_valkey_client.get.return_value = orjson.dumps([])  # existing writes
+        await asyncio.gather(
+            *(
+                saver.aput_writes(sample_config, [("messages", f"r{i}")], f"task-{i}")
+                for i in range(8)
+            )
+        )
 
-        saver = AsyncValkeySaver(client=mock_valkey_client, serde=mock_serializer)
+        writes_key = saver._make_writes_key("test-thread-123", "", "test-checkpoint-id")
+        stored = orjson.loads(await fake_async_client.get(writes_key))
+        assert sorted(w["task_id"] for w in stored) == [f"task-{i}" for i in range(8)]
 
-        await saver.aput_writes(sample_config, writes, task_id)
+    @pytest.mark.asyncio
+    async def test_aput_writes_positional_write_is_idempotent(
+        self, fake_async_client, sample_config
+    ):
+        """Replaying a task's positional write (e.g. around interrupt/resume) must
+        not duplicate it, matching InMemorySaver semantics."""
+        saver = AsyncValkeySaver(client=fake_async_client)
 
-        mock_valkey_client.get.assert_called()
+        await saver.aput_writes(sample_config, [("messages", "v")], "task-a")
+        await saver.aput_writes(sample_config, [("messages", "v")], "task-a")
+
+        writes_key = saver._make_writes_key("test-thread-123", "", "test-checkpoint-id")
+        stored = orjson.loads(await fake_async_client.get(writes_key))
+        assert len(stored) == 1
 
 
 class TestAsyncValkeySaverErrorHandling:
@@ -691,103 +707,74 @@ class TestAsyncValkeySaverKeyGeneration:
 
 
 class TestAsyncValkeySaverAputWritesErrorHandling:
-    """Test aput_writes method error handling."""
+    """Test aput_writes error handling."""
 
     @pytest.mark.asyncio
-    async def test_aput_writes_existing_data_string(
-        self, mock_valkey_client, mock_serializer, sample_config
-    ):
-        """Test aput_writes with existing data as string."""
-        writes = [("channel", "value")]
-        task_id = "test-task"
+    async def test_aput_writes_valkey_error_propagates(self, sample_config):
+        """A client failure inside the transaction is logged and re-raised."""
+        pipe = AsyncMock()
+        pipe.__aenter__.return_value = pipe
+        pipe.watch.side_effect = ValkeyError("Valkey error")
+        client = Mock()
+        client.pipeline = Mock(return_value=pipe)
 
-        # Mock existing writes as string
-        mock_valkey_client.get.return_value = "[]"  # String instead of bytes
-
-        saver = AsyncValkeySaver(client=mock_valkey_client, serde=mock_serializer)
-
-        await saver.aput_writes(sample_config, writes, task_id)
-        mock_valkey_client.get.assert_called()
-
-    @pytest.mark.asyncio
-    async def test_aput_writes_existing_data_invalid_type(
-        self, mock_valkey_client, mock_serializer, sample_config
-    ):
-        """Test aput_writes with existing data as invalid type."""
-        writes = [("channel", "value")]
-        task_id = "test-task"
-
-        # Mock existing writes as invalid type (Mock object)
-        mock_data = Mock()
-        mock_valkey_client.get.return_value = mock_data
-
-        saver = AsyncValkeySaver(client=mock_valkey_client, serde=mock_serializer)
-
-        await saver.aput_writes(sample_config, writes, task_id)
-        mock_valkey_client.get.assert_called()
-
-    @pytest.mark.asyncio
-    async def test_aput_writes_existing_data_json_decode_error(
-        self, mock_valkey_client, mock_serializer, sample_config
-    ):
-        """Test aput_writes with JSON decode error on existing data."""
-        writes = [("channel", "value")]
-        task_id = "test-task"
-
-        # Mock existing writes as invalid JSON
-        mock_valkey_client.get.return_value = b"invalid json"
-
-        saver = AsyncValkeySaver(client=mock_valkey_client, serde=mock_serializer)
-
-        await saver.aput_writes(sample_config, writes, task_id)
-        mock_valkey_client.get.assert_called()
-
-    @pytest.mark.asyncio
-    async def test_aput_writes_existing_data_not_list(
-        self, mock_valkey_client, mock_serializer, sample_config
-    ):
-        """Test aput_writes with existing data that's not a list."""
-        writes = [("channel", "value")]
-        task_id = "test-task"
-
-        # Mock existing writes as dict instead of list
-        mock_valkey_client.get.return_value = orjson.dumps({"not": "a list"})
-
-        saver = AsyncValkeySaver(client=mock_valkey_client, serde=mock_serializer)
-
-        await saver.aput_writes(sample_config, writes, task_id)
-        mock_valkey_client.get.assert_called()
-
-    @pytest.mark.asyncio
-    async def test_aput_writes_valkey_error(
-        self, mock_valkey_client, mock_serializer, sample_config
-    ):
-        """Test aput_writes with ValkeyError."""
-        writes = [("channel", "value")]
-        task_id = "test-task"
-
-        mock_valkey_client.get.side_effect = ValkeyError("Valkey error")
-
-        saver = AsyncValkeySaver(client=mock_valkey_client, serde=mock_serializer)
+        saver = AsyncValkeySaver(client=client)
 
         with pytest.raises(ValkeyError):
-            await saver.aput_writes(sample_config, writes, task_id)
+            await saver.aput_writes(sample_config, [("channel", "value")], "test-task")
 
     @pytest.mark.asyncio
     async def test_aput_writes_key_error(self, mock_valkey_client, mock_serializer):
-        """Test aput_writes with KeyError."""
-        writes = [("channel", "value")]
-        task_id = "test-task"
-
-        # Config missing required keys
+        """A config missing required keys raises before any storage call."""
         bad_config = RunnableConfig(configurable={})
-
-        mock_valkey_client.get.return_value = orjson.dumps([])
-
         saver = AsyncValkeySaver(client=mock_valkey_client, serde=mock_serializer)
 
         with pytest.raises(KeyError):
-            await saver.aput_writes(bad_config, writes, task_id)
+            await saver.aput_writes(bad_config, [("channel", "value")], "test-task")
+
+
+class TestParseWritesBlob:
+    """Test the defensive parsing of the stored writes blob."""
+
+    def test_none_returns_empty(self):
+        assert BaseValkeySaver._parse_writes_blob(None) == []
+
+    def test_string_json_is_decoded(self):
+        assert BaseValkeySaver._parse_writes_blob("[]") == []
+
+    def test_bytes_json_list_is_decoded(self):
+        assert BaseValkeySaver._parse_writes_blob(b'[{"task_id": "a"}]') == [
+            {"task_id": "a"}
+        ]
+
+    def test_invalid_json_returns_empty(self):
+        assert BaseValkeySaver._parse_writes_blob(b"invalid json") == []
+
+    def test_non_list_json_returns_empty(self):
+        assert BaseValkeySaver._parse_writes_blob(orjson.dumps({"not": "a list"})) == []
+
+    def test_unserializable_type_returns_empty(self):
+        assert BaseValkeySaver._parse_writes_blob(object()) == []
+
+
+class TestMergeWrites:
+    """Test the dedup-merge that mirrors InMemorySaver semantics."""
+
+    def test_positional_write_kept_once(self):
+        existing = [{"task_id": "a", "idx": 0, "value": "first"}]
+        new = [{"task_id": "a", "idx": 0, "value": "second"}]
+        assert BaseValkeySaver._merge_writes(existing, new) == existing
+
+    def test_distinct_tasks_are_all_kept(self):
+        existing = [{"task_id": "a", "idx": 0}]
+        new = [{"task_id": "b", "idx": 0}]
+        merged = BaseValkeySaver._merge_writes(existing, new)
+        assert [w["task_id"] for w in merged] == ["a", "b"]
+
+    def test_special_channel_overwrites_in_place(self):
+        existing = [{"task_id": "a", "idx": -1, "value": "old"}]
+        new = [{"task_id": "a", "idx": -1, "value": "new"}]
+        assert BaseValkeySaver._merge_writes(existing, new) == new
 
 
 class TestAsyncValkeySaverAdeleteThread:

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/checkpoint/valkey/test_valkey_checkpoint_saver.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/checkpoint/valkey/test_valkey_checkpoint_saver.py
@@ -449,6 +449,25 @@ class TestValkeySaverUnit:
         writes = json.loads(writes_data)
         assert len(writes) == 3  # 2 from first batch + 1 from second batch
 
+    def test_put_writes_positional_write_is_idempotent(self, saver, fake_valkey_client):
+        """Replaying a task's positional write must not duplicate it."""
+        config_with_checkpoint = {
+            "configurable": {
+                "thread_id": "test-thread",
+                "checkpoint_ns": "test-ns",
+                "checkpoint_id": "test-checkpoint-id",
+            }
+        }
+
+        saver.put_writes(config_with_checkpoint, [("messages", "v")], "task-a")
+        saver.put_writes(config_with_checkpoint, [("messages", "v")], "task-a")
+
+        writes_key = saver._make_writes_key(
+            "test-thread", "test-ns", "test-checkpoint-id"
+        )
+        stored = json.loads(fake_valkey_client.get(writes_key))
+        assert len(stored) == 1
+
     def test_serialize_checkpoint_data(self, saver, sample_checkpoint, sample_metadata):
         """Test checkpoint data serialization."""
         config = {"configurable": {"thread_id": "test-thread"}}


### PR DESCRIPTION
Fixes #1174

`put_writes`/`aput_writes` did a plain read-modify-write on one shared JSON blob. When two tasks flush writes for the same checkpoint at once (parallel tool calls each become their own `Send` task), both read the stale blob and the last `SET` drops the other's write. Shows up as a Bedrock `ValidationException` about a missing `toolResult`.

Wrapped it in a WATCH/MULTI/EXEC transaction (retry on `WatchError`) and deduped the merge by `(task_id, idx)`, same as `InMemorySaver`. I kept the JSON-blob format instead of moving to per-field `HSET`. That version would be atomic for free but changes the on-disk layout, so I went with the smaller change. Easy to switch if you'd rather.

Tests use fakeredis: 8 tasks writing one checkpoint at once with nothing lost, plus the dedup cases. They fail on `main`, pass with the fix.
