### PR TITLE
fix(aws): include model name in invocation_params for Bedrock chat models

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -980,7 +980,7 @@ class ChatBedrock(BaseChatModel, BedrockBase):
     ) -> Dict[str, Any]:
         """Get the parameters used to invoke the model, for tracing purposes."""
         return {
-            "model": self.model_id,
+            "model": self.base_model_id or self.model_id,
             **super()._get_invocation_params(stop=stop, **kwargs),
         }
 

--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -975,6 +975,15 @@ class ChatBedrock(BaseChatModel, BedrockBase):
         populate_by_name=True,
     )
 
+    def _get_invocation_params(
+        self, stop: Optional[List[str]] = None, **kwargs: Any
+    ) -> Dict[str, Any]:
+        """Get the parameters used to invoke the model, for tracing purposes."""
+        return {
+            "model": self.model_id,
+            **super()._get_invocation_params(stop=stop, **kwargs),
+        }
+
     def _get_ls_params(
         self, stop: Optional[List[str]] = None, **kwargs: Any
     ) -> LangSmithParams:

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -1993,6 +1993,15 @@ class ChatBedrockConverse(BaseChatModel):
             }
         )
 
+    def _get_invocation_params(
+        self, stop: Optional[List[str]] = None, **kwargs: Any
+    ) -> Dict[str, Any]:
+        """Get the parameters used to invoke the model, for tracing purposes."""
+        return {
+            "model": self.base_model_id or self.model_id,
+            **super()._get_invocation_params(stop=stop, **kwargs),
+        }
+
     def _get_ls_params(
         self, stop: Optional[List[str]] = None, **kwargs: Any
     ) -> LangSmithParams:

--- a/libs/aws/langchain_aws/chat_models/bedrock_nova_sonic.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_nova_sonic.py
@@ -845,6 +845,7 @@ class ChatBedrockNovaSonic(BaseChatModel):
     def _identifying_params(self) -> Dict[str, Any]:
         """Return identifying parameters for tracing."""
         return {
+            "model": self.model_id,
             "model_id": self.model_id,
             "voice_id": self.voice_id,
             "max_tokens": self.max_tokens,

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
@@ -896,7 +896,7 @@ def test_invocation_params_model_prefers_base_model_id() -> None:
         provider="anthropic",
         region="us-west-2",
     )
-    assert llm._get_invocation_params()["model"] == "anthropic.claude-sonnet-5"
+    assert llm._get_invocation_params()["model"] == "us.anthropic.claude-sonnet-5"
 
 
 def test_beta_use_converse_api() -> None:

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
@@ -882,6 +882,19 @@ def test_standard_tracing_params() -> None:
     }
 
 
+def test_invocation_params_includes_model() -> None:
+    """invocation_params must carry a "model" key so that tracing tools which
+    key off it directly (e.g. cost calculators keyed by model name) work,
+    consistent with ChatOpenAI/ChatAnthropic."""
+    llm = ChatBedrock(
+        model_id="anthropic.claude-3-5-sonnet-20241022-v2:0", region_name="us-west-2"
+    )  # type: ignore[call-arg]
+    assert (
+        llm._get_invocation_params()["model"]
+        == "anthropic.claude-3-5-sonnet-20241022-v2:0"
+    )
+
+
 def test_beta_use_converse_api() -> None:
     llm = ChatBedrock(model_id="amazon.nova.foo", region_name="us-west-2")  # type: ignore[call-arg]
     assert llm.beta_use_converse_api

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
@@ -883,16 +883,20 @@ def test_standard_tracing_params() -> None:
 
 
 def test_invocation_params_includes_model() -> None:
-    """invocation_params must carry a "model" key so that tracing tools which
-    key off it directly (e.g. cost calculators keyed by model name) work,
-    consistent with ChatOpenAI/ChatAnthropic."""
+    llm = ChatBedrock(model="us.anthropic.claude-sonnet-5", region="us-west-2")
+    assert llm._get_invocation_params()["model"] == "us.anthropic.claude-sonnet-5"
+
+
+def test_invocation_params_model_prefers_base_model_id() -> None:
     llm = ChatBedrock(
-        model_id="anthropic.claude-3-5-sonnet-20241022-v2:0", region_name="us-west-2"
-    )  # type: ignore[call-arg]
-    assert (
-        llm._get_invocation_params()["model"]
-        == "anthropic.claude-3-5-sonnet-20241022-v2:0"
+        model=(
+            "arn:aws:bedrock:us-west-2:123456789012:application-inference-profile/abc"
+        ),
+        base_model="us.anthropic.claude-sonnet-5",
+        provider="anthropic",
+        region="us-west-2",
     )
+    assert llm._get_invocation_params()["model"] == "anthropic.claude-sonnet-5"
 
 
 def test_beta_use_converse_api() -> None:

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -791,6 +791,34 @@ def test_standard_tracing_params() -> None:
     }
 
 
+def test_invocation_params_includes_model() -> None:
+    """invocation_params must carry a "model" key so that tracing tools which
+    key off it directly (e.g. cost calculators keyed by model name) work,
+    consistent with ChatOpenAI/ChatAnthropic."""
+    llm = ChatBedrockConverse(
+        model="anthropic.claude-3-5-sonnet-20241022-v2:0", region_name="us-west-2"
+    )
+    assert (
+        llm._get_invocation_params()["model"]
+        == "anthropic.claude-3-5-sonnet-20241022-v2:0"
+    )
+
+
+def test_invocation_params_model_prefers_base_model_id() -> None:
+    """When base_model_id is set (e.g. resolved from an inference profile),
+    it identifies the actual served model and should be preferred over the
+    profile/model_id."""
+    llm = ChatBedrockConverse(
+        model="us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+        base_model_id="anthropic.claude-3-5-sonnet-20241022-v2:0",  # type: ignore[call-arg]
+        region_name="us-west-2",
+    )
+    assert (
+        llm._get_invocation_params()["model"]
+        == "anthropic.claude-3-5-sonnet-20241022-v2:0"
+    )
+
+
 @pytest.mark.parametrize(
     "model_id, disable_streaming",
     [

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -792,31 +792,19 @@ def test_standard_tracing_params() -> None:
 
 
 def test_invocation_params_includes_model() -> None:
-    """invocation_params must carry a "model" key so that tracing tools which
-    key off it directly (e.g. cost calculators keyed by model name) work,
-    consistent with ChatOpenAI/ChatAnthropic."""
     llm = ChatBedrockConverse(
-        model="anthropic.claude-3-5-sonnet-20241022-v2:0", region_name="us-west-2"
+        model="us.anthropic.claude-sonnet-5", region_name="us-west-2"
     )
-    assert (
-        llm._get_invocation_params()["model"]
-        == "anthropic.claude-3-5-sonnet-20241022-v2:0"
-    )
+    assert llm._get_invocation_params()["model"] == "us.anthropic.claude-sonnet-5"
 
 
 def test_invocation_params_model_prefers_base_model_id() -> None:
-    """When base_model_id is set (e.g. resolved from an inference profile),
-    it identifies the actual served model and should be preferred over the
-    profile/model_id."""
     llm = ChatBedrockConverse(
-        model="us.anthropic.claude-3-5-sonnet-20241022-v2:0",
-        base_model_id="anthropic.claude-3-5-sonnet-20241022-v2:0",  # type: ignore[call-arg]
+        model="us.anthropic.claude-sonnet-5",
+        base_model_id="anthropic.claude-sonnet-5",  # type: ignore[call-arg]
         region_name="us-west-2",
     )
-    assert (
-        llm._get_invocation_params()["model"]
-        == "anthropic.claude-3-5-sonnet-20241022-v2:0"
-    )
+    assert llm._get_invocation_params()["model"] == "anthropic.claude-sonnet-5"
 
 
 @pytest.mark.parametrize(

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_nova_sonic.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_nova_sonic.py
@@ -238,6 +238,7 @@ class TestBaseChatModelInterface:
             endpointing_sensitivity="HIGH",
         )
         params = model._identifying_params
+        assert params["model"] == "amazon.nova-2-sonic-v1:0"
         assert params["model_id"] == "amazon.nova-2-sonic-v1:0"
         assert params["voice_id"] == "tiffany"
         assert params["max_tokens"] == 1024


### PR DESCRIPTION
## Summary

`ChatBedrock`, `ChatBedrockConverse`, and `ChatBedrockNovaSonic` never populate a `"model"` key in `invocation_params` (chat models) / `_identifying_params`, unlike `ChatOpenAI` (`langchain_openai`) and `ChatAnthropic` (`langchain_anthropic`), which both include `"model"` directly.

This breaks any tracing/observability integration that reads `invocation_params["model"]` (or the equivalent `_identifying_params`) directly to identify the model, such as MLflow. MLflow's LangChain autolog computes per-call token cost by looking up `SpanAttributeKey.MODEL`, which it sets from `kwargs["invocation_params"].get("model")`. For all three Bedrock chat classes, this is always `None`, so cost is silently never computed, even when the model has a known price in MLflow's (or LiteLLM's) pricing catalog.

Notably, each of these classes' own `_get_ls_params()` already anticipates this key — e.g. in `bedrock_converse.py`:
```python
ls_model_name=params.get("model") or self.base_model_id or self.model_id,
```
— but nothing ever populated `params["model"]`, so the fallback was silently always taken.

## Fix

- `ChatBedrock`, `ChatBedrockConverse`: add a `_get_invocation_params` override that merges in `"model"` (resolving `base_model_id` first where applicable), following the same override pattern used by `BaseChatOpenAI._get_invocation_params`.
- `ChatBedrockNovaSonic`: add `"model"` to the existing `_identifying_params` dict, which already had `"model_id"` under a Bedrock-specific key name but not the generic `"model"` key that tracing conventions expect.

No existing key is renamed or removed — `model_id`/`base_model_id` remain available as before, so this doesn't affect any other consumer (verified: `_identifying_params`/`_get_invocation_params` output only feeds `asdict()`/repr and `_get_ls_params`/LangSmith tracing for these classes; the LLM response cache key uses `_serialized`/`to_json()` instead, since all three classes have `is_lc_serializable() = True`, so caching is unaffected).

`ChatAnthropicBedrock` already inherits a correct `_identifying_params` from `ChatAnthropic` and needs no change.
