### PR TITLE
fix(langgraph-checkpoint-aws): Fix silent drops of custom config values in DynamoDB and Bedrock Sessions integrations

### DIFF
--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/bedrock_sessions/utils.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/bedrock_sessions/utils.py
@@ -471,14 +471,15 @@ def create_client_config(config: Config | None = None) -> Config:
         Config: New config object with combined user agent
 
     """
-    config_kwargs: dict[str, Any] = {}
-    existing_user_agent = getattr(config, "user_agent_extra", "") if config else ""
-    new_user_agent = (
-        f"{existing_user_agent} x-client-framework:langgraph-checkpoint-aws "
-        f"md/sdk_user_agent/{SDK_USER_AGENT}".strip()
+    framework_ua = (
+        f"x-client-framework:langgraph-checkpoint-aws "
+        f"md/sdk_user_agent/{SDK_USER_AGENT}"
     )
-
-    return Config(user_agent_extra=new_user_agent, **config_kwargs)
+    if config is None:
+        return Config(user_agent_extra=framework_ua)
+    existing_user_agent = getattr(config, "user_agent_extra", "") or ""
+    new_user_agent = f"{existing_user_agent} {framework_ua}".strip()
+    return config.merge(Config(user_agent_extra=new_user_agent))
 
 
 async def run_boto3_in_executor(func: Callable[..., T], *args: Any, **kwargs: Any) -> T:

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/dynamodb/utils.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/dynamodb/utils.py
@@ -57,29 +57,19 @@ def create_client_config(config: Config | None = None) -> Config:
     Returns:
         Config: New config object with combined user agent and retry configuration
     """
-    config_kwargs = {}
-    existing_user_agent = getattr(config, "user_agent_extra", "") if config else ""
+    framework_ua = (
+        f"x-client-framework:langgraph-dynamodb md/sdk_user_agent/{SDK_USER_AGENT}"
+    )
+    base_config = Config(
+        user_agent_extra=framework_ua,
+        retries={"mode": "adaptive", "max_attempts": 5},
+    )
+    if config is None:
+        return base_config
 
-    # Add our user agent to existing one
-    new_user_agent = (
-        f"{existing_user_agent} x-client-framework:langgraph-dynamodb "
-        f"md/sdk_user_agent/{SDK_USER_AGENT}"
-    ).strip()
-
-    # Preserve retries configuration
-    if config is None or not hasattr(config, "retries"):
-        config_kwargs["retries"] = {
-            "mode": "adaptive",
-            "max_attempts": 5,
-        }
-    elif config:
-        config_kwargs["retries"] = config.retries  # type: ignore[attr-defined]
-
-    # Preserve max_pool_connections if provided
-    if config and hasattr(config, "max_pool_connections"):
-        config_kwargs["max_pool_connections"] = config.max_pool_connections
-
-    return Config(user_agent_extra=new_user_agent, **config_kwargs)  # type: ignore[arg-type]
+    existing_user_agent = getattr(config, "user_agent_extra", "") or ""
+    new_user_agent = f"{existing_user_agent} {framework_ua}".strip()
+    return base_config.merge(config).merge(Config(user_agent_extra=new_user_agent))
 
 
 def create_dynamodb_client(

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/checkpoint/dynamodb/test_utils.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/checkpoint/dynamodb/test_utils.py
@@ -54,6 +54,20 @@ class TestCreateClientConfig:
         assert "my-app/1.0" in config.user_agent_extra
         assert "langgraph-dynamodb" in config.user_agent_extra
 
+    def test_caller_config_values_preserved(self):
+        """Caller-set values like timeouts survive the merge."""
+        caller = Config(connect_timeout=5, read_timeout=10, max_pool_connections=25)
+        config = create_client_config(caller)
+        assert config.connect_timeout == 5
+        assert config.read_timeout == 10
+        assert config.max_pool_connections == 25
+        # adaptive retry default applies when the caller did not set retries
+        assert config.retries == {"mode": "adaptive", "max_attempts": 5}
+
+    def test_caller_retries_win_over_default(self):
+        config = create_client_config(Config(retries={"max_attempts": 1}))
+        assert config.retries == {"max_attempts": 1}
+
 
 class TestCreateDynamoDBClient:
     """Test create_dynamodb_client function."""

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/test_utils.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/test_utils.py
@@ -146,3 +146,15 @@ def test_process_aws_client_args_user_agent(mock_make_request, mock_client):
     assert hasattr(config_obj, "user_agent_extra")
     assert "existing_agent" in config_obj.user_agent_extra
     assert SDK_USER_AGENT in config_obj.user_agent_extra
+
+
+def test_process_aws_client_args_preserves_caller_config_values():
+    _, client_kwargs = process_aws_client_args(
+        region_name="us-west-2",
+        config=Config(connect_timeout=5, read_timeout=10, max_pool_connections=25),
+    )
+    config_obj = client_kwargs["config"]
+    assert config_obj.connect_timeout == 5
+    assert config_obj.read_timeout == 10
+    assert config_obj.max_pool_connections == 25
+    assert SDK_USER_AGENT in config_obj.user_agent_extra


### PR DESCRIPTION
Similar to #1194, which fixed the AgentCore memory classes.

Updating the `BedrockSessionSaver`, `BedrockAgentRuntimeSessionClient`, `DynamoDBSaver`, `DynamoDBStore` Boto client creation utilities to fix a bug where nearly all custom boto Config values were being silently discarded in favor of a hardcoded configuration preset.