### PR TITLE
feat(aws): support for `reasoning_effort` param for `ChatBedrockConverse`

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -614,18 +614,12 @@ class ChatBedrockConverse(BaseChatModel):
 
     """
 
-    reasoning_effort: Optional[
-        Literal["none", "low", "medium", "high", "xhigh", "max"]
-    ] = None
+    reasoning_effort: Optional[Literal["low", "medium", "high", "xhigh", "max"]] = None
     """Reasoning effort level for models that support configurable reasoning.
 
     Translated into the appropriate provider-specific request format based on the
     model family. Only applied to models whose profile declares supported
     ``reasoning_effort_levels``; unsupported values raise ``ValueError``.
-
-    ``"none"`` disables reasoning outright for native GPT-5.x models, it is
-    not equivalent to omitting the argument, since these models otherwise
-    default to ``"medium"``.
 
     Explicit values already present in ``additional_model_request_fields`` take
     precedence. If the model has no known reasoning-effort translation, a warning

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -614,12 +614,18 @@ class ChatBedrockConverse(BaseChatModel):
 
     """
 
-    reasoning_effort: Optional[Literal["low", "medium", "high", "xhigh", "max"]] = None
+    reasoning_effort: Optional[
+        Literal["none", "low", "medium", "high", "xhigh", "max"]
+    ] = None
     """Reasoning effort level for models that support configurable reasoning.
 
     Translated into the appropriate provider-specific request format based on the
     model family. Only applied to models whose profile declares supported
     ``reasoning_effort_levels``; unsupported values raise ``ValueError``.
+
+    ``"none"`` disables reasoning outright for native GPT-5.x models, it is
+    not equivalent to omitting the argument, since these models otherwise
+    default to ``"medium"``.
 
     Explicit values already present in ``additional_model_request_fields`` take
     precedence. If the model has no known reasoning-effort translation, a warning

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -80,6 +80,7 @@ from langchain_aws.utils import (
     count_tokens_api_supported_for_model,
     create_aws_client,
     parse_model_provider,
+    reasoning_effort_additional_fields,
     thinking_forced_tool_use_unsupported,
     thinking_in_params,
     trim_message_whitespace,
@@ -312,7 +313,25 @@ class ChatBedrockConverse(BaseChatModel):
         feature that outputs the step-by-step reasoning process that led to an
         answer.
 
-        To use it, specify the `thinking` parameter when initializing
+        For models that support configurable reasoning effort (Claude Opus 5/Sonnet 5,
+        Amazon Nova 2, gpt-oss), `reasoning_effort` is the recommended shorthand. It
+        translates to the appropriate provider-specific request format:
+
+        ```python
+        from langchain_aws import ChatBedrockConverse
+
+        model = ChatBedrockConverse(
+            model="us.anthropic.claude-sonnet-5",
+            region_name="us-west-2",
+            reasoning_effort="high",
+        )
+
+        response = model.invoke("What is the cube root of 50.653?")
+        ```
+
+        For finer-grained control (e.g. a fixed thinking token budget on older
+        Claude models), specify the `thinking` parameter directly via
+        `additional_model_request_fields` when initializing
         `ChatBedrockConverse` as shown below.
 
         You will need to specify a token budget to use this feature. See usage example:
@@ -593,6 +612,18 @@ class ChatBedrockConverse(BaseChatModel):
     not inference_config). Refer to the model's AWS documentation for
     supported parameters.
 
+    """
+
+    reasoning_effort: Optional[Literal["low", "medium", "high", "xhigh", "max"]] = None
+    """Reasoning effort level for models that support configurable reasoning.
+
+    Translated into the appropriate provider-specific request format based on the
+    model family. Only applied to models whose profile declares supported
+    ``reasoning_effort_levels``; unsupported values raise ``ValueError``.
+
+    Explicit values already present in ``additional_model_request_fields`` take
+    precedence. If the model has no known reasoning-effort translation, a warning
+    is emitted and the value is ignored.
     """
 
     additional_model_response_field_paths: Optional[List[str]] = None
@@ -1015,6 +1046,19 @@ class ChatBedrockConverse(BaseChatModel):
         if "application-inference-profile" in self.model_id:
             self._configure_streaming_for_resolved_model()
 
+        if not self.profile:
+            self.profile = self._resolve_model_profile()
+
+        if self.reasoning_effort is not None:
+            effort_fields = self._reasoning_effort_fields(self.reasoning_effort)
+            if effort_fields:
+                # Explicit additional_model_request_fields keys win over the
+                # reasoning_effort-derived defaults (e.g. an explicit `thinking`).
+                self.additional_model_request_fields = {
+                    **effort_fields,
+                    **(self.additional_model_request_fields or {}),
+                }
+
         # As of 12/03/24:
         # only claude-3/4, mistral-large, and nova models support tool choice:
         # https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolChoice.html
@@ -1063,9 +1107,6 @@ class ChatBedrockConverse(BaseChatModel):
         # Validate reasoning configuration for Nova 2 models
         self._validate_nova_reasoning_config()
 
-        if not self.profile:
-            self.profile = self._resolve_model_profile()
-
         _add_langchain_aws_version(self)
         return self
 
@@ -1073,6 +1114,38 @@ class ChatBedrockConverse(BaseChatModel):
         """Return the default model profile for this model."""
         model_id = self._get_base_model()
         return _get_default_model_profile(model_id)
+
+    def _reasoning_effort_fields(self, effort: str) -> Dict[str, Any]:
+        """Validate `effort` against the model profile and translate to request
+        fields.
+
+        Translation is only attempted for models whose profile explicitly
+        declares `reasoning_effort_levels` -- this is the single source of
+        truth for "does this specific model support configurable reasoning
+        effort," rather than a broad model-family substring match (e.g. not
+        every Claude model that matches `"claude" in base_model` supports
+        `output_config.effort`).
+        """
+        base_model = self._get_base_model()
+        levels = (self.profile or {}).get("reasoning_effort_levels") or ()
+        if not levels:
+            warnings.warn(
+                f"reasoning_effort is not supported for model {base_model}; ignoring.",
+                stacklevel=2,
+            )
+            return {}
+        if effort not in levels:
+            raise ValueError(
+                f"reasoning_effort={effort!r} is not supported for model "
+                f"{base_model}. Valid values: {list(levels)}"
+            )
+        fields = reasoning_effort_additional_fields(base_model, effort)
+        if not fields:
+            warnings.warn(
+                f"reasoning_effort is not supported for model {base_model}; ignoring.",
+                stacklevel=2,
+            )
+        return fields
 
     def _get_base_model(self) -> str:
         """Return base model id, stripping any regional prefix."""
@@ -1197,6 +1270,11 @@ class ChatBedrockConverse(BaseChatModel):
         # Remove disable_streaming from kwargs as it's not a valid API parameter
         filtered_kwargs = {k: v for k, v in kwargs.items() if k != "disable_streaming"}
         additional_fields = filtered_kwargs.pop("additional_model_request_fields", None)
+        reasoning_effort = filtered_kwargs.pop("reasoning_effort", None)
+        if reasoning_effort is not None:
+            effort_fields = self._reasoning_effort_fields(reasoning_effort)
+            if effort_fields:
+                additional_fields = {**effort_fields, **(additional_fields or {})}
         _apply_response_format(filtered_kwargs)
         cache_control = filtered_kwargs.pop("cache_control", None)
         params = self._converse_params(
@@ -1266,6 +1344,11 @@ class ChatBedrockConverse(BaseChatModel):
         # Remove disable_streaming from kwargs as it's not a valid API parameter
         filtered_kwargs = {k: v for k, v in kwargs.items() if k != "disable_streaming"}
         additional_fields = filtered_kwargs.pop("additional_model_request_fields", None)
+        reasoning_effort = filtered_kwargs.pop("reasoning_effort", None)
+        if reasoning_effort is not None:
+            effort_fields = self._reasoning_effort_fields(reasoning_effort)
+            if effort_fields:
+                additional_fields = {**effort_fields, **(additional_fields or {})}
         _apply_response_format(filtered_kwargs)
         cache_control = filtered_kwargs.pop("cache_control", None)
         params = self._converse_params(

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -1120,7 +1120,7 @@ class ChatBedrockConverse(BaseChatModel):
         fields.
 
         Translation is only attempted for models whose profile explicitly
-        declares `reasoning_effort_levels` -- this is the single source of
+        declares `reasoning_effort_levels`. This is the single source of
         truth for "does this specific model support configurable reasoning
         effort," rather than a broad model-family substring match (e.g. not
         every Claude model that matches `"claude" in base_model` supports

--- a/libs/aws/langchain_aws/data/_profiles.py
+++ b/libs/aws/langchain_aws/data/_profiles.py
@@ -39,7 +39,6 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "pdf_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
-        "reasoning_effort_levels": ["low", "medium", "high"],
     },
     "amazon.nova-lite-v1:0": {
         "name": "Nova Lite",
@@ -308,7 +307,6 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
-        "reasoning_effort_levels": ["low", "medium", "high", "xhigh", "max"],
     },
     "anthropic.claude-sonnet-4-5-20250929-v1:0": {
         "name": "Claude Sonnet 4.5",
@@ -384,7 +382,6 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
-        "reasoning_effort_levels": ["low", "medium", "high", "xhigh", "max"],
     },
     "au.anthropic.claude-haiku-4-5-20251001-v1:0": {
         "name": "Claude Haiku 4.5 (AU)",
@@ -483,7 +480,6 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
-        "reasoning_effort_levels": ["low", "medium", "high", "xhigh", "max"],
     },
     "au.anthropic.claude-sonnet-4-5-20250929-v1:0": {
         "name": "Claude Sonnet 4.5 (AU)",
@@ -559,7 +555,6 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
-        "reasoning_effort_levels": ["low", "medium", "high", "xhigh", "max"],
     },
     "deepseek.r1-v1:0": {
         "name": "DeepSeek-R1",
@@ -805,7 +800,6 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
-        "reasoning_effort_levels": ["low", "medium", "high", "xhigh", "max"],
     },
     "eu.anthropic.claude-sonnet-4-5-20250929-v1:0": {
         "name": "Claude Sonnet 4.5 (EU)",
@@ -881,7 +875,6 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
-        "reasoning_effort_levels": ["low", "medium", "high", "xhigh", "max"],
     },
     "global.anthropic.claude-fable-5": {
         "name": "Claude Fable 5 (Global)",
@@ -1053,7 +1046,6 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
-        "reasoning_effort_levels": ["low", "medium", "high", "xhigh", "max"],
     },
     "global.anthropic.claude-sonnet-4-5-20250929-v1:0": {
         "name": "Claude Sonnet 4.5 (Global)",
@@ -1129,7 +1121,6 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
-        "reasoning_effort_levels": ["low", "medium", "high", "xhigh", "max"],
     },
     "google.gemma-3-12b-it": {
         "name": "Google Gemma 3 12B",
@@ -1301,7 +1292,6 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
-        "reasoning_effort_levels": ["low", "medium", "high", "xhigh", "max"],
     },
     "jp.anthropic.claude-sonnet-4-5-20250929-v1:0": {
         "name": "Claude Sonnet 4.5 (JP)",
@@ -1377,7 +1367,6 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
-        "reasoning_effort_levels": ["low", "medium", "high", "xhigh", "max"],
     },
     "meta.llama3-1-70b-instruct-v1:0": {
         "name": "Llama 3.1 70B Instruct",
@@ -1822,7 +1811,6 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "pdf_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
-        "reasoning_effort_levels": ["low", "high", "max"],
     },
     "moonshotai.kimi-k2.5": {
         "name": "Kimi K2.5",
@@ -1848,7 +1836,6 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "pdf_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
-        "reasoning_effort_levels": ["low", "high", "max"],
     },
     "nvidia.nemotron-nano-12b-v2": {
         "name": "NVIDIA Nemotron Nano 12B v2 VL BF16",
@@ -1974,7 +1961,6 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
-        "reasoning_effort_levels": ["none", "low", "medium", "high", "xhigh"],
     },
     "openai.gpt-5.5": {
         "name": "GPT-5.5",
@@ -2000,7 +1986,6 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
-        "reasoning_effort_levels": ["none", "low", "medium", "high", "xhigh"],
     },
     "openai.gpt-5.6-luna": {
         "name": "GPT-5.6 Luna",
@@ -2026,7 +2011,6 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
-        "reasoning_effort_levels": ["none", "low", "medium", "high", "xhigh", "max"],
     },
     "openai.gpt-5.6-sol": {
         "name": "GPT-5.6 Sol",
@@ -2052,7 +2036,6 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
-        "reasoning_effort_levels": ["none", "low", "medium", "high", "xhigh", "max"],
     },
     "openai.gpt-5.6-terra": {
         "name": "GPT-5.6 Terra",
@@ -2078,7 +2061,6 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
-        "reasoning_effort_levels": ["none", "low", "medium", "high", "xhigh", "max"],
     },
     "openai.gpt-oss-120b": {
         "name": "gpt-oss-120b",
@@ -2104,7 +2086,6 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "pdf_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
-        "reasoning_effort_levels": ["low", "medium", "high"],
     },
     "openai.gpt-oss-120b-1:0": {
         "name": "gpt-oss-120b",
@@ -2130,7 +2111,6 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "pdf_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
-        "reasoning_effort_levels": ["low", "medium", "high"],
     },
     "openai.gpt-oss-20b": {
         "name": "gpt-oss-20b",
@@ -2156,7 +2136,6 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "pdf_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
-        "reasoning_effort_levels": ["low", "medium", "high"],
     },
     "openai.gpt-oss-20b-1:0": {
         "name": "gpt-oss-20b",
@@ -2182,7 +2161,6 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "pdf_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
-        "reasoning_effort_levels": ["low", "medium", "high"],
     },
     "openai.gpt-oss-safeguard-120b": {
         "name": "GPT OSS Safeguard 120B",
@@ -2604,7 +2582,6 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
-        "reasoning_effort_levels": ["low", "medium", "high", "xhigh", "max"],
     },
     "us.anthropic.claude-sonnet-4-5-20250929-v1:0": {
         "name": "Claude Sonnet 4.5 (US)",
@@ -2680,7 +2657,6 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
-        "reasoning_effort_levels": ["low", "medium", "high", "xhigh", "max"],
     },
     "us.deepseek.r1-v1:0": {
         "name": "DeepSeek-R1 (US)",

--- a/libs/aws/langchain_aws/data/_profiles.py
+++ b/libs/aws/langchain_aws/data/_profiles.py
@@ -1974,7 +1974,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
-        "reasoning_effort_levels": ["low", "medium", "high"],
+        "reasoning_effort_levels": ["none", "low", "medium", "high", "xhigh"],
     },
     "openai.gpt-5.5": {
         "name": "GPT-5.5",
@@ -2000,7 +2000,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
-        "reasoning_effort_levels": ["low", "medium", "high"],
+        "reasoning_effort_levels": ["none", "low", "medium", "high", "xhigh"],
     },
     "openai.gpt-5.6-luna": {
         "name": "GPT-5.6 Luna",
@@ -2026,7 +2026,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
-        "reasoning_effort_levels": ["low", "medium", "high"],
+        "reasoning_effort_levels": ["none", "low", "medium", "high", "xhigh", "max"],
     },
     "openai.gpt-5.6-sol": {
         "name": "GPT-5.6 Sol",
@@ -2052,7 +2052,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
-        "reasoning_effort_levels": ["low", "medium", "high"],
+        "reasoning_effort_levels": ["none", "low", "medium", "high", "xhigh", "max"],
     },
     "openai.gpt-5.6-terra": {
         "name": "GPT-5.6 Terra",
@@ -2078,7 +2078,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
-        "reasoning_effort_levels": ["low", "medium", "high"],
+        "reasoning_effort_levels": ["none", "low", "medium", "high", "xhigh", "max"],
     },
     "openai.gpt-oss-120b": {
         "name": "gpt-oss-120b",

--- a/libs/aws/langchain_aws/data/_profiles.py
+++ b/libs/aws/langchain_aws/data/_profiles.py
@@ -39,6 +39,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "pdf_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
+        "reasoning_effort_levels": ["low", "medium", "high"],
     },
     "amazon.nova-lite-v1:0": {
         "name": "Nova Lite",
@@ -307,6 +308,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
+        "reasoning_effort_levels": ["low", "medium", "high", "xhigh", "max"],
     },
     "anthropic.claude-sonnet-4-5-20250929-v1:0": {
         "name": "Claude Sonnet 4.5",
@@ -382,6 +384,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
+        "reasoning_effort_levels": ["low", "medium", "high", "xhigh", "max"],
     },
     "au.anthropic.claude-haiku-4-5-20251001-v1:0": {
         "name": "Claude Haiku 4.5 (AU)",
@@ -480,6 +483,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
+        "reasoning_effort_levels": ["low", "medium", "high", "xhigh", "max"],
     },
     "au.anthropic.claude-sonnet-4-5-20250929-v1:0": {
         "name": "Claude Sonnet 4.5 (AU)",
@@ -555,6 +559,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
+        "reasoning_effort_levels": ["low", "medium", "high", "xhigh", "max"],
     },
     "deepseek.r1-v1:0": {
         "name": "DeepSeek-R1",
@@ -800,6 +805,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
+        "reasoning_effort_levels": ["low", "medium", "high", "xhigh", "max"],
     },
     "eu.anthropic.claude-sonnet-4-5-20250929-v1:0": {
         "name": "Claude Sonnet 4.5 (EU)",
@@ -875,6 +881,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
+        "reasoning_effort_levels": ["low", "medium", "high", "xhigh", "max"],
     },
     "global.anthropic.claude-fable-5": {
         "name": "Claude Fable 5 (Global)",
@@ -1046,6 +1053,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
+        "reasoning_effort_levels": ["low", "medium", "high", "xhigh", "max"],
     },
     "global.anthropic.claude-sonnet-4-5-20250929-v1:0": {
         "name": "Claude Sonnet 4.5 (Global)",
@@ -1121,6 +1129,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
+        "reasoning_effort_levels": ["low", "medium", "high", "xhigh", "max"],
     },
     "google.gemma-3-12b-it": {
         "name": "Google Gemma 3 12B",
@@ -1292,6 +1301,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
+        "reasoning_effort_levels": ["low", "medium", "high", "xhigh", "max"],
     },
     "jp.anthropic.claude-sonnet-4-5-20250929-v1:0": {
         "name": "Claude Sonnet 4.5 (JP)",
@@ -1367,6 +1377,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
+        "reasoning_effort_levels": ["low", "medium", "high", "xhigh", "max"],
     },
     "meta.llama3-1-70b-instruct-v1:0": {
         "name": "Llama 3.1 70B Instruct",
@@ -1811,6 +1822,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "pdf_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
+        "reasoning_effort_levels": ["low", "high", "max"],
     },
     "moonshotai.kimi-k2.5": {
         "name": "Kimi K2.5",
@@ -1836,6 +1848,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "pdf_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
+        "reasoning_effort_levels": ["low", "high", "max"],
     },
     "nvidia.nemotron-nano-12b-v2": {
         "name": "NVIDIA Nemotron Nano 12B v2 VL BF16",
@@ -1961,6 +1974,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
+        "reasoning_effort_levels": ["low", "medium", "high"],
     },
     "openai.gpt-5.5": {
         "name": "GPT-5.5",
@@ -1986,6 +2000,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
+        "reasoning_effort_levels": ["low", "medium", "high"],
     },
     "openai.gpt-5.6-luna": {
         "name": "GPT-5.6 Luna",
@@ -2011,6 +2026,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
+        "reasoning_effort_levels": ["low", "medium", "high"],
     },
     "openai.gpt-5.6-sol": {
         "name": "GPT-5.6 Sol",
@@ -2036,6 +2052,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
+        "reasoning_effort_levels": ["low", "medium", "high"],
     },
     "openai.gpt-5.6-terra": {
         "name": "GPT-5.6 Terra",
@@ -2061,6 +2078,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
+        "reasoning_effort_levels": ["low", "medium", "high"],
     },
     "openai.gpt-oss-120b": {
         "name": "gpt-oss-120b",
@@ -2086,6 +2104,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "pdf_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
+        "reasoning_effort_levels": ["low", "medium", "high"],
     },
     "openai.gpt-oss-120b-1:0": {
         "name": "gpt-oss-120b",
@@ -2111,6 +2130,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "pdf_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
+        "reasoning_effort_levels": ["low", "medium", "high"],
     },
     "openai.gpt-oss-20b": {
         "name": "gpt-oss-20b",
@@ -2136,6 +2156,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "pdf_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
+        "reasoning_effort_levels": ["low", "medium", "high"],
     },
     "openai.gpt-oss-20b-1:0": {
         "name": "gpt-oss-20b",
@@ -2161,6 +2182,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "pdf_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
+        "reasoning_effort_levels": ["low", "medium", "high"],
     },
     "openai.gpt-oss-safeguard-120b": {
         "name": "GPT OSS Safeguard 120B",
@@ -2582,6 +2604,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
+        "reasoning_effort_levels": ["low", "medium", "high", "xhigh", "max"],
     },
     "us.anthropic.claude-sonnet-4-5-20250929-v1:0": {
         "name": "Claude Sonnet 4.5 (US)",
@@ -2657,6 +2680,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
+        "reasoning_effort_levels": ["low", "medium", "high", "xhigh", "max"],
     },
     "us.deepseek.r1-v1:0": {
         "name": "DeepSeek-R1 (US)",

--- a/libs/aws/langchain_aws/data/profile_augmentations.toml
+++ b/libs/aws/langchain_aws/data/profile_augmentations.toml
@@ -5,3 +5,60 @@ image_url_inputs = true
 pdf_inputs = true
 pdf_tool_message = true
 image_tool_message = true
+
+[overrides."anthropic.claude-opus-5"]
+reasoning_effort_levels = ["low", "medium", "high", "xhigh", "max"]
+
+[overrides."au.anthropic.claude-opus-5"]
+reasoning_effort_levels = ["low", "medium", "high", "xhigh", "max"]
+
+[overrides."eu.anthropic.claude-opus-5"]
+reasoning_effort_levels = ["low", "medium", "high", "xhigh", "max"]
+
+[overrides."global.anthropic.claude-opus-5"]
+reasoning_effort_levels = ["low", "medium", "high", "xhigh", "max"]
+
+[overrides."jp.anthropic.claude-opus-5"]
+reasoning_effort_levels = ["low", "medium", "high", "xhigh", "max"]
+
+[overrides."us.anthropic.claude-opus-5"]
+reasoning_effort_levels = ["low", "medium", "high", "xhigh", "max"]
+
+[overrides."anthropic.claude-sonnet-5"]
+reasoning_effort_levels = ["low", "medium", "high", "xhigh", "max"]
+
+[overrides."au.anthropic.claude-sonnet-5"]
+reasoning_effort_levels = ["low", "medium", "high", "xhigh", "max"]
+
+[overrides."eu.anthropic.claude-sonnet-5"]
+reasoning_effort_levels = ["low", "medium", "high", "xhigh", "max"]
+
+[overrides."global.anthropic.claude-sonnet-5"]
+reasoning_effort_levels = ["low", "medium", "high", "xhigh", "max"]
+
+[overrides."jp.anthropic.claude-sonnet-5"]
+reasoning_effort_levels = ["low", "medium", "high", "xhigh", "max"]
+
+[overrides."us.anthropic.claude-sonnet-5"]
+reasoning_effort_levels = ["low", "medium", "high", "xhigh", "max"]
+
+[overrides."amazon.nova-2-lite-v1:0"]
+reasoning_effort_levels = ["low", "medium", "high"]
+
+[overrides."openai.gpt-oss-120b"]
+reasoning_effort_levels = ["low", "medium", "high"]
+
+[overrides."openai.gpt-oss-120b-1:0"]
+reasoning_effort_levels = ["low", "medium", "high"]
+
+[overrides."openai.gpt-oss-20b"]
+reasoning_effort_levels = ["low", "medium", "high"]
+
+[overrides."openai.gpt-oss-20b-1:0"]
+reasoning_effort_levels = ["low", "medium", "high"]
+
+[overrides."moonshot.kimi-k2-thinking"]
+reasoning_effort_levels = ["low", "high", "max"]
+
+[overrides."moonshotai.kimi-k2.5"]
+reasoning_effort_levels = ["low", "high", "max"]

--- a/libs/aws/langchain_aws/utils.py
+++ b/libs/aws/langchain_aws/utils.py
@@ -509,6 +509,24 @@ def thinking_forced_tool_use_unsupported(model: str) -> bool:
     )
 
 
+def reasoning_effort_additional_fields(base_model: str, effort: str) -> Dict[str, Any]:
+    """Translate a `reasoning_effort` value into provider-specific request fields.
+
+    Returns an empty dict if the model family has no known translation; callers
+    are responsible for warning the user in that case.
+    """
+    model = base_model.lower()
+    if model.startswith("amazon.nova-2"):
+        return {"reasoningConfig": {"type": "enabled", "maxReasoningEffort": effort}}
+    if "claude" in model:
+        return {"thinking": {"type": "adaptive"}, "output_config": {"effort": effort}}
+    if model.startswith("openai."):
+        return {"reasoning_effort": effort}
+    if model.startswith(("moonshot.", "moonshotai.")):
+        return {"reasoning_effort": effort}
+    return {}
+
+
 def trim_message_whitespace(messages: List[Any]) -> List[Any]:
     """Trim trailing whitespace from final AIMessage content."""
     if not messages or not isinstance(messages[-1], AIMessage):

--- a/libs/aws/langchain_aws/utils.py
+++ b/libs/aws/langchain_aws/utils.py
@@ -520,7 +520,7 @@ def reasoning_effort_additional_fields(base_model: str, effort: str) -> Dict[str
         return {"reasoningConfig": {"type": "enabled", "maxReasoningEffort": effort}}
     if "claude" in model:
         return {"thinking": {"type": "adaptive"}, "output_config": {"effort": effort}}
-    if model.startswith("openai."):
+    if model.startswith("openai.gpt-oss"):
         return {"reasoning_effort": effort}
     if model.startswith(("moonshot.", "moonshotai.")):
         return {"reasoning_effort": effort}

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -3959,6 +3959,169 @@ def test_reasoning_config_validation_rejects_invalid_type() -> None:
         )  # type: ignore[call-arg]
 
 
+def test_reasoning_effort_claude_translates_to_thinking_and_output_config() -> None:
+    """Test reasoning_effort maps to thinking(adaptive) + output_config.effort."""
+    llm = ChatBedrockConverse(
+        model="us.anthropic.claude-sonnet-5",
+        region_name="us-east-1",
+        reasoning_effort="high",
+    )  # type: ignore[call-arg]
+    assert llm.additional_model_request_fields == {
+        "thinking": {"type": "adaptive"},
+        "output_config": {"effort": "high"},
+    }
+
+
+def test_reasoning_effort_explicit_thinking_wins() -> None:
+    """Test explicit additional_model_request_fields keys beat reasoning_effort."""
+    llm = ChatBedrockConverse(
+        model="us.anthropic.claude-sonnet-5",
+        region_name="us-east-1",
+        reasoning_effort="high",
+        additional_model_request_fields={
+            "thinking": {"type": "enabled", "budget_tokens": 2000}
+        },
+    )  # type: ignore[call-arg]
+    assert llm.additional_model_request_fields == {
+        "thinking": {"type": "enabled", "budget_tokens": 2000},
+        "output_config": {"effort": "high"},
+    }
+
+
+def test_reasoning_effort_call_time_overrides_constructor() -> None:
+    """Test call-time reasoning_effort overrides the constructor value."""
+    mocked_client = mock.MagicMock()
+    mocked_client.converse.return_value = {
+        "output": {"message": {"content": [{"text": "Hello!"}]}},
+        "usage": {"inputTokens": 10, "outputTokens": 5, "totalTokens": 15},
+    }
+    llm = ChatBedrockConverse(
+        client=mocked_client,
+        model="us.anthropic.claude-sonnet-5",
+        region_name="us-east-1",
+        reasoning_effort="low",
+    )  # type: ignore[call-arg]
+
+    llm.invoke([HumanMessage(content="Hi")], reasoning_effort="high")
+
+    call_kwargs = mocked_client.converse.call_args[1]
+    additional_fields = call_kwargs["additionalModelRequestFields"]
+    assert additional_fields == {
+        "thinking": {"type": "adaptive"},
+        "output_config": {"effort": "high"},
+    }
+
+
+def test_reasoning_effort_nova2_translates_to_reasoning_config() -> None:
+    """Test reasoning_effort maps to Nova 2's reasoningConfig and unsets maxTokens."""
+    mocked_client = mock.MagicMock()
+    mocked_client.converse.return_value = {
+        "output": {"message": {"content": [{"text": "Hello!"}]}},
+        "usage": {"inputTokens": 10, "outputTokens": 5, "totalTokens": 15},
+    }
+    llm = ChatBedrockConverse(
+        client=mocked_client,
+        model="amazon.nova-2-lite-v1:0",
+        region_name="us-east-1",
+        reasoning_effort="high",
+    )  # type: ignore[call-arg]
+    assert llm.additional_model_request_fields == {
+        "reasoningConfig": {"type": "enabled", "maxReasoningEffort": "high"}
+    }
+
+    llm.invoke([HumanMessage(content="Hi")])
+
+    call_kwargs = mocked_client.converse.call_args[1]
+    assert "maxTokens" not in call_kwargs["inferenceConfig"]
+
+
+def test_reasoning_effort_nova2_invalid_level_raises() -> None:
+    """Test an effort level unsupported by the model's profile raises ValueError."""
+    with pytest.raises(ValueError, match="reasoning_effort='xhigh' is not supported"):
+        ChatBedrockConverse(
+            model="amazon.nova-2-lite-v1:0",
+            region_name="us-east-1",
+            reasoning_effort="xhigh",
+        )  # type: ignore[call-arg]
+
+
+def test_reasoning_effort_gpt_oss_flat() -> None:
+    """Test reasoning_effort maps to a flat key for gpt-oss models."""
+    llm = ChatBedrockConverse(
+        model="openai.gpt-oss-120b-1:0",
+        region_name="us-east-1",
+        reasoning_effort="medium",
+    )  # type: ignore[call-arg]
+    assert llm.additional_model_request_fields == {"reasoning_effort": "medium"}
+
+
+def test_reasoning_effort_gpt_oss_invalid_level_raises() -> None:
+    """Test a level unsupported by gpt-oss's profile raises ValueError."""
+    with pytest.raises(ValueError, match="reasoning_effort='xhigh' is not supported"):
+        ChatBedrockConverse(
+            model="openai.gpt-oss-120b-1:0",
+            region_name="us-east-1",
+            reasoning_effort="xhigh",
+        )  # type: ignore[call-arg]
+
+
+def test_reasoning_effort_unsupported_model_warns() -> None:
+    """Test reasoning_effort on a model with no known translation warns and no-ops."""
+    with pytest.warns(UserWarning, match="reasoning_effort is not supported"):
+        llm = ChatBedrockConverse(
+            model="meta.llama3-1-70b-instruct-v1:0",
+            region_name="us-east-1",
+            reasoning_effort="high",
+        )  # type: ignore[call-arg]
+    assert not llm.additional_model_request_fields
+
+
+def test_reasoning_effort_older_claude_model_warns_not_translates() -> None:
+    """Test reasoning_effort on a Claude model without declared levels warns.
+
+    Regression test: reasoning_effort must only translate for Claude models
+    whose profile explicitly declares reasoning_effort_levels (opus-5/
+    sonnet-5), not for every model matching "claude" in the id.
+    """
+    with pytest.warns(UserWarning, match="reasoning_effort is not supported"):
+        llm = ChatBedrockConverse(
+            model="us.anthropic.claude-haiku-4-5-20251001-v1:0",
+            region_name="us-east-1",
+            reasoning_effort="high",
+        )  # type: ignore[call-arg]
+    assert not llm.additional_model_request_fields
+
+
+def test_reasoning_effort_native_openai_flat() -> None:
+    """Test reasoning_effort maps to a flat key for native openai.gpt-5.x models."""
+    llm = ChatBedrockConverse(
+        model="openai.gpt-5.5",
+        region_name="us-east-1",
+        reasoning_effort="medium",
+    )  # type: ignore[call-arg]
+    assert llm.additional_model_request_fields == {"reasoning_effort": "medium"}
+
+
+def test_reasoning_effort_moonshot_flat() -> None:
+    """Test reasoning_effort maps to a flat key for Moonshot Kimi K2 models."""
+    llm = ChatBedrockConverse(
+        model="moonshot.kimi-k2-thinking",
+        region_name="us-east-1",
+        reasoning_effort="max",
+    )  # type: ignore[call-arg]
+    assert llm.additional_model_request_fields == {"reasoning_effort": "max"}
+
+
+def test_reasoning_effort_moonshot_invalid_level_raises() -> None:
+    """Test a level unsupported by Moonshot's profile (no "medium") raises."""
+    with pytest.raises(ValueError, match="reasoning_effort='medium' is not supported"):
+        ChatBedrockConverse(
+            model="moonshot.kimi-k2-thinking",
+            region_name="us-east-1",
+            reasoning_effort="medium",
+        )  # type: ignore[call-arg]
+
+
 def test_iam_permission_error_detection() -> None:
     """Test that IAM permission errors for InvokeTool are detected and enhanced."""
     from botocore.exceptions import ClientError

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -3959,12 +3959,17 @@ def test_reasoning_config_validation_rejects_invalid_type() -> None:
         )  # type: ignore[call-arg]
 
 
+# These tests inject `profile=` directly at construction rather than relying on
+# `_profiles.py` containing real data for the model id used.
+
+
 def test_reasoning_effort_claude_translates_to_thinking_and_output_config() -> None:
     """Test reasoning_effort maps to thinking(adaptive) + output_config.effort."""
     llm = ChatBedrockConverse(
         model="us.anthropic.claude-sonnet-5",
         region_name="us-east-1",
         reasoning_effort="high",
+        profile={"reasoning_effort_levels": ["low", "medium", "high", "xhigh", "max"]},
     )  # type: ignore[call-arg]
     assert llm.additional_model_request_fields == {
         "thinking": {"type": "adaptive"},
@@ -3981,6 +3986,7 @@ def test_reasoning_effort_explicit_thinking_wins() -> None:
         additional_model_request_fields={
             "thinking": {"type": "enabled", "budget_tokens": 2000}
         },
+        profile={"reasoning_effort_levels": ["low", "medium", "high", "xhigh", "max"]},
     )  # type: ignore[call-arg]
     assert llm.additional_model_request_fields == {
         "thinking": {"type": "enabled", "budget_tokens": 2000},
@@ -4000,6 +4006,7 @@ def test_reasoning_effort_call_time_overrides_constructor() -> None:
         model="us.anthropic.claude-sonnet-5",
         region_name="us-east-1",
         reasoning_effort="low",
+        profile={"reasoning_effort_levels": ["low", "medium", "high", "xhigh", "max"]},
     )  # type: ignore[call-arg]
 
     llm.invoke([HumanMessage(content="Hi")], reasoning_effort="high")
@@ -4024,6 +4031,7 @@ def test_reasoning_effort_nova2_translates_to_reasoning_config() -> None:
         model="amazon.nova-2-lite-v1:0",
         region_name="us-east-1",
         reasoning_effort="high",
+        profile={"reasoning_effort_levels": ["low", "medium", "high"]},
     )  # type: ignore[call-arg]
     assert llm.additional_model_request_fields == {
         "reasoningConfig": {"type": "enabled", "maxReasoningEffort": "high"}
@@ -4042,6 +4050,7 @@ def test_reasoning_effort_nova2_invalid_level_raises() -> None:
             model="amazon.nova-2-lite-v1:0",
             region_name="us-east-1",
             reasoning_effort="xhigh",
+            profile={"reasoning_effort_levels": ["low", "medium", "high"]},
         )  # type: ignore[call-arg]
 
 
@@ -4051,6 +4060,7 @@ def test_reasoning_effort_gpt_oss_flat() -> None:
         model="openai.gpt-oss-120b-1:0",
         region_name="us-east-1",
         reasoning_effort="medium",
+        profile={"reasoning_effort_levels": ["low", "medium", "high"]},
     )  # type: ignore[call-arg]
     assert llm.additional_model_request_fields == {"reasoning_effort": "medium"}
 
@@ -4062,6 +4072,7 @@ def test_reasoning_effort_gpt_oss_invalid_level_raises() -> None:
             model="openai.gpt-oss-120b-1:0",
             region_name="us-east-1",
             reasoning_effort="xhigh",
+            profile={"reasoning_effort_levels": ["low", "medium", "high"]},
         )  # type: ignore[call-arg]
 
 
@@ -4092,22 +4103,13 @@ def test_reasoning_effort_older_claude_model_warns_not_translates() -> None:
     assert not llm.additional_model_request_fields
 
 
-def test_reasoning_effort_native_openai_flat() -> None:
-    """Test reasoning_effort maps to a flat key for native openai.gpt-5.x models."""
-    llm = ChatBedrockConverse(
-        model="openai.gpt-5.5",
-        region_name="us-east-1",
-        reasoning_effort="medium",
-    )  # type: ignore[call-arg]
-    assert llm.additional_model_request_fields == {"reasoning_effort": "medium"}
-
-
 def test_reasoning_effort_moonshot_flat() -> None:
     """Test reasoning_effort maps to a flat key for Moonshot Kimi K2 models."""
     llm = ChatBedrockConverse(
         model="moonshot.kimi-k2-thinking",
         region_name="us-east-1",
         reasoning_effort="max",
+        profile={"reasoning_effort_levels": ["low", "high", "max"]},
     )  # type: ignore[call-arg]
     assert llm.additional_model_request_fields == {"reasoning_effort": "max"}
 
@@ -4119,6 +4121,7 @@ def test_reasoning_effort_moonshot_invalid_level_raises() -> None:
             model="moonshot.kimi-k2-thinking",
             region_name="us-east-1",
             reasoning_effort="medium",
+            profile={"reasoning_effort_levels": ["low", "high", "max"]},
         )  # type: ignore[call-arg]
 
 

--- a/libs/aws/tests/unit_tests/test_utils.py
+++ b/libs/aws/tests/unit_tests/test_utils.py
@@ -12,6 +12,7 @@ from langchain_aws.utils import (
     count_tokens_api_supported_for_model,
     create_aws_client,
     parse_model_provider,
+    reasoning_effort_additional_fields,
     thinking_disabled_in_params,
     thinking_forced_tool_use_unsupported,
     thinking_in_params,
@@ -517,6 +518,54 @@ def test_thinking_on_by_default(model_id: str, expected_result: bool) -> None:
 )
 def test_thinking_disabled_in_params(params: dict, expected_result: bool) -> None:
     assert thinking_disabled_in_params(params) == expected_result
+
+
+@pytest.mark.parametrize(
+    "base_model,effort,expected_fields",
+    [
+        (
+            "us.anthropic.claude-sonnet-5",
+            "high",
+            {"thinking": {"type": "adaptive"}, "output_config": {"effort": "high"}},
+        ),
+        (
+            "anthropic.claude-opus-5",
+            "xhigh",
+            {"thinking": {"type": "adaptive"}, "output_config": {"effort": "xhigh"}},
+        ),
+        (
+            "amazon.nova-2-lite-v1:0",
+            "medium",
+            {"reasoningConfig": {"type": "enabled", "maxReasoningEffort": "medium"}},
+        ),
+        (
+            "openai.gpt-oss-120b-1:0",
+            "low",
+            {"reasoning_effort": "low"},
+        ),
+        (
+            "openai.gpt-5.5",
+            "medium",
+            {"reasoning_effort": "medium"},
+        ),
+        (
+            "moonshot.kimi-k2-thinking",
+            "max",
+            {"reasoning_effort": "max"},
+        ),
+        (
+            "moonshotai.kimi-k2.5",
+            "low",
+            {"reasoning_effort": "low"},
+        ),
+        ("amazon.titan-text-express-v1", "high", {}),
+        ("meta.llama3-1-70b-instruct-v1:0", "high", {}),
+    ],
+)
+def test_reasoning_effort_additional_fields(
+    base_model: str, effort: str, expected_fields: dict
+) -> None:
+    assert reasoning_effort_additional_fields(base_model, effort) == expected_fields
 
 
 def test_api_key_uses_token_provider(

--- a/libs/aws/tests/unit_tests/test_utils.py
+++ b/libs/aws/tests/unit_tests/test_utils.py
@@ -544,11 +544,6 @@ def test_thinking_disabled_in_params(params: dict, expected_result: bool) -> Non
             {"reasoning_effort": "low"},
         ),
         (
-            "openai.gpt-5.5",
-            "medium",
-            {"reasoning_effort": "medium"},
-        ),
-        (
             "moonshot.kimi-k2-thinking",
             "max",
             {"reasoning_effort": "max"},
@@ -560,6 +555,8 @@ def test_thinking_disabled_in_params(params: dict, expected_result: bool) -> Non
         ),
         ("amazon.titan-text-express-v1", "high", {}),
         ("meta.llama3-1-70b-instruct-v1:0", "high", {}),
+        # Native GPT-5.x models are bedrock-mantle-only
+        ("openai.gpt-5.5", "medium", {}),
     ],
 )
 def test_reasoning_effort_additional_fields(


### PR DESCRIPTION
Mirrors the standardized `reasoning_effort` chat-model parameter introduced in langchain-ai/langchain#38887 for `ChatBedrockConverse`. Today, configuring extended `thinking`/`reasoning` on Bedrock means hand-building provider-specific dicts inside `additional_model_request_fields`. This PR adds a single `reasoning_effort`: `Literal["low","medium","high","xhigh","max"]` field/call-time kwarg that translates to the right wire shape per model family:

| Model family | Request shape |
|--------------|---------------|
| Claude (Opus 5 / Sonnet 5) | `{"thinking": {"type": "adaptive"}, "output_config": {"effort": ...}}` |
| Amazon Nova 2 | `{"reasoningConfig": {"type": "enabled", "maxReasoningEffort": ...}}` |
| OpenAI (native GPT-5.x and open-weight gpt-oss), Moonshot Kimi K2 | `{"reasoning_effort": ...}` |
| Anything else | warnings and no-op |

