### PR TITLE
feat(aws): use Anthropic simplified prompt cache management in ChatBedrockConverse

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -88,7 +88,7 @@ from langchain_aws.utils import (
 
 logger = logging.getLogger(__name__)
 
-
+_MAX_CACHE_POINTS = 4
 _MODEL_PROFILES = cast("ModelProfileRegistry", _PROFILES)
 
 
@@ -717,7 +717,7 @@ class ChatBedrockConverse(BaseChatModel):
         bedrock_messages: List[Dict[str, Any]],
         params: Optional[Dict[str, Any]] = None,
     ) -> None:
-        """Apply cachePoint to system, messages, and tools in Converse API format.
+        """Apply cachePoints to system, messages, and tools in Converse API format.
 
         Args:
             cache_control: Cache control settings dict. Expected keys:
@@ -735,7 +735,9 @@ class ChatBedrockConverse(BaseChatModel):
         if not cache_control:
             return
 
-        is_nova = "amazon.nova" in self._get_base_model().lower()
+        base_model = self._get_base_model().lower()
+        is_nova = "amazon.nova" in base_model
+        is_anthropic = self.provider == "anthropic" or "anthropic" in base_model
 
         cache_point: Dict[str, Any] = {"type": "default"}
         ttl = cache_control.get("ttl")
@@ -743,10 +745,27 @@ class ChatBedrockConverse(BaseChatModel):
             cache_point["ttl"] = ttl
         cache_block = {"cachePoint": cache_point}
 
-        if system and not any(_is_cache_point(b) for b in system):
-            system.append(cache_block)
+        tools = (
+            params.get("toolConfig", {}).get("tools") if params is not None else None
+        )
 
-        if bedrock_messages:
+        manual_count = _count_cache_points(system, bedrock_messages, tools)
+        budget = _MAX_CACHE_POINTS - manual_count
+        if budget <= 0:
+            logger.debug(
+                "Request already contains %d cachePoint blocks (Bedrock maximum "
+                "is %d); skipping automatic cachePoint insertion for cache_control.",
+                manual_count,
+                _MAX_CACHE_POINTS,
+            )
+            return
+
+        # Highest-value points first; the rest take any remaining budget.
+        if budget and system and not any(_is_cache_point(b) for b in system):
+            system.append(cache_block)
+            budget -= 1
+
+        if budget and bedrock_messages:
             last_content = bedrock_messages[-1].get("content")
             if isinstance(last_content, list):
                 has_tool_block = is_nova and any(
@@ -757,11 +776,31 @@ class ChatBedrockConverse(BaseChatModel):
                     _is_cache_point(b) for b in last_content
                 ):
                     last_content.append(cache_block)
+                    budget -= 1
 
-        if params and not is_nova:
-            tools = params.get("toolConfig", {}).get("tools")
-            if tools and not any(_is_cache_point(t) for t in tools):
-                tools.append(cache_block)
+        if (
+            budget
+            and tools
+            and not is_nova
+            and not any(_is_cache_point(t) for t in tools)
+        ):
+            tools.append(cache_block)
+            budget -= 1
+
+        # End-of-history checkpoint for Claude's simplified cache management:
+        # https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html#prompt-caching-simplified
+        if (
+            budget
+            and is_anthropic
+            and not is_nova
+            and manual_count == 0
+            and len(bedrock_messages) >= 2
+        ):
+            penultimate_content = bedrock_messages[-2].get("content")
+            if isinstance(penultimate_content, list) and not any(
+                _is_cache_point(b) for b in penultimate_content
+            ):
+                penultimate_content.append(cache_block)
 
     @model_validator(mode="before")
     @classmethod
@@ -3325,6 +3364,21 @@ def _is_cache_point(cache_point: Any) -> bool:
     if cache_point_data is None:
         return False
     return cache_point_data.get("type") is not None
+
+
+def _count_cache_points(
+    system: List[Dict[str, Any]],
+    bedrock_messages: List[Dict[str, Any]],
+    tools: Optional[List[Dict[str, Any]]] = None,
+) -> int:
+    """Count cachePoint blocks across system, messages, and tools."""
+    count = sum(map(_is_cache_point, system))
+    count += sum(map(_is_cache_point, tools or []))
+    for message in bedrock_messages:
+        content = message.get("content")
+        if isinstance(content, list):
+            count += sum(map(_is_cache_point, content))
+    return count
 
 
 def _has_tool_use_or_result_blocks(messages: List[Dict[str, Any]]) -> bool:

--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
@@ -475,6 +475,27 @@ def test_cache_control_anthropic_multi_turn() -> None:
     assert cache_read > 0, f"Expected cache read on turn 2, got {cache_read}"
 
 
+def test_cache_control_anthropic_with_manual_cache_points() -> None:
+    llm = ChatBedrockConverse(
+        model="us.anthropic.claude-sonnet-5",
+        system=[_LONG_SYSTEM_PROMPT],
+    )
+    llm_with_tools = llm.bind_tools([_get_weather])
+    cache_point = ChatBedrockConverse.create_cache_point()
+    messages = [
+        HumanMessage(content=[{"type": "text", "text": "A" * 400}, cache_point]),
+        AIMessage(content=[{"type": "text", "text": "Noted."}, cache_point]),
+        HumanMessage(content=[{"type": "text", "text": "B" * 400}, cache_point]),
+        AIMessage(content="Also noted."),
+        HumanMessage(content="Reply with exactly: OK"),
+    ]
+    r = llm_with_tools.invoke(
+        messages, cache_control={"type": "ephemeral", "ttl": "5m"}
+    )
+    assert isinstance(r, AIMessage)
+    assert r.content
+
+
 def test_cache_control_nova() -> None:
     llm = ChatBedrockConverse(
         model="us.amazon.nova-2-lite-v1:0",

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -41,6 +41,7 @@ from langchain_aws.chat_models.bedrock_converse import (
     _camel_to_snake,
     _camel_to_snake_keys,
     _convert_tool_blocks_to_text,
+    _count_cache_points,
     _expand_inline_reasoning,
     _extract_response_metadata,
     _extract_usage_metadata,
@@ -5641,7 +5642,11 @@ def test_apply_cache_points_system_and_messages() -> None:
     assert system[-1] == {"cachePoint": {"type": "default"}}
     assert messages[-1]["content"][-1] == {"cachePoint": {"type": "default"}}
     assert messages[0]["content"] == [{"text": "Hello"}]
-    assert messages[1]["content"] == [{"text": "Hi"}]
+    # Anthropic also gets an end-of-history checkpoint on the penultimate message
+    assert messages[1]["content"] == [
+        {"text": "Hi"},
+        {"cachePoint": {"type": "default"}},
+    ]
 
 
 def test_apply_cache_points_no_system() -> None:
@@ -5850,6 +5855,75 @@ def test_apply_cache_points_skips_existing_message_cache_point() -> None:
     assert len(msg_cps) == 1, f"Expected 1 cachePoint in message, got {len(msg_cps)}"
     system_cps = [b for b in system if "cachePoint" in b]
     assert len(system_cps) == 1
+
+
+def test_apply_cache_points_anthropic_end_of_history() -> None:
+    system: list[dict[str, Any]] = [{"text": "You are helpful."}]
+    messages: list[dict[str, Any]] = [
+        {"role": "user", "content": [{"text": "Hello"}]},
+        {"role": "assistant", "content": [{"text": "Hi"}]},
+        {"role": "user", "content": [{"text": "Classify the conversation above."}]},
+    ]
+    params: dict[str, Any] = {
+        "toolConfig": {
+            "tools": [
+                {"toolSpec": {"name": "t", "description": "d", "inputSchema": {}}}
+            ]
+        }
+    }
+    ChatBedrockConverse(
+        client=mock.MagicMock(),
+        model="us.anthropic.claude-sonnet-5",
+        region_name="us-west-2",
+    )._apply_cache_points({"type": "ephemeral"}, system, messages, params)
+    tools = params["toolConfig"]["tools"]
+    assert messages[-2]["content"][-1] == {"cachePoint": {"type": "default"}}
+    assert messages[-1]["content"][-1] == {"cachePoint": {"type": "default"}}
+    assert system[-1] == {"cachePoint": {"type": "default"}}
+    assert _count_cache_points(system, messages, tools) == 4
+
+
+def test_apply_cache_points_non_anthropic_no_end_of_history() -> None:
+    system: list[dict[str, Any]] = [{"text": "System"}]
+    messages: list[dict[str, Any]] = [
+        {"role": "user", "content": [{"text": "Hello"}]},
+        {"role": "assistant", "content": [{"text": "Hi"}]},
+        {"role": "user", "content": [{"text": "Question"}]},
+    ]
+    ChatBedrockConverse(
+        client=mock.MagicMock(),
+        model="us.amazon.nova-pro-v1:0",
+        region_name="us-west-2",
+    )._apply_cache_points({"type": "ephemeral"}, system, messages)
+    assert not any("cachePoint" in b for b in messages[-2]["content"])
+    assert messages[-1]["content"][-1] == {"cachePoint": {"type": "default"}}
+
+
+def test_apply_cache_points_manual_points_capped_at_four() -> None:
+    cp = {"cachePoint": {"type": "default"}}
+    system: list[dict[str, Any]] = [{"text": "System"}]
+    messages: list[dict[str, Any]] = [
+        {"role": "user", "content": [{"text": "a"}, dict(cp)]},
+        {"role": "assistant", "content": [{"text": "b"}, dict(cp)]},
+        {"role": "user", "content": [{"text": "c"}, dict(cp)]},
+        {"role": "assistant", "content": [{"text": "d"}]},
+        {"role": "user", "content": [{"text": "e"}]},
+    ]
+    params: dict[str, Any] = {
+        "toolConfig": {
+            "tools": [
+                {"toolSpec": {"name": "t", "description": "d", "inputSchema": {}}}
+            ]
+        }
+    }
+    ChatBedrockConverse(
+        client=mock.MagicMock(),
+        model="us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        region_name="us-west-2",
+    )._apply_cache_points({"type": "ephemeral"}, system, messages, params)
+    tools = params["toolConfig"]["tools"]
+    assert _count_cache_points(system, messages, tools) == 4
+    assert not any("cachePoint" in b for b in messages[-2]["content"])
 
 
 def test_generate_with_cache_control() -> None:


### PR DESCRIPTION
Minimal PR distilled from the review discussion on #1162 - please see @billcai's analysis in the original PR for full context.

**TL;DR: For Anthropic models, we're updating ChatBedrockConverse's `cache_control` behavior to add a fourth cachePoint on the penultimate message, at the end of the static content.** 

This takes advantage of Bedrock's [simplified cache management feature for Claude](https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html#prompt-caching-simplified), allowing Bedrock to search back through the message history for the longest cached prefix, and keep the conversation largely cache-readable as it grows after each turn. 

Additionally, since this extra cachePoint would hit Bedrock's hard limit of 4 per request, we check for any manual checkpoint already in the message history, and retain it over the 4th auto-checkpoint.

The existing 3-checkpoint `cache_control` behavior for non-Anthropic models remains unchanged. 

