### PR TITLE
feat(aws): Support per-request guardrail configuration on ChatAnthropicBedrock

### DIFF
--- a/libs/aws/langchain_aws/chat_models/anthropic.py
+++ b/libs/aws/langchain_aws/chat_models/anthropic.py
@@ -28,6 +28,45 @@ def _get_default_model_profile(model_name: str) -> ModelProfile:
     return default.copy()
 
 
+def _guardrail_config_to_headers(
+    guardrail_config: dict[str, Any] | None,
+) -> dict[str, str]:
+    """Translate a guardrail_config dict into Bedrock guardrail request headers.
+
+    The native Bedrock ``InvokeModel`` / ``InvokeModelWithResponseStream`` APIs
+    attach guardrails via HTTP headers instead of a request body field, so the
+    Converse-style config is mapped onto those headers here.
+
+    Args:
+        guardrail_config: Dict with ``guardrailIdentifier``,
+            ``guardrailVersion``, and optional ``trace``.
+
+    Returns:
+        Header dict; empty when no guardrail is configured.
+
+    Raises:
+        ValueError: If ``guardrail_config`` is missing
+            ``guardrailIdentifier`` or ``guardrailVersion``.
+    """
+    if not guardrail_config:
+        return {}
+    identifier = guardrail_config.get("guardrailIdentifier")
+    version = guardrail_config.get("guardrailVersion")
+    if not identifier or not version:
+        msg = (
+            "guardrail_config requires both 'guardrailIdentifier' and "
+            "'guardrailVersion'."
+        )
+        raise ValueError(msg)
+    headers: dict[str, str] = {
+        "X-Amzn-Bedrock-GuardrailIdentifier": str(identifier),
+        "X-Amzn-Bedrock-GuardrailVersion": str(version),
+    }
+    if trace := guardrail_config.get("trace"):
+        headers["X-Amzn-Bedrock-Trace"] = str(trace).upper()
+    return headers
+
+
 class ChatAnthropicBedrock(ChatAnthropic):
     """Anthropic Claude via AWS Bedrock.
 
@@ -111,16 +150,22 @@ class ChatAnthropicBedrock(ChatAnthropic):
     """
 
     guardrail_config: dict[str, Any] | None = Field(default=None, alias="guardrails")
-    """Configuration for an Amazon Bedrock Guardrail applied to every request.
+    """Configuration for an Amazon Bedrock Guardrail.
 
-    Same shape as `ChatBedrockConverse`, e.g.
-    `{"guardrailIdentifier": "gr-abc123", "guardrailVersion": "1", "trace": "enabled"}`.
+    The native Bedrock ``InvokeModel`` APIs used by the Anthropic SDK attach
+    guardrails as HTTP request headers rather than a request body field, so
+    this config is translated into ``X-Amzn-Bedrock-GuardrailIdentifier``,
+    ``X-Amzn-Bedrock-GuardrailVersion`` and ``X-Amzn-Bedrock-Trace`` headers
+    injected per-request via the SDK's ``extra_headers`` parameter.
 
-    The native Bedrock `InvokeModel` APIs used by the Anthropic SDK attach
-    guardrails as HTTP request headers rather than a request body field, so this
-    config is translated into the `X-Amzn-Bedrock-GuardrailIdentifier`,
-    `X-Amzn-Bedrock-GuardrailVersion` and `X-Amzn-Bedrock-Trace` headers and
-    merged over `default_headers` (guardrail values win on key conflicts).
+    When set at construction, applies to every request as the default.
+    Can be overridden per-request by passing ``guardrail_config=`` as an
+    invoke kwarg (mirroring ``ChatBedrockConverse`` behaviour)::
+
+        model.invoke("hello", guardrail_config={
+            "guardrailIdentifier": "gr-other",
+            "guardrailVersion": "2",
+        })
     """
 
     @property
@@ -148,39 +193,29 @@ class ChatAnthropicBedrock(ChatAnthropic):
         """
         return ["langchain", "chat_models", "anthropic_bedrock"]
 
-    def _guardrail_headers(self) -> dict[str, str]:
-        """Translate `guardrail_config` into Bedrock guardrail request headers.
+    def _get_request_payload(
+        self,
+        input_: Any,
+        *,
+        stop: list[str] | None = None,
+        **kwargs: Any,
+    ) -> dict:
+        """Override to inject additional Bedrock configs via ``extra_headers``."""
 
-        The native `InvokeModel` / `InvokeModelWithResponseStream` APIs attach
-        guardrails via HTTP headers instead of a request body field, so the
-        Converse-style config is mapped onto those headers here.
+        req_guardrail = kwargs.pop("guardrail_config", None)
+        guardrail = req_guardrail or self.guardrail_config
 
-        Returns:
-            Header dict to merge into the client's default headers; empty when
-            no guardrail is configured.
+        payload = super()._get_request_payload(input_, stop=stop, **kwargs)
 
-        Raises:
-            ValueError: If `guardrail_config` is missing `guardrailIdentifier`
-                or `guardrailVersion` — failing loudly instead of silently
-                sending unguarded requests.
-        """
-        if not self.guardrail_config:
-            return {}
-        identifier = self.guardrail_config.get("guardrailIdentifier")
-        version = self.guardrail_config.get("guardrailVersion")
-        if not identifier or not version:
-            msg = (
-                "guardrail_config requires both 'guardrailIdentifier' and "
-                "'guardrailVersion'."
-            )
-            raise ValueError(msg)
-        headers = {
-            "X-Amzn-Bedrock-GuardrailIdentifier": str(identifier),
-            "X-Amzn-Bedrock-GuardrailVersion": str(version),
-        }
-        if trace := self.guardrail_config.get("trace"):
-            headers["X-Amzn-Bedrock-Trace"] = str(trace).upper()
-        return headers
+        if guardrail:
+            guardrail_headers = _guardrail_config_to_headers(guardrail)
+            existing_extra = payload.get("extra_headers") or {}
+            payload["extra_headers"] = {
+                **existing_extra,
+                **guardrail_headers,
+            }
+
+        return payload
 
     @cached_property
     def _client_params(self) -> dict[str, Any]:
@@ -191,16 +226,13 @@ class ChatAnthropicBedrock(ChatAnthropic):
             or os.getenv("AWS_DEFAULT_REGION")
             or None  # let boto3 resolve
         )
-        default_headers = self.default_headers
-        if guardrail_headers := self._guardrail_headers():
-            default_headers = {**(self.default_headers or {}), **guardrail_headers}
         return _create_bedrock_client_params(
             region_name=region_name,
             aws_access_key_id=self.aws_access_key_id,
             aws_secret_access_key=self.aws_secret_access_key,
             aws_session_token=self.aws_session_token,
             max_retries=self.max_retries,
-            default_headers=default_headers,
+            default_headers=self.default_headers,
             timeout=self.default_request_timeout,
         )
 
@@ -246,6 +278,8 @@ class ChatAnthropicBedrock(ChatAnthropic):
         if self.profile is None:
             model = re.sub(r"^[A-Za-z]{2}\.", "", self.model)
             self.profile = _get_default_model_profile(model)
+        if self.guardrail_config:
+            _guardrail_config_to_headers(self.guardrail_config)
         _add_langchain_aws_version(self)
         return self
 

--- a/libs/aws/tests/unit_tests/chat_models/test_anthropic.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_anthropic.py
@@ -294,19 +294,18 @@ def test_model_profile(model_name: str) -> None:
 
 
 def test_chat_anthropic_bedrock_guardrail_config_sets_headers() -> None:
-    """Test guardrail_config is translated into Bedrock guardrail headers."""
+    """Test guardrail_config is translated into extra_headers in the payload."""
     model = ChatAnthropicBedrock(  # type: ignore[call-arg]
         model=BEDROCK_MODEL_NAME,
         region_name="us-east-1",
-        aws_access_key_id=SecretStr("test-key"),
-        aws_secret_access_key=SecretStr("test-secret"),
         guardrail_config={
             "guardrailIdentifier": "gr-abc123",
             "guardrailVersion": "1",
             "trace": "enabled",
         },
     )
-    headers = model._client_params["default_headers"]
+    payload = model._get_request_payload([HumanMessage(content="hello")], stop=None)
+    headers = payload["extra_headers"]
     assert headers["X-Amzn-Bedrock-GuardrailIdentifier"] == "gr-abc123"
     assert headers["X-Amzn-Bedrock-GuardrailVersion"] == "1"
     assert headers["X-Amzn-Bedrock-Trace"] == "ENABLED"
@@ -322,51 +321,51 @@ def test_chat_anthropic_bedrock_guardrail_config_without_trace() -> None:
             "guardrailVersion": "2",
         },
     )
-    headers = model._client_params["default_headers"]
+    payload = model._get_request_payload([HumanMessage(content="hello")], stop=None)
+    headers = payload["extra_headers"]
     assert headers["X-Amzn-Bedrock-GuardrailVersion"] == "2"
     assert "X-Amzn-Bedrock-Trace" not in headers
 
 
 def test_chat_anthropic_bedrock_no_guardrail_config_no_headers() -> None:
-    """Test that without guardrail_config no guardrail headers are added."""
+    """Test that without guardrail_config no extra_headers are added."""
     model = ChatAnthropicBedrock(  # type: ignore[call-arg]
         model=BEDROCK_MODEL_NAME,
         region_name="us-east-1",
     )
-    headers = model._client_params["default_headers"] or {}
-    assert "X-Amzn-Bedrock-GuardrailIdentifier" not in headers
-    assert "X-Amzn-Bedrock-GuardrailVersion" not in headers
+    payload = model._get_request_payload([HumanMessage(content="hello")], stop=None)
+    assert "extra_headers" not in payload
 
 
 def test_chat_anthropic_bedrock_guardrail_config_merges_default_headers() -> None:
-    """Test guardrail headers merge over user default_headers, keeping the rest."""
+    """Test guardrail headers merge with existing extra_headers."""
     model = ChatAnthropicBedrock(  # type: ignore[call-arg]
         model=BEDROCK_MODEL_NAME,
         region_name="us-east-1",
-        default_headers={
-            "X-Custom": "keep-me",
-            "X-Amzn-Bedrock-GuardrailVersion": "stale",
-        },
         guardrail_config={
             "guardrailIdentifier": "gr-abc123",
             "guardrailVersion": "3",
         },
     )
-    headers = model._client_params["default_headers"]
+    payload = model._get_request_payload(
+        [HumanMessage(content="hello")],
+        stop=None,
+        extra_headers={"X-Custom": "keep-me"},
+    )
+    headers = payload["extra_headers"]
     assert headers["X-Custom"] == "keep-me"
     assert headers["X-Amzn-Bedrock-GuardrailIdentifier"] == "gr-abc123"
     assert headers["X-Amzn-Bedrock-GuardrailVersion"] == "3"
 
 
 def test_chat_anthropic_bedrock_guardrail_config_requires_both_keys() -> None:
-    """Test incomplete guardrail_config fails instead of silently not guarding."""
-    model = ChatAnthropicBedrock(  # type: ignore[call-arg]
-        model=BEDROCK_MODEL_NAME,
-        region_name="us-east-1",
-        guardrail_config={"guardrailIdentifier": "gr-abc123"},
-    )
+    """Test incomplete guardrail_config fails eagerly at construction."""
     with pytest.raises(ValueError, match="guardrailVersion"):
-        _ = model._client_params
+        ChatAnthropicBedrock(  # type: ignore[call-arg]
+            model=BEDROCK_MODEL_NAME,
+            region_name="us-east-1",
+            guardrail_config={"guardrailIdentifier": "gr-abc123"},
+        )
 
 
 def test_chat_anthropic_bedrock_guardrails_alias() -> None:
@@ -380,5 +379,63 @@ def test_chat_anthropic_bedrock_guardrails_alias() -> None:
         },
     )
     assert model.guardrail_config is not None
-    headers = model._client_params["default_headers"]
-    assert headers["X-Amzn-Bedrock-GuardrailIdentifier"] == "gr-abc123"
+    payload = model._get_request_payload([HumanMessage(content="hello")], stop=None)
+    assert payload["extra_headers"]["X-Amzn-Bedrock-GuardrailIdentifier"] == "gr-abc123"
+
+
+def test_chat_anthropic_bedrock_per_request_guardrail_override() -> None:
+    """Test invoke-level guardrail_config overrides the instance default."""
+    model = ChatAnthropicBedrock(  # type: ignore[call-arg]
+        model=BEDROCK_MODEL_NAME,
+        region_name="us-east-1",
+        guardrail_config={
+            "guardrailIdentifier": "gr-default",
+            "guardrailVersion": "1",
+        },
+    )
+    payload = model._get_request_payload(
+        [HumanMessage(content="hello")],
+        stop=None,
+        guardrail_config={
+            "guardrailIdentifier": "gr-override",
+            "guardrailVersion": "5",
+            "trace": "disabled",
+        },
+    )
+    headers = payload["extra_headers"]
+    assert headers["X-Amzn-Bedrock-GuardrailIdentifier"] == "gr-override"
+    assert headers["X-Amzn-Bedrock-GuardrailVersion"] == "5"
+    assert headers["X-Amzn-Bedrock-Trace"] == "DISABLED"
+
+
+def test_chat_anthropic_bedrock_per_request_guardrail_no_default() -> None:
+    """Test per-request guardrail works without an instance-level default."""
+    model = ChatAnthropicBedrock(  # type: ignore[call-arg]
+        model=BEDROCK_MODEL_NAME,
+        region_name="us-east-1",
+    )
+    payload = model._get_request_payload(
+        [HumanMessage(content="hello")],
+        stop=None,
+        guardrail_config={
+            "guardrailIdentifier": "gr-adhoc",
+            "guardrailVersion": "3",
+        },
+    )
+    headers = payload["extra_headers"]
+    assert headers["X-Amzn-Bedrock-GuardrailIdentifier"] == "gr-adhoc"
+    assert headers["X-Amzn-Bedrock-GuardrailVersion"] == "3"
+
+
+def test_chat_anthropic_bedrock_per_request_guardrail_validates() -> None:
+    """Test incomplete per-request guardrail_config raises ValueError."""
+    model = ChatAnthropicBedrock(  # type: ignore[call-arg]
+        model=BEDROCK_MODEL_NAME,
+        region_name="us-east-1",
+    )
+    with pytest.raises(ValueError, match="guardrailVersion"):
+        model._get_request_payload(
+            [HumanMessage(content="hello")],
+            stop=None,
+            guardrail_config={"guardrailIdentifier": "gr-abc123"},
+        )


### PR DESCRIPTION
Related: #1177, addresses follow-up noted here: https://github.com/langchain-ai/langchain-aws/pull/1178#pullrequestreview-4782812273

Moving the logic for guardrail header injection out of `_client_params` (which is frozen at construction) and into a new `_get_request_payload` method (called per-request) that instead sets the guardrail config via the Anthropic SDK's `extra_headers` parameter. 

With this, users of `ChatAnthropicBedrock` can now set per-invoke guardrail overrides, bringing it in line with what `ChatBedrockConverse` supports.