### PR TITLE
fix(aws): support Opus 5 streaming

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -806,6 +806,7 @@ class ChatBedrockConverse(BaseChatModel):
                         "claude-opus-4",
                         "claude-haiku-4",
                         "claude-fable-5",
+                        "claude-opus-5",
                         "claude-sonnet-5",
                     ]
                 )

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -797,6 +797,7 @@ def test_standard_tracing_params() -> None:
         ("us.anthropic.claude-sonnet-4-20250514-v1:0", False),
         ("us.anthropic.claude-opus-4-20250514-v1:0", False),
         ("us.anthropic.claude-sonnet-4-5-20250929-v1:0", False),
+        ("global.anthropic.claude-opus-5", False),
         ("us.anthropic.claude-sonnet-5", False),
         ("us.anthropic.claude-fable-5", False),
         ("us.anthropic.claude-3-haiku-20240307-v1:0", False),
@@ -2476,6 +2477,12 @@ def test__get_base_model() -> None:
         (
             "arn:aws:bedrock:us-west-2::foundation-model/anthropic.claude-3-sonnet-20240229-v1:0",
             "anthropic.claude-3-sonnet-20240229-v1:0",
+            "anthropic",
+            False,
+        ),
+        (
+            "arn:aws:bedrock:us-west-2:123456789012:application-inference-profile/my-profile",
+            "anthropic.claude-opus-5",
             "anthropic",
             False,
         ),


### PR DESCRIPTION
## Summary

Fixes #1184

- allow `ChatBedrockConverse` to stream Claude Opus 5 models instead of silently falling back to Converse
- cover both direct model IDs and application inference profiles

## Validation

- red/green regression verification for both new cases
- `make test`: 988 passed, 1 skipped, 1 xfailed
- `make lint_diff`: Ruff check/format and mypy passed

## AI Disclosure

This fix was implemented and validated with AI assistance.