### PR TITLE
feat(aws): add ChatOpenAIMantle for Bedrock Mantle OpenAI-compatible API

### DIFF
--- a/libs/aws/langchain_aws/__init__.py
+++ b/libs/aws/langchain_aws/__init__.py
@@ -14,7 +14,11 @@ if TYPE_CHECKING:
         create_neptune_opencypher_qa_chain,
         create_neptune_sparql_qa_chain,
     )
-    from langchain_aws.chat_models import ChatAnthropicBedrock, ChatBedrockNovaSonic
+    from langchain_aws.chat_models import (
+        ChatAnthropicBedrock,
+        ChatBedrockNovaSonic,
+        ChatOpenAIMantle,
+    )
     from langchain_aws.document_compressors.rerank import BedrockRerank
     from langchain_aws.embeddings import BedrockEmbeddings
     from langchain_aws.graphs import NeptuneAnalyticsGraph, NeptuneGraph
@@ -87,6 +91,7 @@ __all__ = [
     "ChatBedrock",
     "ChatBedrockConverse",
     "ChatBedrockNovaSonic",
+    "ChatOpenAIMantle",
     "SagemakerEndpoint",
     "AmazonKendraRetriever",
     "AmazonKnowledgeBasesRetriever",
@@ -123,6 +128,10 @@ def __getattr__(name: str) -> Any:
         "ChatBedrockNovaSonic": (
             "langchain_aws.chat_models",
             'pip install "langchain-aws[nova-sonic]"',
+        ),
+        "ChatOpenAIMantle": (
+            "langchain_aws.chat_models",
+            'pip install "langchain-aws[openai]"',
         ),
     }
 

--- a/libs/aws/langchain_aws/chat_models/__init__.py
+++ b/libs/aws/langchain_aws/chat_models/__init__.py
@@ -6,12 +6,14 @@ from langchain_aws.chat_models.bedrock_converse import ChatBedrockConverse
 if TYPE_CHECKING:
     from langchain_aws.chat_models.anthropic import ChatAnthropicBedrock
     from langchain_aws.chat_models.bedrock_nova_sonic import ChatBedrockNovaSonic
+    from langchain_aws.chat_models.openai import ChatOpenAIMantle
 
 __all__ = [
     "ChatAnthropicBedrock",
     "ChatBedrock",
     "ChatBedrockConverse",
     "ChatBedrockNovaSonic",
+    "ChatOpenAIMantle",
 ]
 
 # Mapping of class name to (module path, install hint) for chat models that
@@ -25,6 +27,10 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "ChatBedrockNovaSonic": (
         "langchain_aws.chat_models.bedrock_nova_sonic",
         'pip install "langchain-aws[nova-sonic]"',
+    ),
+    "ChatOpenAIMantle": (
+        "langchain_aws.chat_models.openai",
+        'pip install "langchain-aws[openai]"',
     ),
 }
 

--- a/libs/aws/langchain_aws/chat_models/openai.py
+++ b/libs/aws/langchain_aws/chat_models/openai.py
@@ -9,12 +9,23 @@ structured output, streaming, tracing, multimodal) is inherited unchanged.
 """
 
 import os
-from typing import Any, cast
+from collections.abc import AsyncIterator, Iterator
+from typing import Any, Literal, cast
 
-from langchain_core.language_models import ModelProfile, ModelProfileRegistry
+from langchain_core.language_models import (
+    LanguageModelInput,
+    ModelProfile,
+    ModelProfileRegistry,
+)
 from langchain_core.language_models.chat_models import LangSmithParams
+from langchain_core.outputs import ChatGenerationChunk
+from langchain_core.runnables import Runnable
 from langchain_core.utils import secret_from_env
-from langchain_openai.chat_models.base import BaseChatOpenAI
+from langchain_openai.chat_models.base import (
+    BaseChatOpenAI,
+    _DictOrPydantic,
+    _DictOrPydanticClass,
+)
 from pydantic import ConfigDict, Field, SecretStr, model_validator
 from typing_extensions import Self
 
@@ -150,3 +161,44 @@ class ChatOpenAIMantle(BaseChatOpenAI):
         params = super()._get_ls_params(stop=stop, **kwargs)
         params["ls_provider"] = "openai-mantle"
         return params
+
+    def _stream(self, *args: Any, **kwargs: Any) -> Iterator[ChatGenerationChunk]:
+        """Route to the Chat Completions or Responses API."""
+        if self._use_responses_api({**kwargs, **self.model_kwargs}):
+            return super()._stream_responses(*args, **kwargs)
+        return super()._stream(*args, **kwargs)
+
+    async def _astream(
+        self, *args: Any, **kwargs: Any
+    ) -> AsyncIterator[ChatGenerationChunk]:
+        """Route to the Chat Completions or Responses API."""
+        if self._use_responses_api({**kwargs, **self.model_kwargs}):
+            async for chunk in super()._astream_responses(*args, **kwargs):
+                yield chunk
+        else:
+            async for chunk in super()._astream(*args, **kwargs):
+                yield chunk
+
+    def with_structured_output(
+        self,
+        schema: _DictOrPydanticClass | None = None,
+        *,
+        method: Literal["function_calling", "json_mode", "json_schema"] = "json_schema",
+        include_raw: bool = False,
+        strict: bool | None = None,
+        tools: list | None = None,
+        **kwargs: Any,
+    ) -> Runnable[LanguageModelInput, _DictOrPydantic]:
+        """Model wrapper that returns outputs formatted to match the given schema.
+
+        Identical to ``BaseChatOpenAI.with_structured_output`` except that
+        ``method`` defaults to ``'json_schema'`` (matching ``ChatOpenAI``).
+        """
+        return super().with_structured_output(
+            schema,
+            method=method,
+            include_raw=include_raw,
+            strict=strict,
+            tools=tools,
+            **kwargs,
+        )

--- a/libs/aws/langchain_aws/chat_models/openai.py
+++ b/libs/aws/langchain_aws/chat_models/openai.py
@@ -9,8 +9,9 @@ structured output, streaming, tracing, multimodal) is inherited unchanged.
 """
 
 import os
-from typing import Any
+from typing import Any, cast
 
+from langchain_core.language_models import ModelProfile, ModelProfileRegistry
 from langchain_core.language_models.chat_models import LangSmithParams
 from langchain_core.utils import secret_from_env
 from langchain_openai.chat_models.base import BaseChatOpenAI
@@ -18,8 +19,17 @@ from pydantic import ConfigDict, Field, SecretStr, model_validator
 from typing_extensions import Self
 
 from langchain_aws._version import _add_langchain_aws_version
+from langchain_aws.data._profiles import _PROFILES
 
 _MANTLE_BASE_URL_TEMPLATE = "https://bedrock-mantle.{region}.api.aws/v1"
+
+_MODEL_PROFILES = cast("ModelProfileRegistry", _PROFILES)
+
+
+def _get_default_model_profile(model_name: str) -> ModelProfile:
+    """Return the static capability profile for a Mantle model, or an empty one."""
+    default = _MODEL_PROFILES.get(model_name) or {}
+    return default.copy()
 
 
 class ChatOpenAIMantle(BaseChatOpenAI):
@@ -109,6 +119,13 @@ class ChatOpenAIMantle(BaseChatOpenAI):
     def _stamp_version(self) -> Self:
         """Record the langchain-aws version in tracing metadata."""
         _add_langchain_aws_version(self)
+        return self
+
+    @model_validator(mode="after")
+    def _resolve_profile(self) -> Self:
+        """Populate the model profile from static data unless one was supplied."""
+        if not self.profile:
+            self.profile = _get_default_model_profile(self.model_name)
         return self
 
     @property

--- a/libs/aws/langchain_aws/chat_models/openai.py
+++ b/libs/aws/langchain_aws/chat_models/openai.py
@@ -1,0 +1,135 @@
+"""OpenAI-compatible chat model for the Amazon Bedrock Mantle endpoint.
+
+Amazon Bedrock exposes OpenAI-compatible Chat Completions and Responses APIs on
+the ``bedrock-mantle`` endpoint (``bedrock-mantle.{region}.api.aws``). Because the
+wire format matches OpenAI, this integration is a thin subclass of
+``BaseChatOpenAI`` (mirroring the ``AzureChatOpenAI`` pattern) that only resolves
+the Bedrock Mantle base URL and authentication; all chat behaviour (tool calling,
+structured output, streaming, tracing, multimodal) is inherited unchanged.
+"""
+
+import os
+from typing import Any
+
+from langchain_core.language_models.chat_models import LangSmithParams
+from langchain_core.utils import secret_from_env
+from langchain_openai.chat_models.base import BaseChatOpenAI
+from pydantic import ConfigDict, Field, SecretStr, model_validator
+from typing_extensions import Self
+
+from langchain_aws._version import _add_langchain_aws_version
+
+_MANTLE_BASE_URL_TEMPLATE = "https://bedrock-mantle.{region}.api.aws/v1"
+
+
+class ChatOpenAIMantle(BaseChatOpenAI):
+    """OpenAI-compatible GPT/open-weight models via the Amazon Bedrock Mantle endpoint.
+
+    Talks to the ``bedrock-mantle`` OpenAI-compatible endpoint
+    (``bedrock-mantle.{region}.api.aws``) using the OpenAI Python SDK.
+    Authentication uses an Amazon Bedrock API key (bearer token) rather than
+    AWS SigV4.
+
+    See the [LangChain docs for `ChatOpenAI`](https://docs.langchain.com/oss/python/integrations/chat/openai)
+    for tutorials and feature walkthroughs — the same features apply here.
+
+    Example:
+        ```python
+        # pip install "langchain-aws[openai]"
+        # export AWS_BEARER_TOKEN_BEDROCK="your-bedrock-api-key"
+        # export AWS_REGION="us-east-1"
+
+        from langchain_aws import ChatOpenAIMantle
+
+        model = ChatOpenAIMantle(
+            model="openai.gpt-oss-120b",
+            region_name="us-east-1",
+        )
+        model.invoke("What is 2 + 2?")
+        ```
+
+    Note:
+        This targets the ``bedrock-mantle`` endpoint, which serves only the
+        OpenAI-compatible model catalog (a different, non-superset set of models
+        from ``bedrock-runtime``). For Anthropic Claude on Bedrock, use
+        ``ChatAnthropicBedrock``.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    region_name: str | None = None
+    """AWS region for the Bedrock Mantle endpoint, e.g. ``us-east-1``.
+
+    Falls back to the ``AWS_REGION`` or ``AWS_DEFAULT_REGION`` environment
+    variable when not provided. Used to build the default ``base_url``.
+    """
+
+    bedrock_api_key: SecretStr | None = Field(
+        default_factory=secret_from_env("AWS_BEARER_TOKEN_BEDROCK", default=None)
+    )
+    """Amazon Bedrock API key (bearer token) used to authenticate to Mantle.
+
+    If not provided, read from the ``AWS_BEARER_TOKEN_BEDROCK`` environment
+    variable. Sent as the OpenAI ``api_key``.
+    """
+
+    @model_validator(mode="before")
+    @classmethod
+    def _set_mantle_defaults(cls, values: Any) -> Any:
+        """Resolve the Mantle base URL and bearer key before the client is built.
+
+        Runs before ``BaseChatOpenAI``'s client-construction validator so the
+        OpenAI client is created pointing at the Bedrock Mantle endpoint with the
+        Bedrock API key.
+        """
+        if not isinstance(values, dict):
+            return values
+
+        region = (
+            values.get("region_name")
+            or os.getenv("AWS_REGION")
+            or os.getenv("AWS_DEFAULT_REGION")
+        )
+
+        # Default the base URL to the region's Mantle endpoint unless the caller
+        # supplied one explicitly (either alias form).
+        if not values.get("base_url") and not values.get("openai_api_base") and region:
+            values["base_url"] = _MANTLE_BASE_URL_TEMPLATE.format(region=region)
+
+        # Route the Bedrock API key into the OpenAI ``api_key`` slot unless the
+        # caller already set one explicitly.
+        if not values.get("api_key") and not values.get("openai_api_key"):
+            key = values.get("bedrock_api_key") or os.getenv("AWS_BEARER_TOKEN_BEDROCK")
+            if key:
+                values["api_key"] = key
+
+        return values
+
+    @model_validator(mode="after")
+    def _stamp_version(self) -> Self:
+        """Record the langchain-aws version in tracing metadata."""
+        _add_langchain_aws_version(self)
+        return self
+
+    @property
+    def _llm_type(self) -> str:
+        """Return type of chat model."""
+        return "openai-mantle-chat"
+
+    @property
+    def lc_secrets(self) -> dict[str, str]:
+        """Return a mapping of secret field names to environment variables."""
+        return {"bedrock_api_key": "AWS_BEARER_TOKEN_BEDROCK"}
+
+    @classmethod
+    def get_lc_namespace(cls) -> list[str]:
+        """Get the namespace of the LangChain object."""
+        return ["langchain", "chat_models", "openai_mantle"]
+
+    def _get_ls_params(
+        self, stop: list[str] | None = None, **kwargs: Any
+    ) -> LangSmithParams:
+        """Get standard params for tracing."""
+        params = super()._get_ls_params(stop=stop, **kwargs)
+        params["ls_provider"] = "openai-mantle"
+        return params

--- a/libs/aws/langchain_aws/chat_models/openai.py
+++ b/libs/aws/langchain_aws/chat_models/openai.py
@@ -67,13 +67,6 @@ class ChatOpenAIMantle(BaseChatOpenAI):
 
     model_config = ConfigDict(populate_by_name=True)
 
-    use_responses_api: bool | None = True
-    """Whether to use the Responses API instead of the Chat Completions API.
-
-    Defaults to ``True`` for Bedrock Mantle. Set to ``False`` to use the Chat
-    Completions API, or ``None`` to infer from the invocation params.
-    """
-
     region_name: str | None = None
     """AWS region for the Bedrock Mantle endpoint, e.g. ``us-east-1``.
 

--- a/libs/aws/langchain_aws/chat_models/openai.py
+++ b/libs/aws/langchain_aws/chat_models/openai.py
@@ -67,6 +67,13 @@ class ChatOpenAIMantle(BaseChatOpenAI):
 
     model_config = ConfigDict(populate_by_name=True)
 
+    use_responses_api: bool | None = True
+    """Whether to use the Responses API instead of the Chat Completions API.
+
+    Defaults to ``True`` for Bedrock Mantle. Set to ``False`` to use the Chat
+    Completions API, or ``None`` to infer from the invocation params.
+    """
+
     region_name: str | None = None
     """AWS region for the Bedrock Mantle endpoint, e.g. ``us-east-1``.
 

--- a/libs/aws/langchain_aws/chat_models/openai.py
+++ b/libs/aws/langchain_aws/chat_models/openai.py
@@ -113,8 +113,23 @@ class ChatOpenAIMantle(BaseChatOpenAI):
         )
 
         # Default the base URL to the region's Mantle endpoint unless the caller
-        # supplied one explicitly (either alias form).
-        if not values.get("base_url") and not values.get("openai_api_base") and region:
+        # supplied one explicitly (either alias form). If no base URL is given and
+        # no region can be resolved, fail here rather than let ``BaseChatOpenAI``
+        # fall back to the default OpenAI host — otherwise the Bedrock bearer token
+        # copied into ``api_key`` below would be sent to ``api.openai.com``.
+        has_explicit_base_url = bool(
+            values.get("base_url") or values.get("openai_api_base")
+        )
+        if not has_explicit_base_url:
+            if not region:
+                msg = (
+                    "ChatOpenAIMantle could not resolve an AWS region for the "
+                    "Bedrock Mantle endpoint. Set `region_name`, the `AWS_REGION` "
+                    "or `AWS_DEFAULT_REGION` environment variable, or pass an "
+                    "explicit `base_url`. Refusing to default to the OpenAI host "
+                    "so the Bedrock API key is never sent to api.openai.com."
+                )
+                raise ValueError(msg)
             values["base_url"] = _MANTLE_BASE_URL_TEMPLATE.format(region=region)
 
         # Route the Bedrock API key into the OpenAI ``api_key`` slot unless the

--- a/libs/aws/pyproject.toml
+++ b/libs/aws/pyproject.toml
@@ -25,6 +25,7 @@ Repository = "https://github.com/langchain-ai/langchain-aws"
 [project.optional-dependencies]
 tools = ["bedrock-agentcore>=1.4.0; python_version>='3.10'", "playwright>=1.53.0", "beautifulsoup4>=4.13.4"]
 anthropic = ["langchain-anthropic", "anthropic[bedrock]"]
+openai = ["langchain-openai>=1.0.0", "openai>=1.106.0"]
 valkey = ["valkey-glide-sync>=2.0.0"]
 nova-sonic = ["aws-sdk-bedrock-runtime; python_version>='3.12'"]
 
@@ -38,6 +39,7 @@ test = [
     "pytest-xdist>=3.8.0,<4.0.0",
     "anthropic[bedrock]",
     "langchain-anthropic",
+    "langchain-openai>=1.0.0",
     "langchain-classic>=1.0.0",
     "langchain-tests>=1.1.3",
     "langchain>=1.0.0",
@@ -57,6 +59,7 @@ typing = [
     "types-requests>=2.32.0; platform_python_implementation != 'PyPy'",
     "types-requests>=2.31.0,<2.34.0; platform_python_implementation == 'PyPy'",
     "langchain-anthropic",
+    "langchain-openai>=1.0.0",
 ]
 dev = [
     "boto3-stubs[essential]>=1.42.5",

--- a/libs/aws/tests/integration_tests/chat_models/test_openai.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_openai.py
@@ -1,0 +1,77 @@
+"""Standard LangChain integration tests for ChatOpenAIMantle.
+
+These hit the live Amazon Bedrock Mantle endpoint, so they are skipped unless a
+Bedrock API key is available via ``AWS_BEARER_TOKEN_BEDROCK``. Unskip in CI once
+the test account has ``bedrock-mantle`` API permissions configured.
+
+Run locally with::
+
+    AWS_REGION=us-east-1 AWS_BEARER_TOKEN_BEDROCK=... \\
+        uv run --group test --group test_integration \\
+        pytest tests/integration_tests/chat_models/test_openai.py -v
+"""
+
+import os
+from typing import Type
+
+import pytest
+from langchain_core.language_models import BaseChatModel
+from langchain_tests.integration_tests import ChatModelIntegrationTests
+
+from langchain_aws import ChatOpenAIMantle
+
+# Skip the whole module until a Bedrock Mantle API key (and, in CI, the
+# corresponding account permissions) is available.
+pytestmark = pytest.mark.skipif(
+    not os.getenv("AWS_BEARER_TOKEN_BEDROCK"),
+    reason=(
+        "Requires a Bedrock Mantle API key in AWS_BEARER_TOKEN_BEDROCK. "
+        "Unskip in CI once the test account has bedrock-mantle API permissions."
+    ),
+)
+
+# Open-weight model served on the default Mantle base path (/v1) via the
+# Chat Completions API.
+MODEL_NAME = "openai.gpt-oss-120b"
+
+
+class TestOpenAIMantleIntegration(ChatModelIntegrationTests):
+    @property
+    def chat_model_class(self) -> Type[BaseChatModel]:
+        return ChatOpenAIMantle
+
+    @property
+    def chat_model_params(self) -> dict:
+        return {
+            "model": MODEL_NAME,
+            "region_name": os.getenv("AWS_REGION", "us-east-1"),
+            # Enable usage on streamed responses for this test run. Not set as a
+            # class default: BaseChatOpenAI leaves stream_usage off for custom
+            # base URLs since not every OpenAI-compatible endpoint/model supports
+            # stream_options.include_usage.
+            "stream_usage": True,
+        }
+
+    @property
+    def standard_chat_model_params(self) -> dict:
+        return {"max_tokens": 1000, "temperature": 0}
+
+    # NOTE: capability flags below are conservative defaults for a Mantle
+    # open-weight model. Validate/adjust them against a live run — e.g. gpt-oss
+    # rejects tool_choice="required" and strict structured output on Mantle, so
+    # those may need to be disabled or xfail-marked per model.
+    @property
+    def has_tool_calling(self) -> bool:
+        return True
+
+    @property
+    def has_tool_choice(self) -> bool:
+        # gpt-oss on Mantle does not honor forced tool_choice (returns no
+        # tool_calls / 400 on tool_choice="required"), so the standard
+        # test_tool_choice is skipped. Revisit per-model when adding frontier
+        # models that support forced tool choice.
+        return False
+
+    @property
+    def has_structured_output(self) -> bool:
+        return False

--- a/libs/aws/tests/unit_tests/chat_models/test_openai.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_openai.py
@@ -1,10 +1,13 @@
 """ChatOpenAIMantle unit tests."""
 
 from typing import Tuple, Type, cast
+from unittest.mock import patch
 
 from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import HumanMessage
+from langchain_openai.chat_models.base import BaseChatOpenAI
 from langchain_tests.unit_tests import ChatModelUnitTests
-from pydantic import SecretStr
+from pydantic import BaseModel, SecretStr
 from pytest import MonkeyPatch
 
 from langchain_aws import ChatOpenAIMantle
@@ -146,6 +149,60 @@ def test_profile_empty_for_unknown_model() -> None:
         bedrock_api_key=SecretStr("test-key"),
     )
     assert model.profile == {}
+
+
+def test_stream_routes_to_responses_api() -> None:
+    """_stream delegates to the Responses API path when it is active."""
+    model = ChatOpenAIMantle(
+        model=MODEL_NAME,
+        region_name="us-east-1",
+        bedrock_api_key=SecretStr("test-key"),
+        use_responses_api=True,
+    )
+    with (
+        patch.object(
+            BaseChatOpenAI, "_stream_responses", return_value=iter([])
+        ) as responses,
+        patch.object(BaseChatOpenAI, "_stream", return_value=iter([])) as completions,
+    ):
+        list(model._stream([HumanMessage("hi")]))
+    responses.assert_called_once()
+    completions.assert_not_called()
+
+
+def test_stream_routes_to_chat_completions_when_disabled() -> None:
+    """_stream falls back to Chat Completions when the Responses API is off."""
+    model = ChatOpenAIMantle(
+        model=MODEL_NAME,
+        region_name="us-east-1",
+        bedrock_api_key=SecretStr("test-key"),
+        use_responses_api=False,
+    )
+    with (
+        patch.object(
+            BaseChatOpenAI, "_stream_responses", return_value=iter([])
+        ) as responses,
+        patch.object(BaseChatOpenAI, "_stream", return_value=iter([])) as completions,
+    ):
+        list(model._stream([HumanMessage("hi")]))
+    completions.assert_called_once()
+    responses.assert_not_called()
+
+
+def test_with_structured_output_defaults_to_json_schema() -> None:
+    """with_structured_output defaults method to json_schema."""
+
+    class Schema(BaseModel):
+        answer: str
+
+    model = ChatOpenAIMantle(
+        model=MODEL_NAME,
+        region_name="us-east-1",
+        bedrock_api_key=SecretStr("test-key"),
+    )
+    with patch.object(BaseChatOpenAI, "with_structured_output") as parent:
+        model.with_structured_output(Schema)
+    assert parent.call_args.kwargs["method"] == "json_schema"
 
 
 def test_inherits_openai_features() -> None:

--- a/libs/aws/tests/unit_tests/chat_models/test_openai.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_openai.py
@@ -148,6 +148,24 @@ def test_profile_empty_for_unknown_model() -> None:
     assert model.profile == {}
 
 
+def test_use_responses_api_defaults_true() -> None:
+    """The Responses API is used by default, and remains caller-overridable."""
+    model = ChatOpenAIMantle(
+        model=MODEL_NAME,
+        region_name="us-east-1",
+        bedrock_api_key=SecretStr("test-key"),
+    )
+    assert model.use_responses_api is True
+
+    override = ChatOpenAIMantle(
+        model=MODEL_NAME,
+        region_name="us-east-1",
+        bedrock_api_key=SecretStr("test-key"),
+        use_responses_api=False,
+    )
+    assert override.use_responses_api is False
+
+
 def test_inherits_openai_features() -> None:
     """Key BaseChatOpenAI methods are inherited unchanged."""
     model = ChatOpenAIMantle(

--- a/libs/aws/tests/unit_tests/chat_models/test_openai.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_openai.py
@@ -115,6 +115,39 @@ def test_lc_secrets() -> None:
     assert model.lc_secrets["bedrock_api_key"] == "AWS_BEARER_TOKEN_BEDROCK"
 
 
+def test_profile_resolved_from_model_name() -> None:
+    """The model profile is populated from static profile data by default."""
+    model = ChatOpenAIMantle(
+        model=MODEL_NAME,
+        region_name="us-east-1",
+        bedrock_api_key=SecretStr("test-key"),
+    )
+    assert model.profile is not None
+    assert model.profile.get("tool_calling") is True
+
+
+def test_explicit_profile_is_respected() -> None:
+    """A caller-supplied profile is not overwritten by the default lookup."""
+    custom = {"tool_calling": False}
+    model = ChatOpenAIMantle(
+        model=MODEL_NAME,
+        region_name="us-east-1",
+        bedrock_api_key=SecretStr("test-key"),
+        profile=custom,  # type: ignore[arg-type]
+    )
+    assert model.profile == custom
+
+
+def test_profile_empty_for_unknown_model() -> None:
+    """An unknown model resolves to an empty profile rather than raising."""
+    model = ChatOpenAIMantle(
+        model="openai.does-not-exist",
+        region_name="us-east-1",
+        bedrock_api_key=SecretStr("test-key"),
+    )
+    assert model.profile == {}
+
+
 def test_inherits_openai_features() -> None:
     """Key BaseChatOpenAI methods are inherited unchanged."""
     model = ChatOpenAIMantle(

--- a/libs/aws/tests/unit_tests/chat_models/test_openai.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_openai.py
@@ -3,6 +3,7 @@
 from typing import Tuple, Type, cast
 from unittest.mock import patch
 
+import pytest
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import HumanMessage
 from langchain_openai.chat_models.base import BaseChatOpenAI
@@ -72,6 +73,29 @@ def test_explicit_base_url_is_respected() -> None:
         base_url=custom,
         bedrock_api_key=SecretStr("test-key"),
     )
+    assert model.openai_api_base == custom
+
+
+def test_missing_region_and_base_url_raises() -> None:
+    """Fail locally instead of routing the Bedrock key to the default OpenAI host."""
+    with MonkeyPatch().context() as m:
+        m.delenv("AWS_REGION", raising=False)
+        m.delenv("AWS_DEFAULT_REGION", raising=False)
+        with pytest.raises(ValueError, match="region"):
+            ChatOpenAIMantle(model=MODEL_NAME, bedrock_api_key=SecretStr("test-key"))
+
+
+def test_explicit_base_url_without_region_ok() -> None:
+    """An explicit base_url bypasses the region requirement."""
+    custom = "https://bedrock-mantle.us-east-1.api.aws/v1"
+    with MonkeyPatch().context() as m:
+        m.delenv("AWS_REGION", raising=False)
+        m.delenv("AWS_DEFAULT_REGION", raising=False)
+        model = ChatOpenAIMantle(
+            model=MODEL_NAME,
+            base_url=custom,
+            bedrock_api_key=SecretStr("test-key"),
+        )
     assert model.openai_api_base == custom
 
 

--- a/libs/aws/tests/unit_tests/chat_models/test_openai.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_openai.py
@@ -1,0 +1,133 @@
+"""ChatOpenAIMantle unit tests."""
+
+from typing import Tuple, Type, cast
+
+from langchain_core.language_models import BaseChatModel
+from langchain_tests.unit_tests import ChatModelUnitTests
+from pydantic import SecretStr
+from pytest import MonkeyPatch
+
+from langchain_aws import ChatOpenAIMantle
+
+MODEL_NAME = "openai.gpt-oss-120b"
+
+
+class TestOpenAIMantleStandard(ChatModelUnitTests):
+    @property
+    def chat_model_class(self) -> Type[BaseChatModel]:
+        return ChatOpenAIMantle
+
+    @property
+    def chat_model_params(self) -> dict:
+        return {
+            "model": MODEL_NAME,
+            "region_name": "us-east-1",
+            "bedrock_api_key": "test-bedrock-key",
+        }
+
+    @property
+    def init_from_env_params(self) -> Tuple[dict, dict, dict]:
+        """Env vars, init args, and expected attrs for env-based initialization."""
+        return (
+            {
+                "AWS_BEARER_TOKEN_BEDROCK": "env-bedrock-key",
+                "AWS_REGION": "us-west-2",
+            },
+            {"model": MODEL_NAME},
+            {"bedrock_api_key": "env-bedrock-key"},
+        )
+
+
+def test_initialization() -> None:
+    """Explicit params are stored and the model is an OpenAI-compatible model."""
+    model = ChatOpenAIMantle(
+        model=MODEL_NAME,
+        region_name="us-east-1",
+        bedrock_api_key=SecretStr("test-key"),
+    )
+    assert model.model_name == MODEL_NAME
+    assert model.region_name == "us-east-1"
+    assert cast("SecretStr", model.bedrock_api_key).get_secret_value() == "test-key"
+
+
+def test_default_base_url_from_region() -> None:
+    """base_url defaults to the region's Bedrock Mantle endpoint."""
+    model = ChatOpenAIMantle(
+        model=MODEL_NAME,
+        region_name="us-east-1",
+        bedrock_api_key=SecretStr("test-key"),
+    )
+    assert model.openai_api_base == "https://bedrock-mantle.us-east-1.api.aws/v1"
+
+
+def test_explicit_base_url_is_respected() -> None:
+    """An explicit base_url overrides the region-derived default."""
+    custom = "https://bedrock-mantle.us-east-1.api.aws/openai/v1"
+    model = ChatOpenAIMantle(
+        model=MODEL_NAME,
+        region_name="us-east-1",
+        base_url=custom,
+        bedrock_api_key=SecretStr("test-key"),
+    )
+    assert model.openai_api_base == custom
+
+
+def test_region_and_key_from_env() -> None:
+    """Region and bedrock_api_key are read from the environment."""
+    with MonkeyPatch().context() as m:
+        m.delenv("AWS_DEFAULT_REGION", raising=False)
+        m.setenv("AWS_REGION", "eu-west-1")
+        m.setenv("AWS_BEARER_TOKEN_BEDROCK", "env-key")
+        model = ChatOpenAIMantle(model=MODEL_NAME)
+        assert model.openai_api_base == "https://bedrock-mantle.eu-west-1.api.aws/v1"
+        assert cast("SecretStr", model.bedrock_api_key).get_secret_value() == "env-key"
+
+
+def test_bedrock_api_key_routed_to_openai_key() -> None:
+    """The Bedrock API key is used as the OpenAI client api_key."""
+    model = ChatOpenAIMantle(
+        model=MODEL_NAME,
+        region_name="us-east-1",
+        bedrock_api_key=SecretStr("bearer-abc"),
+    )
+    assert cast("SecretStr", model.openai_api_key).get_secret_value() == "bearer-abc"
+
+
+def test_ls_params_provider() -> None:
+    """Tracing provider is reported as openai-mantle."""
+    model = ChatOpenAIMantle(
+        model=MODEL_NAME,
+        region_name="us-east-1",
+        bedrock_api_key=SecretStr("test-key"),
+    )
+    ls_params = model._get_ls_params()
+    assert ls_params["ls_provider"] == "openai-mantle"
+    assert ls_params["ls_model_name"] == MODEL_NAME
+
+
+def test_lc_secrets() -> None:
+    """The bedrock_api_key maps to its environment variable."""
+    model = ChatOpenAIMantle(
+        model=MODEL_NAME,
+        region_name="us-east-1",
+        bedrock_api_key=SecretStr("test-key"),
+    )
+    assert model.lc_secrets["bedrock_api_key"] == "AWS_BEARER_TOKEN_BEDROCK"
+
+
+def test_inherits_openai_features() -> None:
+    """Key BaseChatOpenAI methods are inherited unchanged."""
+    model = ChatOpenAIMantle(
+        model=MODEL_NAME,
+        region_name="us-east-1",
+        bedrock_api_key=SecretStr("test-key"),
+    )
+    for attr in (
+        "bind_tools",
+        "with_structured_output",
+        "_stream",
+        "_astream",
+        "_generate",
+        "_agenerate",
+    ):
+        assert hasattr(model, attr)

--- a/libs/aws/tests/unit_tests/chat_models/test_openai.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_openai.py
@@ -148,24 +148,6 @@ def test_profile_empty_for_unknown_model() -> None:
     assert model.profile == {}
 
 
-def test_use_responses_api_defaults_true() -> None:
-    """The Responses API is used by default, and remains caller-overridable."""
-    model = ChatOpenAIMantle(
-        model=MODEL_NAME,
-        region_name="us-east-1",
-        bedrock_api_key=SecretStr("test-key"),
-    )
-    assert model.use_responses_api is True
-
-    override = ChatOpenAIMantle(
-        model=MODEL_NAME,
-        region_name="us-east-1",
-        bedrock_api_key=SecretStr("test-key"),
-        use_responses_api=False,
-    )
-    assert override.use_responses_api is False
-
-
 def test_inherits_openai_features() -> None:
     """Key BaseChatOpenAI methods are inherited unchanged."""
     model = ChatOpenAIMantle(

--- a/libs/aws/uv.lock
+++ b/libs/aws/uv.lock
@@ -124,9 +124,9 @@ name = "aws-sdk-bedrock-runtime"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "smithy-aws-core", extra = ["eventstream", "json"], marker = "python_full_version >= '3.12'" },
-    { name = "smithy-core", marker = "python_full_version >= '3.12'" },
-    { name = "smithy-http", extra = ["awscrt"], marker = "python_full_version >= '3.12'" },
+    { name = "smithy-aws-core", extra = ["eventstream", "json"] },
+    { name = "smithy-core" },
+    { name = "smithy-http", extra = ["awscrt"] },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/67/8a/ed3fd98775273b0b7f6006b4970aa876d506668b7fe29145f54fcb941c3b/aws_sdk_bedrock_runtime-0.7.0.tar.gz", hash = "sha256:0cb172cbc03ff060e5c1d6f9cfa9a8ac5e71d9e0d58d3117006ebf614cbb4677", size = 170304, upload-time = "2026-06-23T04:04:52.382Z" }
 wheels = [
@@ -642,7 +642,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1062,6 +1062,10 @@ anthropic = [
 nova-sonic = [
     { name = "aws-sdk-bedrock-runtime", marker = "python_full_version >= '3.12'" },
 ]
+openai = [
+    { name = "langchain-openai" },
+    { name = "openai" },
+]
 tools = [
     { name = "beautifulsoup4" },
     { name = "bedrock-agentcore" },
@@ -1086,6 +1090,7 @@ test = [
     { name = "langchain" },
     { name = "langchain-anthropic" },
     { name = "langchain-classic" },
+    { name = "langchain-openai" },
     { name = "langchain-tests" },
     { name = "langgraph-checkpoint" },
     { name = "playwright" },
@@ -1103,6 +1108,7 @@ test-integration = [
 ]
 typing = [
     { name = "langchain-anthropic" },
+    { name = "langchain-openai" },
     { name = "mypy" },
     { name = "types-requests" },
 ]
@@ -1116,12 +1122,14 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.43.32" },
     { name = "langchain-anthropic", marker = "extra == 'anthropic'" },
     { name = "langchain-core", specifier = ">=1.4.7" },
+    { name = "langchain-openai", marker = "extra == 'openai'", specifier = ">=1.0.0" },
     { name = "numpy", specifier = ">=1.0.0,<3" },
+    { name = "openai", marker = "extra == 'openai'", specifier = ">=1.106.0" },
     { name = "playwright", marker = "extra == 'tools'", specifier = ">=1.53.0" },
     { name = "pydantic", specifier = ">=2.10.6,<3" },
     { name = "valkey-glide-sync", marker = "extra == 'valkey'", specifier = ">=2.0.0" },
 ]
-provides-extras = ["tools", "anthropic", "valkey", "nova-sonic"]
+provides-extras = ["tools", "anthropic", "openai", "valkey", "nova-sonic"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1136,6 +1144,7 @@ test = [
     { name = "langchain", specifier = ">=1.0.0" },
     { name = "langchain-anthropic" },
     { name = "langchain-classic", specifier = ">=1.0.0" },
+    { name = "langchain-openai", specifier = ">=1.0.0" },
     { name = "langchain-tests", specifier = ">=1.1.3" },
     { name = "langgraph-checkpoint", specifier = ">=4.1.0" },
     { name = "playwright", specifier = ">=1.53.0" },
@@ -1153,6 +1162,7 @@ test-integration = [
 ]
 typing = [
     { name = "langchain-anthropic" },
+    { name = "langchain-openai", specifier = ">=1.0.0" },
     { name = "mypy", specifier = ">=1.17.1" },
     { name = "types-requests", marker = "platform_python_implementation != 'PyPy'", specifier = ">=2.32.0" },
     { name = "types-requests", marker = "platform_python_implementation == 'PyPy'", specifier = ">=2.31.0,<2.34.0" },
@@ -1195,6 +1205,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a7/fc/84e23e8adff5adcd7792273ad610c4972ec534658a52698fb8db6defa87a/langchain_core-1.5.1.tar.gz", hash = "sha256:b0df382704c6403c1e0c9603415bce09290455d4aeeb38f350d15f78ca597483", size = 972219, upload-time = "2026-07-23T20:13:22.282Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/55/1e/1eb8833dc59b9c1f49da89a4a1ad7510440c9eb57fb539ea2203294a1acd/langchain_core-1.5.1-py3-none-any.whl", hash = "sha256:c5ec8f51dd05124f950c9afd0fd8bb3f7be4e405eeb868d481b2f8ff652cb9d2", size = 561634, upload-time = "2026-07-23T20:13:20.717Z" },
+]
+
+[[package]]
+name = "langchain-openai"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "openai" },
+    { name = "tiktoken" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bf/1b/a83bf6cae4632363cef0b6f2ee1b4f62c8a5ebcf22cd8ef24430a736c2a8/langchain_openai-1.4.1.tar.gz", hash = "sha256:6d16be615d997db80294731b8e768783f1fb8e0313668e64acd50cd68acbad20", size = 3262416, upload-time = "2026-07-23T20:31:13.053Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/1c/8b604dc8be2735c8ae5c655e520066231057d1301958c20c776e62bd00fb/langchain_openai-1.4.1-py3-none-any.whl", hash = "sha256:8528bb34cc78fdfd2d895573c7917f9441cbb82db5f18ae0e6b3b75d95bdefb3", size = 122067, upload-time = "2026-07-23T20:31:11.809Z" },
 ]
 
 [[package]]
@@ -1688,6 +1712,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/94/a8/f98e50356cf167df656c526c2dfeec2d7dde182f2a3da4b458a5938e2776/numpy-2.5.1-cp314-cp314t-win32.whl", hash = "sha256:6eab239876581b2b3c5a242281b6007bbdbcd1c7085d7709bb57c5929b11e6bf", size = 6263298, upload-time = "2026-07-04T17:07:53.445Z" },
     { url = "https://files.pythonhosted.org/packages/72/ac/96ae880cdecad0b3275d9359fcec72667b49a4863c9f12942e43679dda02/numpy-2.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:83ce9c80d5b521b0d77ddcbe5447c218d247929b6cc056ca5351342accfff0af", size = 12748623, upload-time = "2026-07-04T17:07:55.384Z" },
     { url = "https://files.pythonhosted.org/packages/a1/5a/4d2b1601df3602dba7a14f3348ba9bfe94a18adb428e693df6154c293831/numpy-2.5.1-cp314-cp314t-win_arm64.whl", hash = "sha256:5a6db61f9aaa57e369905c67d852045d3c4f7126405b29d09b19dec118e9c9cb", size = 10697674, upload-time = "2026-07-04T17:07:58.506Z" },
+]
+
+[[package]]
+name = "openai"
+version = "2.50.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/f5/e7735f2af272ee179a287911a698b3cbdb59d7a4ac4874571363adf1e4de/openai-2.50.0.tar.gz", hash = "sha256:5128f7caf4a6b01aefd6e7e93efe170a2c3427b8de286b9af5cdff3aa47e02c8", size = 1081965, upload-time = "2026-07-28T22:16:31.674Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/ca/db315b3bb748c26c644a3f85b7d509e774354d6518d47080b1446005ee41/openai-2.50.0-py3-none-any.whl", hash = "sha256:90bdddcc5a2fa529b350fac9c5780d87e5c361dcc6090ab57b0d470b0d7af7fa", size = 1650721, upload-time = "2026-07-28T22:16:29.48Z" },
 ]
 
 [[package]]
@@ -2283,6 +2326,127 @@ wheels = [
 ]
 
 [[package]]
+name = "regex"
+version = "2026.7.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/98/04b13f1ddfb63158025291c02e03eb42fbb7acb51d091d541050eb4e35e8/regex-2026.7.19.tar.gz", hash = "sha256:7e77b324909c1617cbb4c668677e2c6ae13f44d7c1de0d4f15f2e3c10f3315b5", size = 416440, upload-time = "2026-07-19T00:19:48.923Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/13/bbf7d9d1887fe4a3693527c6caa232c197ea9da91f1212e9672eff60329d/regex-2026.7.19-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:555497390743af1a65045fa4527782d10ff5b88970359412baa4a1e628fe393b", size = 494009, upload-time = "2026-07-19T00:16:13.602Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/19/783688e75a2bec15d50aec0d5e7e317d363808bc82a6eb6750b897bfcd7b/regex-2026.7.19-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:343a4504e3fb688c47cad451221ca5d4814f42b1e16c0065bde9cbf7f473bd52", size = 295287, upload-time = "2026-07-19T00:16:15.702Z" },
+    { url = "https://files.pythonhosted.org/packages/16/01/cefe4f051302ca298d3f3e79ed6dbd933ac84485b9515acdd6a52d70cef7/regex-2026.7.19-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5ebee1ee89c39c953baac6924fcde08c5bb427c4057510862f9d7c7bdb3d8665", size = 290633, upload-time = "2026-07-19T00:16:17.182Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/1e/1045ca2cabb12e8ec41ad0d138e9f3ff1eb079d30a6f51ccf7d709b44aad/regex-2026.7.19-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:062f8cb7a9739c4835d22bd96f370c59aba89f257adcfa53be3cc209e08d3ae0", size = 785300, upload-time = "2026-07-19T00:16:18.505Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/4a/20e5bca184e90bf1bd187efdb53363f4a7b7b34f01d54ced5740caf104bd/regex-2026.7.19-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1123ef4211d763ee771d47916a1596e2f4915794f7aabdc1adcb20e4249a6951", size = 854079, upload-time = "2026-07-19T00:16:19.909Z" },
+    { url = "https://files.pythonhosted.org/packages/09/9b/5a2e59678be3b24aa6a42b2c6d66a48daa212593e9f4096fe7ba577fa9b1/regex-2026.7.19-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6e44c0e7c5664be20aee92085153150c0a7967310a73a43c0f832b7cd35d0dd3", size = 899496, upload-time = "2026-07-19T00:16:21.453Z" },
+    { url = "https://files.pythonhosted.org/packages/48/9a/7317f14ed8ed9fd998d1978b4802b07bc4d79216353c435dbcc1ddd1301f/regex-2026.7.19-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:98c6ac18480fcdb33f35439183f1d2e79760ab41930309c6d951cb1f8e46694c", size = 793541, upload-time = "2026-07-19T00:16:22.991Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/53/833c2db3e274d3c191f4c42fe5bfa358e4c8b617d5d7312d31334965fc46/regex-2026.7.19-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4458124d71339f505bf1fb94f69fd1bb8fa9d2481eebfef27c10ef4f2b9e12f6", size = 785515, upload-time = "2026-07-19T00:16:24.654Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b9/efb2f9fa151d71db09d4015e1fb92fee47416f01c12164836bbd23e2f3c2/regex-2026.7.19-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fbf300e2070bb35038660b3be1be4b91b0024edb41517e6996320b49b92b4175", size = 769556, upload-time = "2026-07-19T00:16:26.207Z" },
+    { url = "https://files.pythonhosted.org/packages/81/4d/45610c263f8eadb84e4a1fabd904d81d5176226faa9104ef498bf8a8b285/regex-2026.7.19-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b2b506b1788df5fecd270a10d5e70a95fe77b87ea2b370a318043f6f5f817ee6", size = 774130, upload-time = "2026-07-19T00:16:27.786Z" },
+    { url = "https://files.pythonhosted.org/packages/40/95/1b40d87c7a9e5480bec7a87bce9fd67fc3f14b5f106c8ee66d660249072f/regex-2026.7.19-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:52579c60a6078be70a0e49c81d6e56d677f34cd439af281a0083b8c7bc75c095", size = 848694, upload-time = "2026-07-19T00:16:29.412Z" },
+    { url = "https://files.pythonhosted.org/packages/17/8b/bb45968addd5b394ef9cd9184bd9c65ade1a819dbb2b92b71ad52a0c7907/regex-2026.7.19-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:2955907b7157a6660f27079edf7e0229e9c9c5325c77a2ef6a890cba91efa6f0", size = 758505, upload-time = "2026-07-19T00:16:31.006Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/6f/33386c672fbf43e21602135a0f29a97ee251a483f007fe51d10e9b2dbc93/regex-2026.7.19-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:89dfee3319f5ae3f75ebd5c2445a809bb320252ba5529ffdafea4ef25d79cf1a", size = 836985, upload-time = "2026-07-19T00:16:32.459Z" },
+    { url = "https://files.pythonhosted.org/packages/22/f1/9112b86e9bb075619862e8e42b604794389f1958faa68fb69bde505dd90e/regex-2026.7.19-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:3d3143f159261b1ce5b24c261c590e5913370c3200c5e9ebbb92b5aa5e111902", size = 782610, upload-time = "2026-07-19T00:16:33.857Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/f9/13d460d8a385ca0b0be9e6be80a90968b9293b3e30895543ad2d1d1653e4/regex-2026.7.19-cp310-cp310-win32.whl", hash = "sha256:64729333167c2dcaaa56a331d40ee097bd9c5617ffd51dabb09eaddafb1b532e", size = 266772, upload-time = "2026-07-19T00:16:35.194Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/90/29addd7a03e1aea402c1f31467e25c80caabc8c3735b88a23cf73b0aa9c2/regex-2026.7.19-cp310-cp310-win_amd64.whl", hash = "sha256:1c398716054621aa300b3d411f467dda903806c5da0df6945ab73982b8d115db", size = 277967, upload-time = "2026-07-19T00:16:36.847Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/ba/ecfce06fe66c122bc6f77ae284887a9282e4411fe1e6268c5266611ca054/regex-2026.7.19-cp310-cp310-win_arm64.whl", hash = "sha256:064f1760a5a4ade65c5419be23e782f29147528e8a66e0c42dd4cedb8d4e9fc6", size = 276963, upload-time = "2026-07-19T00:16:38.315Z" },
+    { url = "https://files.pythonhosted.org/packages/05/e5/cef4de2bac939280b68d32adc659478845238a8274f2f79c465063f590ad/regex-2026.7.19-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ac777001cdfc28b72477d93c8564bb7583081ea8fb45cdca3d568e0a4f87183c", size = 494012, upload-time = "2026-07-19T00:16:39.927Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/87/e86f51eb117457bb7803132ffe5cb6e2841e2b5bea4cc85d397f3c6e257d/regex-2026.7.19-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:59787bd5f8c70aa339084e961d2996b53fbdeab4d5393bba5c1fe1fc32e02bae", size = 295281, upload-time = "2026-07-19T00:16:41.433Z" },
+    { url = "https://files.pythonhosted.org/packages/41/2e/2360c41d8080a3d9ec7e5c90fad6eab3b50192869d10e9a5609e48c8177b/regex-2026.7.19-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:90c633e7e8d6bf4e992b8b36ce69e018f834b641dd6de8cea6d78c06ffa119c5", size = 290615, upload-time = "2026-07-19T00:16:43.058Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/69/b65ba4344efbc771b28fe5dde84cbbb6c8f9551165952fe78def5b9dde6a/regex-2026.7.19-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:87ccab0db8d5f4fbb0272642113c1adb2ffc698c16d3a0944580222331fa7a20", size = 791804, upload-time = "2026-07-19T00:16:44.662Z" },
+    { url = "https://files.pythonhosted.org/packages/81/b6/a40dfa0dc6224b36f620c00296eacc830489cbf8c2837b6750dfe6170375/regex-2026.7.19-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9e50d748a32da622f256e8d505867f5d3c43a837c6a9f0efb149655fadd1042a", size = 861723, upload-time = "2026-07-19T00:16:46.412Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/02/735991dee71abd83196a7962f7ed8bf5aa05720ff06e2d3ff896a85e2bbb/regex-2026.7.19-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bf1516fe58fc104f39b2d1dbe2d5e27d0cd45c4be2e42ba6ee0cc763701ec3c7", size = 905932, upload-time = "2026-07-19T00:16:47.956Z" },
+    { url = "https://files.pythonhosted.org/packages/45/6c/e7098d8b846ccdbf431d8c081b61e496526a27a28094ed09e0dce21b3f54/regex-2026.7.19-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:09f3e5287f94f17b709dc9a9e70865855feee835c861613be144218ce4ca82cc", size = 801407, upload-time = "2026-07-19T00:16:49.43Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/18/34b69274e2649bcc7d9b089c2b2983fb2632d8ecf667e359593be9072e79/regex-2026.7.19-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6383cd2ed53a646c659ba1fe65727db76437fdaa069e697a0b44a51d5843d864", size = 774448, upload-time = "2026-07-19T00:16:51.352Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/e6/0a72247d025585fd3800b98e040b84d562a88af6303347100484849f4f01/regex-2026.7.19-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:09d3007fc76249a83cdd33de160d50e6cb77f54e09d8fa9e7148e10607ce24af", size = 783297, upload-time = "2026-07-19T00:16:53.071Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/aa/c4f65ae7dd02a36b323a70c4cff326e1f3442361aaebc9311100a130d54f/regex-2026.7.19-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:6f8c6e7a1cfa3dc9d0ee2de0e65e834537fa29992cc3976ffec914afc35c5dd5", size = 854736, upload-time = "2026-07-19T00:16:54.607Z" },
+    { url = "https://files.pythonhosted.org/packages/62/c3/668082bcc817b9e694189b84997aeba7385b7779faa6711788679c482e35/regex-2026.7.19-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:b2ea4a3e8357be8849e833beeae757ac3c7a6b3fc055c03c808a53c91ad30d82", size = 763298, upload-time = "2026-07-19T00:16:56.289Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/fb/2d07ad555e7af88aa5f867fdafa47a8d945ee237c20af3ebceb46a820835/regex-2026.7.19-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:80115dd39481fd3a4b4080220799dbcacb921a844de4b827264ececacbe17c78", size = 844430, upload-time = "2026-07-19T00:16:57.933Z" },
+    { url = "https://files.pythonhosted.org/packages/51/15/c82a471fe3dce56f03745635b43aa456c40dc0db089e07ef148b331507d1/regex-2026.7.19-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d6ce43a0269d68cee79a7d1ade7def53c20f8f2a047b92d7b5d5bcc73ae88327", size = 789683, upload-time = "2026-07-19T00:16:59.583Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/f4/7532a2c59d56f5398902c20de60f0c9a5d1cd364e42a051b48e1b210be7b/regex-2026.7.19-cp311-cp311-win32.whl", hash = "sha256:9be2a6647740dd3cca6acb24e87f03d7632cd280dbce9bbe40c26353a215a45d", size = 266778, upload-time = "2026-07-19T00:17:01.032Z" },
+    { url = "https://files.pythonhosted.org/packages/83/2b/cf1bc631db154eb95520d9d5dbc2371ff77a0f014bbf7d748fed8496aa63/regex-2026.7.19-cp311-cp311-win_amd64.whl", hash = "sha256:8d3469c91dd92ee41b7c95280edbd975ef1ba9195086686623a1c6e8935ce965", size = 277983, upload-time = "2026-07-19T00:17:02.571Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/bd/56ceaf170e875d5a6761bf2bfd0d040f1cacc896850d5e40cb29b11bbd06/regex-2026.7.19-cp311-cp311-win_arm64.whl", hash = "sha256:36aacfb15faaff3ced55afbf35ec72f50d4aee22082c4f7fe0573a33e2fca92e", size = 276961, upload-time = "2026-07-19T00:17:04.135Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/b9/d11d7e501ac8fd7d617684423ebb9561e0b998481c1e4cbc0cb212c5d74a/regex-2026.7.19-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2cc3460cedf7579948486eab03bc9ad7089df4d7281c0f47f4afe03e8d13f02d", size = 496778, upload-time = "2026-07-19T00:17:05.677Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/a9/a5ab6f312f24318019170dc485d5421fe4f89e43a98640da50d95a8a7041/regex-2026.7.19-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0e9554c8785eac5cffe6300f69a91f58ba72bc88a5f8d661235ad7c6aa5b8ccd", size = 297122, upload-time = "2026-07-19T00:17:07.59Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/63/4cab4d7f2d384a144d420b763d97674cb70619c878ea6fcd7640d0e62143/regex-2026.7.19-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d7da47a0f248977f08e2cb659ff3c17ddc13a4d39b3a7baa0a81bf5b415430f6", size = 292009, upload-time = "2026-07-19T00:17:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/22/85/102a81b218298957d4ea7d2f084fae537a71add9d6ff93c8e67284c5f45e/regex-2026.7.19-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:93db40c8de0815baab96a06e08a984bac71f989d13bab789e382158c5d426797", size = 796708, upload-time = "2026-07-19T00:17:11.542Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b5/dc136af5629938a037cd2b304c12240e132ec92f38be8ff9cc89af2a1f2d/regex-2026.7.19-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:66bd62c59a5427746e8c44becae1d9b99d22fb13f30f492083dfb9ad7c45cc18", size = 865651, upload-time = "2026-07-19T00:17:13.312Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/75/67402ae3cd9c8c988a4c805d15ee3eef015e7ca4cb112cf3e640fc1f4153/regex-2026.7.19-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1649eb39fcc9ea80c4d2f110fde2b8ab2aef3877b98f02ab9b14e961f418c511", size = 911756, upload-time = "2026-07-19T00:17:15.015Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/8e/096d00c7c480ef2ff4265349b14e2261d4ab787ba1f74e2e80d1c58079c3/regex-2026.7.19-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9dce8ec9695f531a1b8a6f314fd4b393adcccf2ea861db480cdf97a301d01a68", size = 801798, upload-time = "2026-07-19T00:17:17.208Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/41/e7ecac6edb5722417f85cc67eaf386322fbe8acf6918ec2fdc37c20dd9d0/regex-2026.7.19-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3080a7fd38ef049bd489e01c970c97dd84ff446a885b0f1f6b26d9b1ad13ce11", size = 776933, upload-time = "2026-07-19T00:17:19.347Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/69/03c9b3f058d66403e0ca2c938696e81d51cd4c6d47ec5265f02f96948d9a/regex-2026.7.19-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1d793a7988e04fcb1e2e135567443d82173225d657419ec09414a9b5a145b986", size = 784338, upload-time = "2026-07-19T00:17:21.057Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/f7/b38ab3d43f284afbb618fcd15d0e77eb786ae461ce1f6bc7494619ddc0f2/regex-2026.7.19-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:e8b0abe7d870f53ca5143895fef7d1041a0c831a140d3dc2c760dd7ba25d4a8b", size = 860452, upload-time = "2026-07-19T00:17:23.119Z" },
+    { url = "https://files.pythonhosted.org/packages/15/5c/ff60ef0571121714f3cf9920bc183071e384a10b556d042e0fdb06cc07a5/regex-2026.7.19-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:4e5413bd5f13d3a4e3539ca98f70f75e7fca92518dd7f117f030ebedd10b60cb", size = 765958, upload-time = "2026-07-19T00:17:24.81Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/0f/bd34021162c0ab47f9a315bd56cd5642e920c8e5668a75ef6c6a6fca590d/regex-2026.7.19-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:73b133a9e6fb512858e7f065e96f1180aa46646bc74a83aea62f1d314f3dd035", size = 851765, upload-time = "2026-07-19T00:17:26.993Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/20/a2ca43edade0595cccfdc98636739f536d9e26898e7dbddc2b9e98898953/regex-2026.7.19-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:dbe6493fbd27321b1d1f2dd4f5c7e5bd4d8b1d7cab7f32fd67db3d0b2ed8248a", size = 789714, upload-time = "2026-07-19T00:17:28.699Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/47/e02db4015d424fc83c00ea0ac8c5e5ec14397943de9abf909d5ce3a25931/regex-2026.7.19-cp312-cp312-win32.whl", hash = "sha256:ddd67571c10869f65a5d7dde536d1e066e306cc90de57d7de4d5f34802428bb5", size = 267157, upload-time = "2026-07-19T00:17:31.051Z" },
+    { url = "https://files.pythonhosted.org/packages/08/8e/c780c131f79b42ed22d1bd7da4096c2c35f813e835acd02ef0f018bd892c/regex-2026.7.19-cp312-cp312-win_amd64.whl", hash = "sha256:e30d40268a28d54ce0437031750497004c22602b8e3ab891f759b795a003b312", size = 277777, upload-time = "2026-07-19T00:17:32.848Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/4c/e4d7e086449bdf379d89774bf1f89dc4a41943f3c5a6125a03905b34b5fb/regex-2026.7.19-cp312-cp312-win_arm64.whl", hash = "sha256:de9208bb427130c82a5dbfd104f92c8876fc9559278c880b3002755bbbe9c83d", size = 277136, upload-time = "2026-07-19T00:17:34.803Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/3d/84165e4299ff76f3a40fe1f2abf939e976f693383a08d2beea6af62bd2c1/regex-2026.7.19-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f035d9dc1d25eff9d361456572231c7d27b5ccd473ca7dc0adfce732bd006d40", size = 496552, upload-time = "2026-07-19T00:17:36.808Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a2/a65293e6e4cf28eb7ee1be5335a5386c40d6742e9f47fafc8fec785e16c7/regex-2026.7.19-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c42572142ed0b9d5d261ba727157c426510da78e20828b66bbb855098b8a4e38", size = 296983, upload-time = "2026-07-19T00:17:38.816Z" },
+    { url = "https://files.pythonhosted.org/packages/95/47/2d0564e93d87bc48618360ddca232a2ca612bbdf53ce8465d45ca5ce14ee/regex-2026.7.19-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:40b34dd88658e4fedd2fddbf0275ac970d00614b731357f425722a3ed1983d11", size = 291832, upload-time = "2026-07-19T00:17:40.726Z" },
+    { url = "https://files.pythonhosted.org/packages/07/cd/42dfbabff3dfc9603c501c0e2e2c5adbb09d127b267bf5348de0af338c15/regex-2026.7.19-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c41c63992bf1874cebb6e7f56fd7d3c007924659a604ae3d90e427d40d4fd13", size = 796775, upload-time = "2026-07-19T00:17:42.382Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5d/f6a4839f2b934e3eed5973fd07f5929ee97d4c98939fb275ea23c274ee16/regex-2026.7.19-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1d3372064506b94dd2c67c845f2db8062e9e9ba84d04e33cb96d7d33c11fe1ae", size = 865687, upload-time = "2026-07-19T00:17:44.185Z" },
+    { url = "https://files.pythonhosted.org/packages/14/b0/b47d6c36049bc59806a50bd4c86ced70bbe058d787f80281b1d7a9b0e024/regex-2026.7.19-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fce7760bf283405b2c7999cab3da4e72f7deca6396013115e3f7a955db9760da", size = 911962, upload-time = "2026-07-19T00:17:46.442Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/be/ff61f28f9273658cfe23acbbac5217221f6519960ed401e61dfdab12bc35/regex-2026.7.19-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c0d702548d89d572b2929879bc883bb7a4c4709efafe4512cadee56c55c9bd15", size = 801817, upload-time = "2026-07-19T00:17:48.25Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/bb/8b4f7f26b333f9f79e1b453613c39bb4776f51d38ae66dd0ba31d6b354ca/regex-2026.7.19-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d446c6ac40bb6e05025ccee55b84d80fe9bf8e93010ffc4bb9484f13d498835f", size = 776908, upload-time = "2026-07-19T00:17:50.183Z" },
+    { url = "https://files.pythonhosted.org/packages/09/13/610110fc5921d380516d03c26b652555f08aa0d23ea78a771231873c3638/regex-2026.7.19-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4c3501bfa814ab07b5580741f9bf78dfdfe146a04057f82df9e2402d2a975939", size = 784426, upload-time = "2026-07-19T00:17:52.454Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/f5/1ef9e2a83a5947c57ebff0b377cb5727c3d5ec1992317a320d035cd0dbb6/regex-2026.7.19-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:c4585c3e64b4f9e583b4d2683f18f5d5d872b3d71dcf24594b74ecc23602fa96", size = 860600, upload-time = "2026-07-19T00:17:54.229Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/02/073af33a3ec149241d11c80acea91e722aa0adbf05addd50f251c4fe89c3/regex-2026.7.19-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:571fde9741eb0ccde23dd4e0c1d50fbae910e901fa7e629faf39b2dda740d220", size = 765950, upload-time = "2026-07-19T00:17:56.041Z" },
+    { url = "https://files.pythonhosted.org/packages/81/a9/d1e9f819dc394a568ef370cd56cf25394e957a2235f8370f23b576e5a475/regex-2026.7.19-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:15b364b9b98d6d2fe1a85034c23a3180ff913f46caddc3895f6fd65186255ccc", size = 851794, upload-time = "2026-07-19T00:17:57.897Z" },
+    { url = "https://files.pythonhosted.org/packages/03/3a/8ae83eda7579feacdf984e71fb9e70635fb6f832eeddca58427ec4fca926/regex-2026.7.19-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ffd8893ccc1c2fce6e0d6ca402d716fe1b29db70c7132609a05955e31b2aa8f2", size = 789845, upload-time = "2026-07-19T00:17:59.97Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/23/c195cbfe5a75fdec64d8f6554fd15237b837919d2c61bdc141d7c807b08b/regex-2026.7.19-cp313-cp313-win32.whl", hash = "sha256:f0fa4fa9c3632d708742baf2282f2055c11d888a790362670a403cbf48a2c404", size = 267135, upload-time = "2026-07-19T00:18:01.958Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/80/a11de8404b7272b70acb45c1c05987cce60b45d5693da2e176f0e390d564/regex-2026.7.19-cp313-cp313-win_amd64.whl", hash = "sha256:d51ffd3427640fa2da6ade574ceba932f210ad095f65fcc450a2b0a0d454868e", size = 277747, upload-time = "2026-07-19T00:18:04.121Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/29/0f5c8eff1b4f1f3d83276d365fccecf666afcc7d947420943bf394d07adb/regex-2026.7.19-cp313-cp313-win_arm64.whl", hash = "sha256:c670fe7be5b6020b76bc6e8d2196074657e1327595bca93a389e1a76ab130ad8", size = 277129, upload-time = "2026-07-19T00:18:05.821Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/4c/44b74742052cedda40f9ae469532a037112f7311a36669a891fba8984bb0/regex-2026.7.19-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:db47b561c9afd884baa1f96f797c9ca369872c4b65912bc691cfa99e68340af2", size = 501134, upload-time = "2026-07-19T00:18:07.567Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/45/bbd038b5e39ee5613a5a689290145b40058cc152c41de9cc23639d2b9734/regex-2026.7.19-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:65dcd28d3eba2ab7c2fd906485cc301392b47cc2234790d27d4e4814e02cdfda", size = 299418, upload-time = "2026-07-19T00:18:09.38Z" },
+    { url = "https://files.pythonhosted.org/packages/65/38/c5bde94b4cedfd5850d64c3f08222d8e1600e84f6ee71d9b44b4b8163f74/regex-2026.7.19-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:f2e7f8e2ab6c2922be02c7ec45185aa5bd771e2e57b95455ee343a44d8130dff", size = 294486, upload-time = "2026-07-19T00:18:11.188Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/6a/2f5e107cb26c960b781967178899daf2787a7ab151844ed3c01d6fc95474/regex-2026.7.19-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fe31f28c94402043161876a258a9c6f757cb485905c7614ce8d6cd40e6b7bdc1", size = 811643, upload-time = "2026-07-19T00:18:12.975Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d4/a2f963406d7d73a62eed84ba05a258afb6cad1b21aa4517443ce40506b78/regex-2026.7.19-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f8f6fa298bb4f7f58a33334406218ba74716e68feddf5e4e54cd5d8082705abf", size = 871081, upload-time = "2026-07-19T00:18:14.733Z" },
+    { url = "https://files.pythonhosted.org/packages/45/a3/44be546340bedb15f13063f5e7fe16793ea4d9ea2e805d09bd174ac27724/regex-2026.7.19-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:cc1b2440423a851fad781309dd87843868f4f66a6bcd1ddb9225cf4ec2c84732", size = 917372, upload-time = "2026-07-19T00:18:16.724Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/f6/e0870b0fd2a40dba0074e4b76e514b21313d37946c9248453e34ec43923e/regex-2026.7.19-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ac59a0900474a52b7c04af8196affc22bd9842acb0950df12f7b813e983609a", size = 816089, upload-time = "2026-07-19T00:18:18.617Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/27/957e8e22690ad6634572b39b71f130a6105f4d0718bb16849eac00fff147/regex-2026.7.19-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4896db1f4ce0576765b8272aa922df324e0f5b9bb2c3d03044ff32a7234a9aba", size = 785206, upload-time = "2026-07-19T00:18:20.464Z" },
+    { url = "https://files.pythonhosted.org/packages/76/a4/186e410941e731037c01166069ab86da9f65e8f8110c18009ccf4bd623ee/regex-2026.7.19-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:4e6883a021db30511d9fb8cfb0f222ce1f2c369f7d4d8b0448f449a93ba0bdfc", size = 800431, upload-time = "2026-07-19T00:18:22.716Z" },
+    { url = "https://files.pythonhosted.org/packages/73/9f/e4e10e023d291d64a33e246610b724493bf1ce98e0e59c9b7c837e5acfb7/regex-2026.7.19-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:09523a592938aa9f587fb74467c63ff0cf88fc3df14c82ab0f0517dcf76aaa62", size = 864906, upload-time = "2026-07-19T00:18:24.772Z" },
+    { url = "https://files.pythonhosted.org/packages/24/57/ccb20b6be5f1f52a053d1ba2a8f7a077edb9d918248b8490d7506c6832b3/regex-2026.7.19-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:1ebac3474b8589fce2f9b225b650afd61448f7c73a5d0255a10cc6366471aed1", size = 773559, upload-time = "2026-07-19T00:18:27.008Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/82/f3b263cf8fad927dc102891da8502e718b7ff9d19af7a2a07c03865d7188/regex-2026.7.19-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:4a0530bb1b8c1c985e7e2122e2b4d3aedd8a3c21c6bfddae6767c4405668b56e", size = 857739, upload-time = "2026-07-19T00:18:29.107Z" },
+    { url = "https://files.pythonhosted.org/packages/47/2e/1687bd1b6c2aed5e672ccf845fc11557821fe7366d921b50889ea5ce57bf/regex-2026.7.19-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2ef7eeb108c47ce7bcc9513e51bcb1bf57e8f483d52fce68a8642e3527141ae0", size = 804522, upload-time = "2026-07-19T00:18:31.362Z" },
+    { url = "https://files.pythonhosted.org/packages/76/7c/cc4e7655181b2d9235b704f2c5e19d8eff002bbc437bae59baee0e381aca/regex-2026.7.19-cp313-cp313t-win32.whl", hash = "sha256:64b6ca7391a1395c2638dd5c7456d67bea44fc6c5e8e92c5dc8aa6a8f23292b4", size = 269141, upload-time = "2026-07-19T00:18:33.479Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/14/961b4c7b05a2391c32dbc85e27773076671ef8f97f36cec70fe414734c02/regex-2026.7.19-cp313-cp313t-win_amd64.whl", hash = "sha256:f04b9f56b0e0614c0126be12c2c2d9f8850c1e57af302bd0a63bed379d4af974", size = 280036, upload-time = "2026-07-19T00:18:35.419Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/67/795644550d788ddbb6dc458c95895f8009978ea6d6ea76b005eb3f45e8c9/regex-2026.7.19-cp313-cp313t-win_arm64.whl", hash = "sha256:fcee38cd8e5089d6d4f048ba1233b3ad76e5954f545382180889112ff5cb712d", size = 279394, upload-time = "2026-07-19T00:18:37.454Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/25/0c4c452f8ef3efe456745b2f33195f5904b573fb4c2ff3f0cb9ec188461e/regex-2026.7.19-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:a81758ed242b861b72e778ba34d41366441a2e10b16b472784c88da2dea7e2dd", size = 496750, upload-time = "2026-07-19T00:18:39.633Z" },
+    { url = "https://files.pythonhosted.org/packages/24/9e/b70ca6c1704f6c7cd32a9e143c86cc5968d10981eca284bad670c245ea7d/regex-2026.7.19-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4aa5435cdb3eb6f55fe98a171b05e3fbcd95fadaa4aa32acf62afd9b0cfdbcac", size = 297093, upload-time = "2026-07-19T00:18:41.583Z" },
+    { url = "https://files.pythonhosted.org/packages/87/74/0b692da2520d51fbff19c88b83d97e4c702909dd02386c585998b7e2dbed/regex-2026.7.19-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:60be8693a1dadc210bbcbc0db3e26da5f7d01d1d5a3da594e99b4fa42df404f5", size = 292043, upload-time = "2026-07-19T00:18:43.347Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/a7/1d478e614016045a33feae57446215f9fd65b665a5ceb2f891fb3183bc52/regex-2026.7.19-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d19662dbedbe783d323196312d38f5ba53cf56296378252171985da6899887d3", size = 797214, upload-time = "2026-07-19T00:18:45.362Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ae/11b9c9411d92c30e3d2db32df5a31133e4a99a8fc397a604fd08f6c4bffb/regex-2026.7.19-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d15df07081d91b76ff20d43f94592ee110330152d617b730fdbe5ef9fb680053", size = 866433, upload-time = "2026-07-19T00:18:47.315Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/62/2b2efc4992f91d6d204b24c647c9f9412e85379d92b7c0ab9fdae622327e/regex-2026.7.19-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:56ad4d9f77df871a99e25c37091052a02528ec0eb059de928ee33956b854b45b", size = 911360, upload-time = "2026-07-19T00:18:49.588Z" },
+    { url = "https://files.pythonhosted.org/packages/14/71/986ceea9aa3da548bf1357cad89b63915ec6d21ec957c8113b29ece567df/regex-2026.7.19-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7322ec6cc9fba9d49ab888bb82d67ac5625627aa168f0165139b17018df3fb8a", size = 801275, upload-time = "2026-07-19T00:18:51.767Z" },
+    { url = "https://files.pythonhosted.org/packages/15/be/ce9d9534b2cda96eab32c548261224b9b4e220a4126f098f60f42ae7b4cd/regex-2026.7.19-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9c7472192ebfad53a6be7c4a8bfb2d64b81c0e93a1fc8c57e1dd0b638297b5d1", size = 777131, upload-time = "2026-07-19T00:18:54.053Z" },
+    { url = "https://files.pythonhosted.org/packages/61/2b/58b5c710f2c3929515a25f3a1ca0dad0dcd4518d4fff3cf23bc7adb8dcd2/regex-2026.7.19-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c10b82c2634df08dfb13b1f04e38fe310d086ee092f4f69c0c8da234251e556e", size = 785020, upload-time = "2026-07-19T00:18:56.579Z" },
+    { url = "https://files.pythonhosted.org/packages/84/03/5fe091935b74f15fe0f97998c215cae418d1c0413f6258c7d4d2e83aa37f/regex-2026.7.19-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:17ed5692f6acc4183e98331101a5f9e4f64d72fe58b753da4d444a2c77d05b12", size = 861263, upload-time = "2026-07-19T00:18:58.64Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/fa/d60bf82e10841eef62a9e32aac401468f05fddfbcb2942e342b1ba3d2433/regex-2026.7.19-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:22a992de9a0d91bda927bf02b94351d737a0302905432c88a53de7c4b9ce62e2", size = 766199, upload-time = "2026-07-19T00:19:00.705Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/5d/11e64d151b0662b81d6bf644c74dc118d461df85bdf2577fadbbf751788a/regex-2026.7.19-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:618a0aed532be87294c4477b0481f3aa0f1520f4014a4374dd4cf789b4cd2c97", size = 851317, upload-time = "2026-07-19T00:19:03.015Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/34/532efb87488d90807bae6a443d357ee5e2728a478c597619c8aaa17cc0bd/regex-2026.7.19-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2ce9e679f776649746729b6c86382da519ef649c8e34cc41df0d2e5e0f6c36d4", size = 789557, upload-time = "2026-07-19T00:19:05.338Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/90/3a8d5ca977171ec3ae21a71207d2228b2663bde14d7f7ef0e6363ecf9290/regex-2026.7.19-cp314-cp314-win32.whl", hash = "sha256:73f272fba87b8ccfe70a137d02a54af386f6d27aa509fbffdd978f5947aae1aa", size = 272531, upload-time = "2026-07-19T00:19:07.487Z" },
+    { url = "https://files.pythonhosted.org/packages/96/e1/8862885e70409de70e8c005f57fb2e7be8d9ef0317250d60f4c9660a300d/regex-2026.7.19-cp314-cp314-win_amd64.whl", hash = "sha256:d721e53758b2cca74990185eb0671dd466d7a388a1a45d0c6f4c13cef41a68ac", size = 280831, upload-time = "2026-07-19T00:19:09.46Z" },
+    { url = "https://files.pythonhosted.org/packages/08/82/2693e53e29f9104d9de95d37ce4dd826bd32d5f9c0085d3aa6ac042675c4/regex-2026.7.19-cp314-cp314-win_arm64.whl", hash = "sha256:65fa6cb38ed5e9c3637e68e544f598b39c3b86b808ed0627a67b68320384b459", size = 281099, upload-time = "2026-07-19T00:19:11.398Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b7/9a01aa16461a18cde9d7b9c3ab21e501db2ce33725f53014342b91df2b0a/regex-2026.7.19-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:5a2721c8720e2cb3c209925dfb9200199b4b07361c9e01d321719404b21458b3", size = 501121, upload-time = "2026-07-19T00:19:13.425Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/5e/bbaeca815dc9191c424c94a4fdc5c87c75748a64a6271821212ebdd4e1a3/regex-2026.7.19-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:199535629f25caf89698039af3d1ad5fcae7f933e2112c73f1cdf49165c99518", size = 299415, upload-time = "2026-07-19T00:19:15.43Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/d6/0dd1a321afaab95eb7ff44aa0f637301786f1dc71c6b797b9ed236ed8890/regex-2026.7.19-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9b60d7814174f059e5de4ab98271cc5ba9259cfea55273a81544dceea32dc8d9", size = 294483, upload-time = "2026-07-19T00:19:17.879Z" },
+    { url = "https://files.pythonhosted.org/packages/92/5f/40bacf91d0904f812e13bbbab3864604c463eced8afdc54aeaa50492ea95/regex-2026.7.19-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dbece16025afda5e3031af0c4059207e61dcf73ef13af844964f57f387d1c435", size = 811833, upload-time = "2026-07-19T00:19:20.102Z" },
+    { url = "https://files.pythonhosted.org/packages/94/7c/4902744261f775aeede8b5627314b38482da29cf49a57b66a6fb753246c5/regex-2026.7.19-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d24ecb4f5e009ea0bd275ee37ad9953b32005e2e5e60f8bbae16da0dbbf0d3a0", size = 871270, upload-time = "2026-07-19T00:19:22.365Z" },
+    { url = "https://files.pythonhosted.org/packages/16/70/6980c9be6bf21c0a60ed3e0aea39cf419ecf3b08d1d9947bc56e196ef186/regex-2026.7.19-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8cae6fd77a5b72dae505084b1a2ee0360139faf72fedbab667cd7cc65aae7a6a", size = 917534, upload-time = "2026-07-19T00:19:24.529Z" },
+    { url = "https://files.pythonhosted.org/packages/52/92/8b2bd872782ce8c42691e39acb38eb8efe014e5ddb78ad7d943d6f197ce9/regex-2026.7.19-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9724e6cb5e478cd7d8cabf027826178739cb18cf0e117d0e32814d479fa02276", size = 816135, upload-time = "2026-07-19T00:19:26.919Z" },
+    { url = "https://files.pythonhosted.org/packages/de/2d/33a602f657bdc4041f17d79f92ab18261d255d91a06117a6e29df023e5e2/regex-2026.7.19-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:572fc57b0009c735ee56c175ea021b637a15551a312f56734277f923d6fd0f6c", size = 785492, upload-time = "2026-07-19T00:19:29.192Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/36/0987cf4cb271680064a70d24a475873775a151d0b7058698a006cb0cae4a/regex-2026.7.19-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:20568e182eb82d39a6bf7cff3fd58566f14c75c6f74b2c8c96537eecf9010e3a", size = 800658, upload-time = "2026-07-19T00:19:31.392Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/24/c14f31c135e1ba55fa4f9a58ca98d0842512bf6188230763c31c8f449e3b/regex-2026.7.19-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:1d58561843f0ff7dc78b4c28b5e2dc388f3eff94ebc8a232a3adba961fc00009", size = 865073, upload-time = "2026-07-19T00:19:33.485Z" },
+    { url = "https://files.pythonhosted.org/packages/14/85/181a12211f22469f24d2de1ebddfe397d2396e2c29013b9a58134a91069a/regex-2026.7.19-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:61bb1bd45520aacd56dd80943bd34991fb5350afdd1f36f2282230fd5154a218", size = 773684, upload-time = "2026-07-19T00:19:35.599Z" },
+    { url = "https://files.pythonhosted.org/packages/23/58/bd1a0c1a62251366f8d21f41b1ea3c76994962071b8b6ea42f72d505c0f0/regex-2026.7.19-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:cd3584591ea4429026cdb931b054342c2bcf189b44ff367f8d5c15bc092a2966", size = 857769, upload-time = "2026-07-19T00:19:37.738Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/4f/f7e2dad6756b2fe1fe75dd90a628c3b45f249d39f948dd90cd2476325417/regex-2026.7.19-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5cc26a66e212fa5d6c6170c3a40d99d888db3020c6fdab1523250d4341382e44", size = 804546, upload-time = "2026-07-19T00:19:40.229Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/d7/01d31d5bdb09bc026fab77f59a371fdf8f9b292e4810546c56182ca70498/regex-2026.7.19-cp314-cp314t-win32.whl", hash = "sha256:2c4e61e2e1be56f63ec3cc618aa9e0de81ef6f43d177205451840022e24f5b78", size = 274526, upload-time = "2026-07-19T00:19:42.398Z" },
+    { url = "https://files.pythonhosted.org/packages/52/0e/cea4ce73bc0a8247a0748228ae6669984c7e1f8134b6fa66e59c0572e0ea/regex-2026.7.19-cp314-cp314t-win_amd64.whl", hash = "sha256:c639ea314df70a7b2811e8020448c75af8c9445f5a60f8a4ced81c306a9380c2", size = 283763, upload-time = "2026-07-19T00:19:44.644Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/b6/26e41975febae63b7a6e3e02f32cff6cff2e4f10d19c929082f56aebf7c6/regex-2026.7.19-cp314-cp314t-win_arm64.whl", hash = "sha256:9a15e785f244f3e07847b984ce8773fc3da10a9f3c131cc49a4c5b4d672b4547", size = 283451, upload-time = "2026-07-19T00:19:46.639Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2373,9 +2537,9 @@ name = "smithy-aws-core"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aws-sdk-signers", marker = "python_full_version >= '3.12'" },
-    { name = "smithy-core", marker = "python_full_version >= '3.12'" },
-    { name = "smithy-http", marker = "python_full_version >= '3.12'" },
+    { name = "aws-sdk-signers" },
+    { name = "smithy-core" },
+    { name = "smithy-http" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fc/a8/37bfde59519f45d2047d0033b791aca6574d867aaf57bb56a6de42ab5c26/smithy_aws_core-0.7.0.tar.gz", hash = "sha256:34e82d09fc808acd5ffc80f03828d0609c6a211f49f0884dc6ee7ca095a1b6af", size = 15670, upload-time = "2026-06-23T04:04:50.365Z" }
 wheels = [
@@ -2384,10 +2548,10 @@ wheels = [
 
 [package.optional-dependencies]
 eventstream = [
-    { name = "smithy-aws-event-stream", marker = "python_full_version >= '3.12'" },
+    { name = "smithy-aws-event-stream" },
 ]
 json = [
-    { name = "smithy-json", marker = "python_full_version >= '3.12'" },
+    { name = "smithy-json" },
 ]
 
 [[package]]
@@ -2395,7 +2559,7 @@ name = "smithy-aws-event-stream"
 version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "smithy-core", marker = "python_full_version >= '3.12'" },
+    { name = "smithy-core" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/0e/6efb3a4ed92c0f1ada6de060ac92e7115a1e34d0ab1fb99a6056734a88ea/smithy_aws_event_stream-0.3.0.tar.gz", hash = "sha256:a0e227367a973144e205a075d0a424f95c92f26656a1018d08900da2ae547c49", size = 12818, upload-time = "2026-05-05T18:04:14.317Z" }
 wheels = [
@@ -2416,7 +2580,7 @@ name = "smithy-http"
 version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "smithy-core", marker = "python_full_version >= '3.12'" },
+    { name = "smithy-core" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/58/5a772d212e066d6fc1398946c4aae19bcdaa75209879d776f641b6a06b5b/smithy_http-0.4.2.tar.gz", hash = "sha256:50d11b6a55e42448450a01e3d0f605ccee65a72abf52d02eed82862a15be5937", size = 29616, upload-time = "2026-06-23T04:04:45.687Z" }
 wheels = [
@@ -2425,7 +2589,7 @@ wheels = [
 
 [package.optional-dependencies]
 awscrt = [
-    { name = "awscrt", marker = "python_full_version >= '3.12'" },
+    { name = "awscrt" },
 ]
 
 [[package]]
@@ -2433,8 +2597,8 @@ name = "smithy-json"
 version = "0.2.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ijson", marker = "python_full_version >= '3.12'" },
-    { name = "smithy-core", marker = "python_full_version >= '3.12'" },
+    { name = "ijson" },
+    { name = "smithy-core" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/6c/418b5687d8933b7a135d5e1a98c61fe814b98f72517dbae0e666860cb876/smithy_json-0.2.3.tar.gz", hash = "sha256:686e9b55a36dacb08e472732b358573ef78009055e05e9fce2e806d61490b2b3", size = 7805, upload-time = "2026-06-23T04:04:47.71Z" }
 wheels = [
@@ -2566,6 +2730,67 @@ wheels = [
 ]
 
 [[package]]
+name = "tiktoken"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "regex" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/e5/5f3cb2159769d0f4324c0e9e87f9de3c4b1cd45848a96b2eb3566ad5ca77/tiktoken-0.13.0.tar.gz", hash = "sha256:c9435714c3a84c2319499de9a300c0e604449dd0799ff246458b3bb6a7f433c1", size = 38986, upload-time = "2026-05-15T04:51:27.153Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/e3/03c90dadcf5b3f82b83cee9adee60ef666b329c654f58c066af44eae0287/tiktoken-0.13.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:47b1df8d73390a24f94980c75158cdd5c56d256f16d55f30cb49c230caba9ba4", size = 1036627, upload-time = "2026-05-15T04:50:11.229Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/30/760463e5b2e8ad2bc229ae0a17ecb06727b6cbc094f08d8f65844315632e/tiktoken-0.13.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7d40c6c5aab171dcd6eb8455bc567bde404bb9def60cdb8c1299cc782b242bb9", size = 984699, upload-time = "2026-05-15T04:50:12.874Z" },
+    { url = "https://files.pythonhosted.org/packages/de/8a/8895f342a6b6aabd1a358e672f6f077b3ae51d0c63ca605d142db3bcd8ab/tiktoken-0.13.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:9b842981fa91accdffd48ff6408a977b7a91c3fbda55d353c3c68114d5c9d69e", size = 1118690, upload-time = "2026-05-15T04:50:14.234Z" },
+    { url = "https://files.pythonhosted.org/packages/51/e0/92557768fb0801f0d9dd9243cb9b6d342900b05e4b1006d4771f49ce233e/tiktoken-0.13.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:ed5a30027cb4d8c7ca8b273d4766f3db3cf58fad9e9f3b1a68a351ffb54873d5", size = 1138423, upload-time = "2026-05-15T04:50:15.668Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b9/a3d99feeedb032ffd09cd6652077f86bdee9a70dd0b990b2b272b445d4c3/tiktoken-0.13.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:7ab10f4a21c2999846940113f6dbd72e0fa06a24119feddd74cc47e85818e06d", size = 1185077, upload-time = "2026-05-15T04:50:17.19Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/93/bab868277d475dc6d2aaacd34cdd239c282f4908dcc8702e0a3311a8e032/tiktoken-0.13.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:a2937ad042d49d50eac6e1ba07c5661d4bd3942a5b1e0c0d08475c4df83676e1", size = 1241702, upload-time = "2026-05-15T04:50:18.772Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/16/27e9f7e0ed76e501cfefc9fb2112df4c7bf70ca96945b15ecb7615aac860/tiktoken-0.13.0-cp310-cp310-win_amd64.whl", hash = "sha256:44733b99bfd72b590cd0936b1c01b3b4dd73122db2d544bc1ceeb18a7678c910", size = 876565, upload-time = "2026-05-15T04:50:20.268Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/4c/1bc81f4cd53e827c4ee67ca951b5935724716049452d8dfa09b8b82372bb/tiktoken-0.13.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:7bfe1849caa65d1e1d9871817170ec497bbb7984e182012e1bdce72f66608cdb", size = 1036353, upload-time = "2026-05-15T04:50:21.757Z" },
+    { url = "https://files.pythonhosted.org/packages/75/91/10b9c7076bc02c246c853201fdbbe300a4b8c5ed7b84c25f7403f4e32655/tiktoken-0.13.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:91c180fe255bd5a86d8316210d2833a1d4d33d026cd86a67812f4773743c8d26", size = 984644, upload-time = "2026-05-15T04:50:23.256Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/e4/fceae98015fab47fcd49b8bd7f46145bcd187a47e0add1e5378ed67ef980/tiktoken-0.13.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:059c8ecf554eb5b41e6e054ba467b871b03277d267dee7244380aca4359747d4", size = 1119261, upload-time = "2026-05-15T04:50:24.348Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/39/fe42ad00de01a8c4a49ad8649a2c8a316835a9cad5961b11d21eac0020a5/tiktoken-0.13.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:36217497eaffc158607a3b26f065300db2aefd43b115263f3b9688ce38146173", size = 1138253, upload-time = "2026-05-15T04:50:25.505Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c4/ccee1ecccca107e9a16efcecdeeb964c325305038554d466ece65b42338f/tiktoken-0.13.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:303f7d91b4fce3baddbcde05c139091d4caa5026ac7214c1dc7ff7a71ee429ff", size = 1185747, upload-time = "2026-05-15T04:50:27.02Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/03/cd0cba295522b91eb55c6b2704f1df895f8226cfe60ab10d4d51d0cc9e69/tiktoken-0.13.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5d48843bee149630eb735a99e1f4a85b47308d21868ea63163f6e87768d3cfed", size = 1241265, upload-time = "2026-05-15T04:50:28.815Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/25/a10efd564402d82c2ff50d12057353ace447aa8007deceaa48641f63d35c/tiktoken-0.13.0-cp311-cp311-win_amd64.whl", hash = "sha256:fc1c44cd37b43fc46bae593129164f4f281e82ea116b57a85aa81bda57eafc94", size = 876509, upload-time = "2026-05-15T04:50:30.026Z" },
+    { url = "https://files.pythonhosted.org/packages/85/8e/144bde4e01df66b34bb865557c7cd754ed08b036217ebd79c9db5e9048a9/tiktoken-0.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:32ac870a806cfb260a02d0cb70426aef02e038297f8ad50df5040bb5af360791", size = 1034888, upload-time = "2026-05-15T04:50:31.579Z" },
+    { url = "https://files.pythonhosted.org/packages/36/18/d4ac9d20956cdebca04841316660ed584c2fecdc2b81722a28bc7ad3b1e4/tiktoken-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4d9980f11429ed2d737c463bb1fb78cf330caa026adf002f714aced7849a687b", size = 982970, upload-time = "2026-05-15T04:50:32.961Z" },
+    { url = "https://files.pythonhosted.org/packages/74/ed/6bb8d05b9f731f749fee5c6f5ca63e981143c826a5985877330507bd13b7/tiktoken-0.13.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:3f277ebea5edd7b8bf03c6f9431e1d67d517530115572b2dc1d465326e8f88c7", size = 1115741, upload-time = "2026-05-15T04:50:34.475Z" },
+    { url = "https://files.pythonhosted.org/packages/34/de/2ca96b07a82d972b74fe4b46de055b79c904e45c7eab699354a0bfa697dc/tiktoken-0.13.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:a116178fa7e1b4065bff05214360373a65cac22f965be7b3f73d00a0dbfe7649", size = 1136523, upload-time = "2026-05-15T04:50:35.782Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/dc/9dafec002c2d4424378563cf4cf5c7fb93631d2a55013c8b87554ee4012c/tiktoken-0.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2c397ddda233208345b01bd30f2fca79ff730e55731d0108a603f9bc57f6af3b", size = 1181954, upload-time = "2026-05-15T04:50:36.99Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/d0/1f8578c45b2f24759b46f0b50d31878c63c73e6bf0f2227e10ec5c5408dc/tiktoken-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:95097e4f89b06403976e498abf61a0ee73a7497e73fb599cb211d8197a054d91", size = 1240069, upload-time = "2026-05-15T04:50:38.221Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/90/28d7f154888610aa9237e541986beb62b479df29d193a5a0617dbb1514d0/tiktoken-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:8f2d16e7a7c783ad81f36e457d046d1f1c8af70b22aec8a13238efe531977c41", size = 874748, upload-time = "2026-05-15T04:50:39.587Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/83/b096c859c2a47c11731bf2f5885f4028b809dfe2396582883eed9cae372f/tiktoken-0.13.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5df5d1507bd245f1ccad4a074698240021239e455eb0bb4ced4e3d7181872154", size = 1034228, upload-time = "2026-05-15T04:50:40.988Z" },
+    { url = "https://files.pythonhosted.org/packages/53/61/c68e123b6d753e3fc2751e9b18e732c9d8bf1e1926762e736eee935d931c/tiktoken-0.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8fe806a50664e83a6ffd56cbd1e4f5dcc6cd32a3e7538f70dc38b1a271384545", size = 982978, upload-time = "2026-05-15T04:50:42.195Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/8b/96cc178cc584e65d363134500f297790b06cd48cdeb1e8fcf7bbe60f4715/tiktoken-0.13.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:125bc05005e747f993a83dc67934249932d6e4209854452cd4c0b1d53fba3ba2", size = 1116355, upload-time = "2026-05-15T04:50:43.564Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f5/bab735d2c72ea55404b295d02d092644eb5f7cc6205e34d35eb9abfb9ab2/tiktoken-0.13.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5e6358911cab4adee6712da27d65573496a4f68cf8a2b5fca6a4ad10fc5748cf", size = 1135772, upload-time = "2026-05-15T04:50:44.782Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b9/6de04ebdf904edfaad87788011b3735087a0c9ea671b9027e1e4e965e8c8/tiktoken-0.13.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:975cbd78d085d75d26b59660e262736dcaed1e35f8f142cd6291025c01d25486", size = 1182415, upload-time = "2026-05-15T04:50:46.422Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/9c/470a05f3b1caf038f44880e334d47ab674e0c80d514c66b375d14d5afa10/tiktoken-0.13.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:75ab9bc99fa020a4c283424590ecd7f3afd70c1c281cb3fa3192a6c3af9f9615", size = 1239879, upload-time = "2026-05-15T04:50:48.052Z" },
+    { url = "https://files.pythonhosted.org/packages/42/a6/c1936d16055436cb32e6c6128d68629622e00f4768562f55653752d34768/tiktoken-0.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:6b1615f0ff71953d19729ceb18865429c185b0a23c5353f1bbca34a394bf60f7", size = 874829, upload-time = "2026-05-15T04:50:49.202Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/07/acb5992c3772b5a36284f742cfb7a5895aa4471d1848ac31464ad50d7fdf/tiktoken-0.13.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:6eb4a5bfbc6426938026b1a334e898ac53541360d62d8c689870160cc80abd67", size = 1033600, upload-time = "2026-05-15T04:50:50.4Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e9/742e9aec30f59b9f161f7ff7cd072e02ea836c9e1c0854a8076dfcd40d5c/tiktoken-0.13.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:43cee3e5400573b2046fbf092cc7a5bc30164f9e4c95ce20714da929df48737a", size = 982516, upload-time = "2026-05-15T04:50:52.03Z" },
+    { url = "https://files.pythonhosted.org/packages/72/74/ca1541b053e7648254d2e4b42a253e1bb4359f2c91a0a8d49228c794e1a0/tiktoken-0.13.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:7de52e3f566d19b3b11bd37eea552c6c305ad74081f736882bd44d148ed4c48d", size = 1115518, upload-time = "2026-05-15T04:50:53.543Z" },
+    { url = "https://files.pythonhosted.org/packages/46/e3/93825eaf5a4a504795b787e5d5dea07fbeb3dabf97aa7b450be8bde59c89/tiktoken-0.13.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:51384448aa508e4df84c0f7c1dc3211c7f7b8096325660ee5fc82f3e11b381ce", size = 1136867, upload-time = "2026-05-15T04:50:55.191Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/46/002b68de6827091d5ae90b048f326e8aad8d953520950e5ce1508879414f/tiktoken-0.13.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:e28157350f7ebf35008dd8e9e0fdb621f976e4230c881099c85e8cf07eaa50e2", size = 1181826, upload-time = "2026-05-15T04:50:56.296Z" },
+    { url = "https://files.pythonhosted.org/packages/db/c6/d393e3185a276505182f7abd93fe714f3c444a2be9180798fa052347504e/tiktoken-0.13.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:165cf1820ea4a354985c2490a5205d4cc74661c934aca79dd0368232fff94e0f", size = 1239489, upload-time = "2026-05-15T04:50:57.918Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/4d/bc07d1f1635d4897a202acc0ae11c2886eaa7325c359ba4741b47bf8e225/tiktoken-0.13.0-cp313-cp313t-win_amd64.whl", hash = "sha256:6c43a675ca14f6f2749ba7f12075d37456015a24b859f2517b9beb4ef30807ec", size = 873820, upload-time = "2026-05-15T04:50:59.528Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/93/0dd6adca026a616c3a92974566b43381eea4b475ce1f36c062b8271a9ac5/tiktoken-0.13.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaaaef47c2406277181d2086484c317bf7fc433e2d5d03ff94f56b0dcec87471", size = 1034977, upload-time = "2026-05-15T04:51:00.957Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/77/5ec6e6bc5b30bed6d93f7f2162d8f6b32437b3ba27cb527cfe004f6109c9/tiktoken-0.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ca8b310bd93b3772cb1b7922d915446864860f562bdfe4825c63a0aed3fb28cd", size = 983635, upload-time = "2026-05-15T04:51:02.629Z" },
+    { url = "https://files.pythonhosted.org/packages/94/b0/c8ae9aff00d625c50659b4513e707a0462c4bf5d4d6cc1b802103225c02e/tiktoken-0.13.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:32e0c12305105002c047b3bb1070b0dd9a73b0cb3b2856a8972b810e7a4f5881", size = 1116036, upload-time = "2026-05-15T04:51:04.082Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/ac/6a5dddd1d0a6018ecb389bd0353e6b4a515eb4d2286611bd0ace1937b9e1/tiktoken-0.13.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:5ba5fd62507a932d1241346179e3b39bc7bf7408f03c272652d93b3bedf5db24", size = 1135544, upload-time = "2026-05-15T04:51:05.229Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/b8/585032b4384b2f7dcdaddcb52865c83a701a420d09e3c2b4a2be1c450c57/tiktoken-0.13.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d108bc2d470fc53c8ecd24f2c0fd2b5f98c33e87cdb6aa2e9b8c5dced703d273", size = 1182217, upload-time = "2026-05-15T04:51:06.517Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/b6/993ff1ded3958215fd341a847b8e5ffeb5de473f435296870d314fc91ac4/tiktoken-0.13.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cb99cb5127449f58d0a2d5f5ccfb390d8dbdfd919c221246caaee29d8725ed51", size = 1239404, upload-time = "2026-05-15T04:51:07.843Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3d/fef7e06e3b33e7538db0ced734cf9fe23b6832d2ac4990c119c377aec55e/tiktoken-0.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:115c4f26ffa11caac8b54eea35c2ad38c612c20a48d35dd15d70a02ac6f51f58", size = 918686, upload-time = "2026-05-15T04:51:08.925Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/82/a7fc44582bc32ab00de988a2299bf77c077f59068b233109e34b7d6ca7e6/tiktoken-0.13.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:472527e9132952f2fbf77cd290658bacf003d4d5a3fabc18e5fbd407cbae4d9b", size = 1034454, upload-time = "2026-05-15T04:51:10.035Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d0/24d8a890c14f432a05cea669c17bebeaa99f96a7c79523b590f564246411/tiktoken-0.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:4e2f67d27c9626cdd25fe33d9313c5cdb3d8d82da646b68d6eb8e7e9c20e6448", size = 982976, upload-time = "2026-05-15T04:51:11.23Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b7/2ab43f62788a9266187a9bfc1d3af99ad83e5eaa25fbef168a69cd5ad14f/tiktoken-0.13.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:2b920b35805cd64585a37c3dc7ce65fba4d2d36016be01e1d7942482ca29093a", size = 1115526, upload-time = "2026-05-15T04:51:12.608Z" },
+    { url = "https://files.pythonhosted.org/packages/64/39/1494321ed323ce7a14d88e3cd6cb9058625977df1c6961ddc492bd10a9f3/tiktoken-0.13.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:493af3aa28a4aaf2e3d2600a2ee717252c9bf5ab38fff94eb5a02db5ab77e5ad", size = 1136466, upload-time = "2026-05-15T04:51:13.926Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d9/dfd086aa2d918c563a140720e0ce296cada1634efd2783d5cf51e05f984e/tiktoken-0.13.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6644c9c2b5cf3916f5a3641d7d12fdb3f006a7b3d9ff6acdaec44e29ab1ff91e", size = 1181863, upload-time = "2026-05-15T04:51:15.025Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/68/a18b4f307086954fdae32714cb4f85562e34f9d34ab206e61f1816aa6018/tiktoken-0.13.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5cb65b60b9408563676d874a3a4ee573370066f0dc4e29d84e82e989c6517424", size = 1239218, upload-time = "2026-05-15T04:51:16.103Z" },
+    { url = "https://files.pythonhosted.org/packages/16/5b/f2aa703a4fc5d2dff73460a7d46cc2f3f44aa0f3dd8eeb20d2a0ecf68862/tiktoken-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:85b78cc3a2c3d48723ca751fa981f1fedccd54194ca0471b957364353a898b07", size = 918110, upload-time = "2026-05-15T04:51:17.237Z" },
+]
+
+[[package]]
 name = "tomli"
 version = "2.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2617,6 +2842,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.70.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/3b/6c24bec5be5e743ffd99576daa5cc077722fc7d5bbc00bd133fa0c698dc6/tqdm-4.70.0.tar.gz", hash = "sha256:55b0b0dbd97462d06ebee91e4dac24ed4d4702be82b24f07e6c1d27e08cea220", size = 795438, upload-time = "2026-07-27T11:33:15.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/1c/01bfd571a64e7f270e6bab5e33777debe0edc56759233ce84f27dec92d14/tqdm-4.70.0-py3-none-any.whl", hash = "sha256:7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953", size = 80184, upload-time = "2026-07-27T11:33:13.167Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds `ChatOpenAIMantle`, a thin `BaseChatOpenAI` subclass targeting the Amazon Bedrock **Mantle** OpenAI-compatible endpoint (`bedrock-mantle.{region}.api.aws`). Mirrors the `AzureChatOpenAI` pattern: only endpoint + auth are overridden, so tool calling, structured output, streaming, tracing, and multimodal are inherited from `BaseChatOpenAI` and stay in sync with `langchain-openai`.

This reframes the approach explored in #1018 (a ~1000-line from-scratch `BaseChatModel`) into a small subclass, addressing the recurring review feedback there ("why reimplement what `ChatOpenAI` already does").

## What's included

- `ChatOpenAIMantle(BaseChatOpenAI)` — region → `base_url` resolution (`/v1`) and a Bedrock API key (`bedrock_api_key` / `AWS_BEARER_TOKEN_BEDROCK`) routed into the OpenAI `api_key`.
- New `langchain-aws[openai]` optional extra.
- Exports wired into `langchain_aws` and `langchain_aws.chat_models` (lazy-imported).
- Standard `ChatModelUnitTests` suite + focused unit tests.
- Skip-gated standard `ChatModelIntegrationTests` (skips unless `AWS_BEARER_TOKEN_BEDROCK` is set; unskip in CI once the account has `bedrock-mantle` permissions).

## Naming

`ChatOpenAIMantle` — provider-SDK-first (like `ChatAnthropicBedrock`), with `Mantle` making the endpoint explicit.

## Testing

- Unit: standard suite + focused tests pass (17 passed, 1 skipped).
- Integration (live, gpt-oss-120b, us-east-1): **29 passed, 21 skipped**. Skips are standard capability-gated cases; `has_structured_output`/`has_tool_choice` are `False` and `stream_usage=True` is set in the test to reflect gpt-oss's Mantle behavior.
- ruff + mypy clean.

<details>
  <summary>Integration test results:</summary>

```
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_no_overrides_DO_NOT_OVERRIDE PASSED                                                                                                   [  2%] 
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_invoke PASSED                                                                                                                         [  4%] 
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_ainvoke PASSED                                                                                                                        [  6%] 
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_stream[model0] PASSED                                                                                                                 [  8%] 
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_stream[model1] PASSED                                                                                                                 [ 10%] 
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_astream[model0] PASSED                                                                                                                [ 12%] 
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_astream[model1] PASSED                                                                                                                [ 14%] 
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_stream_events_v3 PASSED                                                                                                               [ 16%] 
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_astream_events_v3 PASSED                                                                                                              [ 18%]
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_invoke_with_model_override SKIPPED (model_override_value not specified.)                                                              [ 20%]
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_ainvoke_with_model_override SKIPPED (model_override_value not specified.)                                                             [ 22%]
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_stream_with_model_override SKIPPED (model_override_value not specified.)                                                              [ 24%]
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_astream_with_model_override SKIPPED (model_override_value not specified.)                                                             [ 26%]
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_batch PASSED                                                                                                                          [ 28%]
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_abatch PASSED                                                                                                                         [ 30%]
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_conversation PASSED                                                                                                                   [ 32%]
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_double_messages_conversation PASSED                                                                                                   [ 34%]
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_usage_metadata PASSED                                                                                                                 [ 36%]
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_usage_metadata_streaming PASSED                                                                                                       [ 38%]
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_stop_sequence PASSED                                                                                                                  [ 40%]
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_tool_calling[model0] PASSED                                                                                                           [ 42%]
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_tool_calling[model1] PASSED                                                                                                           [ 44%]
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_tool_calling_async PASSED                                                                                                             [ 46%]
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_bind_runnables_as_tools PASSED                                                                                                        [ 48%]
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_tool_message_histories_string_content PASSED                                                                                          [ 50%]
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_tool_message_histories_list_content PASSED                                                                                            [ 52%]
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_tool_choice SKIPPED (Test requires tool choice.)                                                                                      [ 54%]
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_tool_calling_with_no_arguments PASSED                                                                                                 [ 56%]
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_tool_message_error_status PASSED                                                                                                      [ 58%]
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_structured_few_shot_examples PASSED                                                                                                   [ 60%]
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_structured_output[pydantic] SKIPPED (Test requires structured output.)                                                                [ 62%]
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_structured_output[typeddict] SKIPPED (Test requires structured output.)                                                               [ 64%]
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_structured_output[json_schema] SKIPPED (Test requires structured output.)                                                             [ 66%]
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_structured_output_async[pydantic] SKIPPED (Test requires structured output.)                                                          [ 68%]
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_structured_output_async[typeddict] SKIPPED (Test requires structured output.)                                                         [ 70%]
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_structured_output_async[json_schema] SKIPPED (Test requires structured output.)                                                       [ 72%]
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_structured_output_pydantic_2_v1 SKIPPED (Test requires structured output.)                                                            [ 74%]
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_structured_output_optional_param SKIPPED (Test requires structured output.)                                                           [ 76%]
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_json_mode SKIPPED (Test requires json mode support.)                                                                                  [ 78%]
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_pdf_inputs SKIPPED (Model does not support PDF inputs.)                                                                               [ 80%]
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_audio_inputs SKIPPED (Model does not support audio inputs.)                                                                           [ 82%]
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_image_inputs SKIPPED (Model does not support image message.)                                                                          [ 84%]
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_image_tool_message SKIPPED (Model does not support image tool message.)                                                               [ 86%]
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_pdf_tool_message SKIPPED (Model does not support PDF tool message.)                                                                   [ 88%]
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_anthropic_inputs SKIPPED (Model does not explicitly support Anthropic inputs.)                                                        [ 90%]
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_message_with_name PASSED                                                                                                              [ 92%]
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_agent_loop[model0] PASSED                                                                                                             [ 94%]
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_agent_loop[model1] PASSED                                                                                                             [ 96%]
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_stream_time SKIPPED (VCR not set up.)                                                                                                 [ 98%]
tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_unicode_tool_call_integration PASSED                                                                                                  [100%]

======================================================================================================= slowest 5 durations =======================================================================================================
2.52s call     tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_tool_calling_with_no_arguments
2.26s call     tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_agent_loop[model0]
2.25s call     tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_tool_calling[model1]
2.13s call     tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_agent_loop[model1]
2.05s call     tests/integration_tests/chat_models/test_openai.py::TestOpenAIMantleIntegration::test_tool_calling[model0]
================================================================================================= 29 passed, 21 skipped in 32.24s =================================================================================================

```

</details>



## Scope / follow-ups

This is intentionally the **basic** class (static bearer key only). Planned follow-ups:

1. **Credential helper from #1018** — port `_BedrockApiKeyProvider`, the auto-refreshing short-term bearer-token provider (botocore `RefreshableCredentials`-style advisory/mandatory refresh windows, `bedrock_api_key_ttl_seconds`, AWS credential kwargs), and inject it as a callable `api_key` into `BaseChatOpenAI`'s client construction (requires `openai>=1.106.0`). Not implemented here — the current class only accepts a pre-minted static key and does not refresh.
2. Base-path routing by model family (`/v1` vs `/openai/v1` for frontier models) and per-model `use_responses_api` defaults.
3. Per-model capability flags / structured-output support as more Mantle models are validated.

> Note: AI agent assistance was used in drafting this change.
