### PR TITLE
feat(aws): Support Claude Opus 5 default thinking in ChatBedrock

### DIFF
--- a/libs/aws/langchain_aws/utils.py
+++ b/libs/aws/langchain_aws/utils.py
@@ -489,7 +489,9 @@ def thinking_disabled_in_params(params: dict) -> bool:
 
 def thinking_on_by_default(model: str) -> bool:
     """Check if the model runs adaptive thinking without a thinking parameter."""
-    return any(x in model for x in ("claude-sonnet-5", "claude-fable-5"))
+    return any(
+        x in model for x in ("claude-sonnet-5", "claude-opus-5", "claude-fable-5")
+    )
 
 
 def thinking_forced_tool_use_unsupported(model: str) -> bool:

--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock.py
@@ -242,6 +242,7 @@ def test_chat_bedrock_streaming_generation_info() -> None:
     "model,model_kwargs",
     [
         ("us.anthropic.claude-sonnet-5", {"thinking": {"type": "disabled"}}),
+        ("us.anthropic.claude-opus-5", {"thinking": {"type": "disabled"}}),
         ("mistral.mistral-7b-instruct-v0:2", {}),
     ],
 )
@@ -267,6 +268,7 @@ def test_bedrock_streaming(model: str, model_kwargs: dict) -> None:
     "model,model_kwargs",
     [
         ("us.anthropic.claude-sonnet-5", {"thinking": {"type": "disabled"}}),
+        ("us.anthropic.claude-opus-5", {"thinking": {"type": "disabled"}}),
         ("mistral.mistral-7b-instruct-v0:2", {}),
     ],
 )

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
@@ -2148,8 +2148,16 @@ def test_system_prompt_string_format() -> None:
     assert isinstance(body["system"], str)
 
 
-def test_stream_thinking_on_by_default_returns_block_content() -> None:
-    """Sonnet/Fable 5 streams should not mix string and block content."""
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "us.anthropic.claude-sonnet-5",
+        "global.anthropic.claude-opus-5",
+        "global.anthropic.claude-fable-5",
+    ],
+)
+def test_stream_thinking_on_by_default_returns_block_content(model_id: str) -> None:
+    """Default-thinking Claude streams must not mix string and block content."""
     mock_client = MagicMock()
 
     def stream_gen():
@@ -2181,7 +2189,7 @@ def test_stream_thinking_on_by_default_returns_block_content() -> None:
 
     llm = ChatBedrock(
         client=mock_client,
-        model="us.anthropic.claude-sonnet-5",
+        model=model_id,
         region="us-west-2",
     )
     full = None

--- a/libs/aws/tests/unit_tests/test_utils.py
+++ b/libs/aws/tests/unit_tests/test_utils.py
@@ -453,6 +453,7 @@ def test_trim_message_whitespace_with_empty_messages() -> None:
         ("us.anthropic.claude-3-5-sonnet-20240620-v1:0", True),
         ("us.anthropic.claude-fable-5", False),
         ("us.anthropic.claude-sonnet-5", False),
+        ("global.anthropic.claude-opus-5", False),
         ("us.anthropic.claude-3-sonnet-20240229-v1:0", False),
         ("us.meta.llama4-scout-17b-instruct-v1:0", False),
         ("us.amazon.nova-pro-v1:0", False),
@@ -479,6 +480,7 @@ def test_count_tokens_api_supported_for_model(
         ("us.anthropic.claude-haiku-4-5-20251001-v1:0", True),
         ("global.anthropic.claude-opus-4-8", False),
         ("us.anthropic.claude-sonnet-5", False),
+        ("global.anthropic.claude-opus-5", False),
         ("global.anthropic.claude-fable-5", False),
     ],
 )
@@ -492,6 +494,7 @@ def test_thinking_forced_tool_use_unsupported(
     "model_id,expected_result",
     [
         ("us.anthropic.claude-sonnet-5", True),
+        ("global.anthropic.claude-opus-5", True),
         ("global.anthropic.claude-fable-5", True),
         ("global.anthropic.claude-opus-4-8", False),
         ("anthropic.claude-sonnet-4-6", False),


### PR DESCRIPTION
Mainly updating ChatBedrock to ensure that we correctly handle Opus 5's potential output formats while streaming on the default adaptive thinking mode (as was previously done for Sonnet and Fable 5 in https://github.com/langchain-ai/langchain-aws/pull/1157.)

Also, (per the [AWS docs](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-5.html)) Opus 5 re-instated the ability to disable thinking entirely, which is more flexible than Sonnet 5 (accepts `thinking: {"type": "disabled"}` but it doesn't have an effect) and Opus 5 (rejects `disabled` with a hard exception). So, I've also added Opus 5 into the streaming integration tests matrices to ensure that its forced plaintext streaming mode is represented.