### PR TITLE
fix(langgraph-checkpoint-aws): Support custom Boto config in AgentCore memory classes

### DIFF
--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/agentcore/helpers.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/agentcore/helpers.py
@@ -53,6 +53,17 @@ MAX_PAYLOAD_ITEMS_PER_EVENT = 100  # max items in payload array
 MAX_PAYLOAD_BYTES_PER_EVENT = 10_000_000  # 10 MB max event size
 
 
+def merge_client_config(base_config: Config, boto3_kwargs: dict[str, Any]) -> Config:
+    """Handle merging caller-supplied Config into the final boto config."""
+    caller_config: Config | None = boto3_kwargs.pop("config", None)
+    if not isinstance(caller_config, Config):
+        return base_config
+    base_ua = getattr(base_config, "user_agent_extra", "") or ""
+    caller_ua = getattr(caller_config, "user_agent_extra", "") or ""
+    merged = base_config.merge(caller_config)
+    return merged.merge(Config(user_agent_extra=f"{caller_ua} {base_ua}".strip()))
+
+
 class BedrockAgentCoreClientWithRetry:
     """Wrapper around bedrock-agentcore client with retry logic.
 
@@ -252,8 +263,9 @@ class AgentCoreEventClient:
         else:
             self.serializer = serializer
 
-        config = Config(
-            user_agent_extra="x-client-framework:langgraph_agentcore_memory"
+        config = merge_client_config(
+            Config(user_agent_extra="x-client-framework:langgraph_agentcore_memory"),
+            boto3_kwargs,
         )
         raw_client = boto3.client("bedrock-agentcore", config=config, **boto3_kwargs)
         self.client = BedrockAgentCoreClientWithRetry(

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/store/agentcore/store.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/store/agentcore/store.py
@@ -29,6 +29,7 @@ from langgraph.store.base import (
 
 from ...checkpoint.agentcore.helpers import (
     convert_langchain_messages_to_event_messages,
+    merge_client_config,
 )
 
 logger = logging.getLogger(__name__)
@@ -82,9 +83,14 @@ class AgentCoreMemoryStore(BaseStore):
         self.memory_id = memory_id
         self.hierarchical_search = hierarchical_search
 
-        config = Config(
-            user_agent_extra="x-client-framework:langgraph_agentcore_memory_store",
-            retries={"max_attempts": 4, "mode": "adaptive"},
+        config = merge_client_config(
+            Config(
+                user_agent_extra=(
+                    "x-client-framework:langgraph_agentcore_memory_store"
+                ),
+                retries={"max_attempts": 4, "mode": "adaptive"},
+            ),
+            boto3_kwargs,
         )
         self.client = boto3.client("bedrock-agentcore", config=config, **boto3_kwargs)
 

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_saver.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_saver.py
@@ -1173,6 +1173,29 @@ class TestAgentCoreEventClient:
             mock_boto3_client.return_value = mock_boto_client
             yield AgentCoreEventClient("test-memory-id", serializer)
 
+    def test_caller_config_merged_into_client(self, serializer):
+        from botocore.config import Config
+
+        with patch("boto3.client") as mock_boto3_client:
+            AgentCoreEventClient(
+                "test-memory-id",
+                serializer,
+                region_name="us-west-2",
+                config=Config(connect_timeout=5, read_timeout=10),
+            )
+        call_kwargs = mock_boto3_client.call_args[1]
+        merged = call_kwargs["config"]
+        assert call_kwargs["region_name"] == "us-west-2"
+        assert merged.connect_timeout == 5
+        assert merged.read_timeout == 10
+        assert "langgraph_agentcore_memory" in merged.user_agent_extra
+
+    def test_no_caller_config_keeps_default(self, serializer):
+        with patch("boto3.client") as mock_boto3_client:
+            AgentCoreEventClient("test-memory-id", serializer)
+        merged = mock_boto3_client.call_args[1]["config"]
+        assert "langgraph_agentcore_memory" in merged.user_agent_extra
+
     def test_store_blob_event(self, client, mock_boto_client, sample_checkpoint_event):
         client.store_blob_event(sample_checkpoint_event, "session_id", "actor_id")
 

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_store.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_store.py
@@ -84,6 +84,21 @@ class TestAgentCoreMemoryStore:
         with pytest.raises(TypeError):
             AgentCoreMemoryStore()
 
+    def test_init_with_caller_config(self, memory_id):
+        """Test successful merge of user Config into final boto client config"""
+        from botocore.config import Config
+
+        with patch("boto3.client") as mock_boto3_client:
+            AgentCoreMemoryStore(
+                memory_id=memory_id,
+                region_name="us-west-2",
+                config=Config(read_timeout=10),
+            )
+        merged = mock_boto3_client.call_args[1]["config"]
+        assert merged.read_timeout == 10
+        assert merged.retries["mode"] == "adaptive"
+        assert "langgraph_agentcore_memory_store" in merged.user_agent_extra
+
     def test_batch_get_op_success(self, store, mock_boto_client, sample_memory_record):
         """Test successful GetOp operation."""
         mock_boto_client.get_memory_record.return_value = {


### PR DESCRIPTION
Fixes #1194.

Users can now pass a custom boto `Config` on initialization of `AgentCoreMemorySaver` and `AgentCoreMemoryStore`, overriding any hardcoded values (with the exception of `user_agent_extra`, which gets prepended to the existing default `x-client-framework:langgraph_agentcore_memory`.)



