### PR TITLE
feat(aws): add DynamoDBVectorStore backed by DynamoDB vector indexes

### DIFF
--- a/libs/aws/langchain_aws/__init__.py
+++ b/libs/aws/langchain_aws/__init__.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from langchain_aws.document_compressors.rerank import BedrockRerank
     from langchain_aws.embeddings import BedrockEmbeddings
     from langchain_aws.graphs import NeptuneAnalyticsGraph, NeptuneGraph
+    from langchain_aws.vectorstores.dynamodb import DynamoDBVectorStore
     from langchain_aws.vectorstores.inmemorydb import (
         InMemorySemanticCache,
         InMemoryVectorStore,
@@ -103,6 +104,7 @@ __all__ = [
     "InMemoryVectorStore",
     "InMemorySemanticCache",
     "AmazonS3Vectors",
+    "DynamoDBVectorStore",
     "BedrockRerank",
     "ValkeyVectorStore",
 ]
@@ -143,6 +145,7 @@ def __getattr__(name: str) -> Any:
         "InMemorySemanticCache": "langchain_aws.vectorstores.inmemorydb",
         "InMemoryVectorStore": "langchain_aws.vectorstores.inmemorydb",
         "AmazonS3Vectors": "langchain_aws.vectorstores.s3_vectors",
+        "DynamoDBVectorStore": "langchain_aws.vectorstores.dynamodb",
         "ValkeyVectorStore": "langchain_aws.vectorstores.valkey",
         "NeptuneAnalyticsGraph": "langchain_aws.graphs",
         "NeptuneGraph": "langchain_aws.graphs",

--- a/libs/aws/langchain_aws/vectorstores/__init__.py
+++ b/libs/aws/langchain_aws/vectorstores/__init__.py
@@ -2,6 +2,7 @@ import importlib
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from langchain_aws.vectorstores.dynamodb import DynamoDBVectorStore
     from langchain_aws.vectorstores.inmemorydb import (
         InMemorySemanticCache,
         InMemoryVectorStore,
@@ -10,6 +11,7 @@ if TYPE_CHECKING:
     from langchain_aws.vectorstores.valkey import ValkeyVectorStore
 
 __all__ = [
+    "DynamoDBVectorStore",
     "InMemoryVectorStore",
     "InMemorySemanticCache",
     "AmazonS3Vectors",
@@ -17,6 +19,7 @@ __all__ = [
 ]
 
 _module_lookup = {
+    "DynamoDBVectorStore": "langchain_aws.vectorstores.dynamodb",
     "InMemoryVectorStore": "langchain_aws.vectorstores.inmemorydb",
     "InMemorySemanticCache": "langchain_aws.vectorstores.inmemorydb",
     "AmazonS3Vectors": "langchain_aws.vectorstores.s3_vectors",

--- a/libs/aws/langchain_aws/vectorstores/dynamodb/__init__.py
+++ b/libs/aws/langchain_aws/vectorstores/dynamodb/__init__.py
@@ -1,0 +1,3 @@
+from langchain_aws.vectorstores.dynamodb.base import DynamoDBVectorStore
+
+__all__ = ["DynamoDBVectorStore"]

--- a/libs/aws/langchain_aws/vectorstores/dynamodb/base.py
+++ b/libs/aws/langchain_aws/vectorstores/dynamodb/base.py
@@ -36,6 +36,9 @@ _VECTOR_ATTR = "embedding"
 _CONTENT_ATTR = "page_content"
 _METADATA_ATTR = "metadata"
 
+# Attribute names this store owns; a partition attribute must not collide.
+_RESERVED_ATTRS = frozenset({_PK_ATTR, _VECTOR_ATTR, _CONTENT_ATTR, _METADATA_ATTR})
+
 
 def _to_dynamodb_compatible(value: Any) -> Any:
     """Recursively convert floats to Decimal for DynamoDB serialization.
@@ -86,10 +89,20 @@ class DynamoDBVectorStore(VectorStore):
     To use, provide a table name and an embedding function. The table and
     vector index are created on first write if they don't exist.
 
-    Limitations: metadata filtering is not supported (a ``filter`` argument
-    is rejected rather than silently ignored), and maximal marginal
-    relevance (MMR) search is not implemented. SearchVectors returns at
-    most the top 100 matches per query.
+    Pass ``partition_attribute`` to scope searches. The index is then created
+    with a ``SearchSchema`` partition key on that document metadata field, and
+    each search examines only one value of it rather than the whole corpus,
+    which is how the index scales search throughput. The partition value is
+    supplied per search via ``filter={partition_attribute: value}``, or once
+    via ``default_partition_value``.
+
+    Limitations: inline filter attributes are not yet supported, so ``filter``
+    accepts only the partition key (any other key is rejected rather than
+    silently ignored), and maximal marginal relevance (MMR) search is not
+    implemented. SearchVectors returns at most the top 100 matches per query.
+    ``Dimensions``, ``DistanceFunction``, ``SearchSchema`` and the projection
+    are all fixed when the index is created; this store validates the first
+    three against an existing index rather than proceeding with a mismatch.
 
     Example:
         ```python
@@ -112,6 +125,8 @@ class DynamoDBVectorStore(VectorStore):
         embedding: Embeddings,
         index_name: str = "documents-vector-index",
         distance_function: Literal["COSINE", "EUCLIDEAN", "DOT_PRODUCT"] = "COSINE",
+        partition_attribute: Optional[str] = None,
+        default_partition_value: Optional[str] = None,
         create_table_if_not_exist: bool = True,
         relevance_score_fn: Optional[Callable[[float], float]] = None,
         region_name: Optional[str] = None,
@@ -129,6 +144,21 @@ class DynamoDBVectorStore(VectorStore):
             index_name: Name of the vector index on the table.
             distance_function: Distance function for the vector index.
                 One of "COSINE" (default), "EUCLIDEAN", "DOT_PRODUCT".
+            partition_attribute: Name of a document metadata field to use as
+                the vector index partition key. When set, the index is created
+                with a ``SearchSchema`` HASH element on this attribute and each
+                search is scoped to a single value of it, which lets the index
+                scale search throughput horizontally instead of examining the
+                whole corpus. Prefer low-to-medium cardinality values such as
+                a collection, category or tenant. This is part of the index
+                schema and cannot be changed after the index is created.
+                Every search must then supply the value, via
+                ``filter={partition_attribute: value}`` or
+                ``default_partition_value``.
+            default_partition_value: Value to use for ``partition_attribute``
+                when a document's metadata omits it and when a search supplies
+                no ``filter``. Only valid together with
+                ``partition_attribute``.
             create_table_if_not_exist: Create the table and vector index on
                 first use if they don't exist. Default is True.
             relevance_score_fn: Override for the relevance score conversion
@@ -143,6 +173,20 @@ class DynamoDBVectorStore(VectorStore):
         self.table_name = table_name
         self.index_name = index_name
         self.distance_function = distance_function
+        self.partition_attribute = partition_attribute
+        self.default_partition_value = default_partition_value
+        if default_partition_value is not None and partition_attribute is None:
+            raise ValueError(
+                "default_partition_value requires partition_attribute: without "
+                "a SearchSchema partition key there is nothing to scope "
+                "searches by."
+            )
+        if partition_attribute is not None and partition_attribute in _RESERVED_ATTRS:
+            raise ValueError(
+                f"partition_attribute '{partition_attribute}' collides with an "
+                f"attribute this store manages ({', '.join(sorted(_RESERVED_ATTRS))})"
+                ". Choose a different metadata field name."
+            )
         self.create_table_if_not_exist = create_table_if_not_exist
         self.relevance_score_fn = relevance_score_fn
         self._embedding = embedding
@@ -192,6 +236,104 @@ class DynamoDBVectorStore(VectorStore):
         waiter.wait(TableName=self.table_name)
         self._wait_for_vector_index()
 
+    def _validate_existing_search_schema(self, index: dict) -> None:
+        """Check the existing index's partition key matches configuration.
+
+        SearchSchema is immutable after index creation, so a mismatch cannot be
+        reconciled at runtime. Both directions are silent failures if allowed
+        through: an index with a HASH element rejects searches that omit
+        SearchConditionExpression, and an index without one has no partition to
+        scope by, so a configured store would send a condition the index cannot
+        satisfy.
+        """
+        existing_hash = next(
+            (
+                el.get("AttributeName")
+                for el in index.get("SearchSchema") or []
+                if el.get("SearchSchemaElementType") == "HASH"
+            ),
+            None,
+        )
+        if existing_hash == self.partition_attribute:
+            return
+        if existing_hash is None:
+            raise ValueError(
+                f"Vector index '{self.index_name}' was created without a "
+                "SearchSchema partition key but this store is configured with "
+                f"partition_attribute='{self.partition_attribute}'. The search "
+                "schema cannot be changed after creation. Drop "
+                "partition_attribute, or create a separate index (a table "
+                "supports multiple vector indexes) with the partition key."
+            )
+        if self.partition_attribute is None:
+            raise ValueError(
+                f"Vector index '{self.index_name}' has a SearchSchema "
+                f"partition key on '{existing_hash}', so every search must "
+                "supply its value, but this store is configured without a "
+                f"partition_attribute. Construct the store with "
+                f"partition_attribute='{existing_hash}'."
+            )
+        raise ValueError(
+            f"Vector index '{self.index_name}' has a SearchSchema partition "
+            f"key on '{existing_hash}' but this store is configured for "
+            f"'{self.partition_attribute}'. The search schema cannot be "
+            f"changed after creation. Use "
+            f"partition_attribute='{existing_hash}' or a different index."
+        )
+
+    def _partition_value_for_write(self, metadata: dict) -> Optional[str]:
+        """Resolve the partition value for a document being written."""
+        if self.partition_attribute is None:
+            return None
+        value = metadata.get(self.partition_attribute, self.default_partition_value)
+        if value is None:
+            raise ValueError(
+                f"Document metadata is missing '{self.partition_attribute}', "
+                "which is the vector index partition key. An item written "
+                "without it cannot be reached by any search. Supply it in the "
+                "document metadata or set default_partition_value."
+            )
+        return str(value)
+
+    def _partition_condition(self, filter: Optional[dict]) -> dict:
+        """Build the SearchConditionExpression kwargs for a search."""
+        if self.partition_attribute is None:
+            if filter is not None:
+                raise ValueError(
+                    "DynamoDBVectorStore does not support metadata filtering "
+                    "unless the index declares a SearchSchema. Construct the "
+                    "store with partition_attribute=<field> to scope searches, "
+                    "or remove the 'filter' argument (silently ignoring it "
+                    "would return unfiltered results)."
+                )
+            return {}
+
+        if filter is None:
+            value = self.default_partition_value
+        else:
+            unknown = set(filter) - {self.partition_attribute}
+            if unknown:
+                raise ValueError(
+                    f"Unsupported filter keys {sorted(unknown)}: only "
+                    f"'{self.partition_attribute}' (the vector index partition "
+                    "key) can be filtered on. Inline filter attributes are not "
+                    "yet supported by this store."
+                )
+            value = filter.get(self.partition_attribute, self.default_partition_value)
+
+        if value is None:
+            raise ValueError(
+                f"This index is partitioned on '{self.partition_attribute}', so "
+                "every search must supply its value. Pass "
+                f"filter={{'{self.partition_attribute}': <value>}} or set "
+                "default_partition_value on the store."
+            )
+        return {
+            "SearchConditionExpression": "#pk = :pk",
+            "ExpressionAttributeNames": {"#pk": self.partition_attribute},
+            "ExpressionAttributeValues": {":pk": {"S": str(value)}},
+        }
+
     def _create_vector_index(self, *, dimensions: int) -> None:
         """Retrofit the vector index onto an existing table."""
         self.client.update_table(
@@ -201,15 +343,25 @@ class DynamoDBVectorStore(VectorStore):
         self._wait_for_vector_index()
 
     def _vector_index_spec(self, dimensions: int) -> dict:
-        # No SearchSchema: the index spans the whole table so searches are
-        # global over the corpus (unlike a partition-scoped memory store).
-        return {
+        # Without a SearchSchema HASH element the index spans the whole table,
+        # so every search examines the entire corpus and cannot scale
+        # horizontally. With one, each search is scoped to a single partition
+        # value and SearchConditionExpression becomes mandatory.
+        spec: dict = {
             "IndexName": self.index_name,
             "VectorAttribute": {"AttributeName": _VECTOR_ATTR},
             "Projection": {"ProjectionType": "ALL"},
             "Dimensions": dimensions,
             "DistanceFunction": self.distance_function,
         }
+        if self.partition_attribute is not None:
+            spec["SearchSchema"] = [
+                {
+                    "AttributeName": self.partition_attribute,
+                    "SearchSchemaElementType": "HASH",
+                }
+            ]
+        return spec
 
     def _wait_for_vector_index(self, timeout: int = 600) -> None:
         """Poll describe_table until the vector index reports ACTIVE."""
@@ -269,6 +421,7 @@ class DynamoDBVectorStore(VectorStore):
                         f"distance_function='{existing_fn}' or use a different "
                         "index."
                     )
+                self._validate_existing_search_schema(idx)
                 return
         if not self.create_table_if_not_exist:
             raise ValueError(
@@ -347,6 +500,13 @@ class DynamoDBVectorStore(VectorStore):
                 ),
                 _VECTOR_ATTR: {"L": [{"N": str(v)} for v in vec]},
             }
+            # A SearchSchema element must name a top-level attribute, so the
+            # partition field is promoted out of the metadata map. It stays in
+            # metadata too, so Documents round-trip unchanged.
+            partition_value = self._partition_value_for_write(metadata or {})
+            if partition_value is not None:
+                assert self.partition_attribute is not None
+                item[self.partition_attribute] = {"S": partition_value}
             requests.append({"PutRequest": {"Item": item}})
 
         for i in range(0, len(requests), batch_size):
@@ -503,12 +663,13 @@ class DynamoDBVectorStore(VectorStore):
 
         See ``similarity_search_with_score`` for the score semantics.
         """
-        if kwargs.get("filter") is not None:
+        if kwargs.get("filter") is not None and self.partition_attribute is None:
             raise ValueError(
                 "DynamoDBVectorStore does not support metadata filtering: the "
                 "vector index is created without a filterable SearchSchema. "
-                "Remove the 'filter' argument (silently ignoring it would "
-                "return unfiltered results)."
+                "Construct the store with partition_attribute=<field> to scope "
+                "searches by a partition key, or remove the 'filter' argument "
+                "(silently ignoring it would return unfiltered results)."
             )
         if k < 1 or k > _MAX_TOP_K:
             raise ValueError(
@@ -519,6 +680,7 @@ class DynamoDBVectorStore(VectorStore):
             IndexName=self.index_name,
             SearchVector=[{"N": str(v)} for v in embedding],
             TopK=k,
+            **self._partition_condition(kwargs.get("filter")),
         )
         results = []
         for r in resp.get("SearchResults", []):

--- a/libs/aws/langchain_aws/vectorstores/dynamodb/base.py
+++ b/libs/aws/langchain_aws/vectorstores/dynamodb/base.py
@@ -253,6 +253,22 @@ class DynamoDBVectorStore(VectorStore):
                         f"{dimensions}-dimensional vectors. Use a matching "
                         "embedding model or a different index."
                     )
+                # The service scores using the index's DistanceFunction, which
+                # is immutable after creation. Relevance conversion keys off
+                # self.distance_function, so a mismatch silently returns
+                # wrongly-scaled scores rather than failing.
+                existing_fn = idx.get("DistanceFunction")
+                if existing_fn is not None and existing_fn != self.distance_function:
+                    raise ValueError(
+                        f"Vector index '{self.index_name}' has DistanceFunction="
+                        f"{existing_fn} but this store is configured for "
+                        f"{self.distance_function}. The index metric cannot be "
+                        "changed after creation, and searches would be scored "
+                        f"by {existing_fn} while relevance scores were computed "
+                        f"for {self.distance_function}. Construct the store with "
+                        f"distance_function='{existing_fn}' or use a different "
+                        "index."
+                    )
                 return
         if not self.create_table_if_not_exist:
             raise ValueError(

--- a/libs/aws/langchain_aws/vectorstores/dynamodb/base.py
+++ b/libs/aws/langchain_aws/vectorstores/dynamodb/base.py
@@ -223,12 +223,15 @@ class DynamoDBVectorStore(VectorStore):
 
     def _create_table(self, *, dimensions: int) -> None:
         """Create the table with the vector index and wait until ACTIVE."""
-        self.client.create_table(
+        attribute_definitions = [{"AttributeName": _PK_ATTR, "AttributeType": "S"}]
+        if self.partition_attribute is not None:
+            attribute_definitions.append(
+                {"AttributeName": self.partition_attribute, "AttributeType": "S"}
+            )
+        self.table = self.client.create_table(
             TableName=self.table_name,
             BillingMode="PAY_PER_REQUEST",
-            AttributeDefinitions=[
-                {"AttributeName": _PK_ATTR, "AttributeType": "S"},
-            ],
+            AttributeDefinitions=attribute_definitions,
             KeySchema=[{"AttributeName": _PK_ATTR, "KeyType": "HASH"}],
             VectorIndexes=[self._vector_index_spec(dimensions)],
         )
@@ -354,10 +357,15 @@ class DynamoDBVectorStore(VectorStore):
 
     def _create_vector_index(self, *, dimensions: int) -> None:
         """Retrofit the vector index onto an existing table."""
-        self.client.update_table(
-            TableName=self.table_name,
-            VectorIndexUpdates=[{"Create": self._vector_index_spec(dimensions)}],
-        )
+        update_params: dict = {
+            "TableName": self.table_name,
+            "VectorIndexUpdates": [{"Create": self._vector_index_spec(dimensions)}],
+        }
+        if self.partition_attribute is not None:
+            update_params["AttributeDefinitions"] = [
+                {"AttributeName": self.partition_attribute, "AttributeType": "S"}
+            ]
+        self.client.update_table(**update_params)
         self._wait_for_vector_index()
 
     def _vector_index_spec(self, dimensions: int) -> dict:

--- a/libs/aws/langchain_aws/vectorstores/dynamodb/base.py
+++ b/libs/aws/langchain_aws/vectorstores/dynamodb/base.py
@@ -295,8 +295,27 @@ class DynamoDBVectorStore(VectorStore):
             )
         return str(value)
 
-    def _partition_condition(self, filter: Optional[dict]) -> dict:
-        """Build the SearchConditionExpression kwargs for a search."""
+    def _search_kwargs(self, filter: Optional[dict]) -> dict:
+        """Build the per-request kwargs for a SearchVectors call.
+
+        Two things ride here. The projection expression bounds what comes back
+        to exactly the attributes ``_item_to_document`` reads, which matters
+        because SearchVectors responses are capped at 16 MB with no pagination,
+        so a high TopK over large items can approach that limit. Unlike the
+        index projection, which is immutable, this is a per-request choice.
+
+        The partition condition is required whenever the index declares a
+        SearchSchema HASH element.
+        """
+        kwargs: dict = {
+            "ProjectionExpression": "#id, #c, #m",
+            "ExpressionAttributeNames": {
+                "#id": _PK_ATTR,
+                "#c": _CONTENT_ATTR,
+                "#m": _METADATA_ATTR,
+            },
+        }
+
         if self.partition_attribute is None:
             if filter is not None:
                 raise ValueError(
@@ -306,7 +325,7 @@ class DynamoDBVectorStore(VectorStore):
                     "or remove the 'filter' argument (silently ignoring it "
                     "would return unfiltered results)."
                 )
-            return {}
+            return kwargs
 
         if filter is None:
             value = self.default_partition_value
@@ -328,11 +347,10 @@ class DynamoDBVectorStore(VectorStore):
                 f"filter={{'{self.partition_attribute}': <value>}} or set "
                 "default_partition_value on the store."
             )
-        return {
-            "SearchConditionExpression": "#pk = :pk",
-            "ExpressionAttributeNames": {"#pk": self.partition_attribute},
-            "ExpressionAttributeValues": {":pk": {"S": str(value)}},
-        }
+        kwargs["SearchConditionExpression"] = "#pk = :pk"
+        kwargs["ExpressionAttributeNames"]["#pk"] = self.partition_attribute
+        kwargs["ExpressionAttributeValues"] = {":pk": {"S": str(value)}}
+        return kwargs
 
     def _create_vector_index(self, *, dimensions: int) -> None:
         """Retrofit the vector index onto an existing table."""
@@ -680,7 +698,7 @@ class DynamoDBVectorStore(VectorStore):
             IndexName=self.index_name,
             SearchVector=[{"N": str(v)} for v in embedding],
             TopK=k,
-            **self._partition_condition(kwargs.get("filter")),
+            **self._search_kwargs(kwargs.get("filter")),
         )
         results = []
         for r in resp.get("SearchResults", []):

--- a/libs/aws/langchain_aws/vectorstores/dynamodb/base.py
+++ b/libs/aws/langchain_aws/vectorstores/dynamodb/base.py
@@ -228,7 +228,7 @@ class DynamoDBVectorStore(VectorStore):
             attribute_definitions.append(
                 {"AttributeName": self.partition_attribute, "AttributeType": "S"}
             )
-        self.table = self.client.create_table(
+        self.client.create_table(
             TableName=self.table_name,
             BillingMode="PAY_PER_REQUEST",
             AttributeDefinitions=attribute_definitions,

--- a/libs/aws/langchain_aws/vectorstores/dynamodb/base.py
+++ b/libs/aws/langchain_aws/vectorstores/dynamodb/base.py
@@ -1,0 +1,567 @@
+"""Amazon DynamoDB vector store for LangChain.
+
+Documents live as items in a DynamoDB table; a DynamoDB vector index over an
+embedding attribute serves approximate nearest neighbor search. One database
+serves both the application's operational data and its retrieval corpus, with
+no separate vector database to run.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import random
+import time
+import uuid
+from decimal import Decimal
+from typing import Any, Callable, Iterable, List, Literal, Optional, Sequence
+
+from boto3.dynamodb.types import TypeDeserializer, TypeSerializer
+from botocore.exceptions import ClientError
+from langchain_core.documents import Document
+from langchain_core.embeddings import Embeddings
+from langchain_core.vectorstores import VectorStore
+
+from langchain_aws.utils import create_aws_client
+
+logger = logging.getLogger(__name__)
+
+# Service maximum for SearchVectors TopK, verified against the live API:
+# "Provided TopK value ... must be between 1 and 100 inclusive".
+_MAX_TOP_K = 100
+
+_PK_ATTR = "id"
+_VECTOR_ATTR = "embedding"
+_CONTENT_ATTR = "page_content"
+_METADATA_ATTR = "metadata"
+
+
+def _to_dynamodb_compatible(value: Any) -> Any:
+    """Recursively convert floats to Decimal for DynamoDB serialization.
+
+    boto3's TypeSerializer rejects Python floats; DynamoDB numbers are
+    Decimal. Applied to user metadata before writing.
+    """
+    if isinstance(value, float):
+        return Decimal(str(value))
+    if isinstance(value, dict):
+        return {k: _to_dynamodb_compatible(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_to_dynamodb_compatible(v) for v in value]
+    return value
+
+
+def _from_dynamodb_types(value: Any) -> Any:
+    """Recursively convert Decimals back to int/float for user metadata."""
+    if isinstance(value, Decimal):
+        as_int = int(value)
+        return as_int if value == as_int else float(value)
+    if isinstance(value, dict):
+        return {k: _from_dynamodb_types(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_from_dynamodb_types(v) for v in value]
+    return value
+
+
+def _cosine_relevance_score_fn(distance: float) -> float:
+    """Cosine distance (0 == identical) to relevance score in [0, 1]."""
+    return 1.0 - distance / 2.0
+
+
+def _euclidean_relevance_score_fn(distance: float) -> float:
+    """Euclidean distance to a monotonically decreasing relevance score."""
+    return 1.0 / (1.0 + distance)
+
+
+class DynamoDBVectorStore(VectorStore):
+    """Amazon DynamoDB vector store using a DynamoDB vector index.
+
+    Documents are stored as regular DynamoDB items and searched via the
+    table's vector index (approximate nearest neighbor). Like a global
+    secondary index, the vector index is eventually consistent: a search
+    issued immediately after ``add_texts`` may not include the just-written
+    documents until the index catches up.
+
+    To use, provide a table name and an embedding function. The table and
+    vector index are created on first write if they don't exist.
+
+    Limitations: metadata filtering is not supported (a ``filter`` argument
+    is rejected rather than silently ignored), and maximal marginal
+    relevance (MMR) search is not implemented. SearchVectors returns at
+    most the top 100 matches per query.
+
+    Example:
+        ```python
+        from langchain_aws.embeddings import BedrockEmbeddings
+        from langchain_aws.vectorstores.dynamodb import DynamoDBVectorStore
+
+        vector_store = DynamoDBVectorStore.from_texts(
+            ["hello", "developer", "wife"],
+            embedding=BedrockEmbeddings(model_id="amazon.titan-embed-text-v2:0"),
+            table_name="my-documents",
+        )
+        docs = vector_store.similarity_search("greeting", k=2)
+        ```
+    """
+
+    def __init__(
+        self,
+        *,
+        table_name: str,
+        embedding: Embeddings,
+        index_name: str = "documents-vector-index",
+        distance_function: Literal["COSINE", "EUCLIDEAN", "DOT_PRODUCT"] = "COSINE",
+        create_table_if_not_exist: bool = True,
+        relevance_score_fn: Optional[Callable[[float], float]] = None,
+        region_name: Optional[str] = None,
+        credentials_profile_name: Optional[str] = None,
+        endpoint_url: Optional[str] = None,
+        config: Any = None,
+        client: Any = None,
+        **kwargs: Any,
+    ):
+        """Create a DynamoDBVectorStore.
+
+        Args:
+            table_name: Name of the DynamoDB table holding the documents.
+            embedding: Embedding function used for documents and queries.
+            index_name: Name of the vector index on the table.
+            distance_function: Distance function for the vector index.
+                One of "COSINE" (default), "EUCLIDEAN", "DOT_PRODUCT".
+            create_table_if_not_exist: Create the table and vector index on
+                first use if they don't exist. Default is True.
+            relevance_score_fn: Override for the relevance score conversion
+                used by ``similarity_search_with_relevance_scores``.
+            region_name: AWS region name.
+            credentials_profile_name: Name of an AWS credentials profile.
+            endpoint_url: Custom endpoint URL for the DynamoDB service.
+            config: An optional ``botocore.config.Config`` for the client.
+            client: Pre-configured boto3 DynamoDB client.
+            kwargs: Additional keyword arguments.
+        """
+        self.table_name = table_name
+        self.index_name = index_name
+        self.distance_function = distance_function
+        self.create_table_if_not_exist = create_table_if_not_exist
+        self.relevance_score_fn = relevance_score_fn
+        self._embedding = embedding
+        self._serializer = TypeSerializer()
+        self._deserializer = TypeDeserializer()
+        self.client = client
+        if client is None:
+            self.client = create_aws_client(
+                "dynamodb",
+                region_name=region_name,
+                credentials_profile_name=credentials_profile_name,
+                endpoint_url=endpoint_url,
+                config=config,
+            )
+
+    @property
+    def embeddings(self) -> Embeddings:
+        """The embedding function used for documents and queries."""
+        return self._embedding
+
+    # ------------------------------------------------------------------
+    # Provisioning
+    # ------------------------------------------------------------------
+
+    def _get_table_vector_indexes(self) -> Optional[list[dict]]:
+        """Return the table's vector indexes, or None if the table is absent."""
+        try:
+            resp = self.client.describe_table(TableName=self.table_name)
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "ResourceNotFoundException":
+                return None
+            raise
+        return resp["Table"].get("VectorIndexes", [])
+
+    def _create_table(self, *, dimensions: int) -> None:
+        """Create the table with the vector index and wait until ACTIVE."""
+        self.client.create_table(
+            TableName=self.table_name,
+            BillingMode="PAY_PER_REQUEST",
+            AttributeDefinitions=[
+                {"AttributeName": _PK_ATTR, "AttributeType": "S"},
+            ],
+            KeySchema=[{"AttributeName": _PK_ATTR, "KeyType": "HASH"}],
+            VectorIndexes=[self._vector_index_spec(dimensions)],
+        )
+        waiter = self.client.get_waiter("table_exists")
+        waiter.wait(TableName=self.table_name)
+        self._wait_for_vector_index()
+
+    def _create_vector_index(self, *, dimensions: int) -> None:
+        """Retrofit the vector index onto an existing table."""
+        self.client.update_table(
+            TableName=self.table_name,
+            VectorIndexUpdates=[{"Create": self._vector_index_spec(dimensions)}],
+        )
+        self._wait_for_vector_index()
+
+    def _vector_index_spec(self, dimensions: int) -> dict:
+        # No SearchSchema: the index spans the whole table so searches are
+        # global over the corpus (unlike a partition-scoped memory store).
+        return {
+            "IndexName": self.index_name,
+            "VectorAttribute": {"AttributeName": _VECTOR_ATTR},
+            "Projection": {"ProjectionType": "ALL"},
+            "Dimensions": dimensions,
+            "DistanceFunction": self.distance_function,
+        }
+
+    def _wait_for_vector_index(self, timeout: int = 600) -> None:
+        """Poll describe_table until the vector index reports ACTIVE."""
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            indexes = self._get_table_vector_indexes() or []
+            for idx in indexes:
+                if idx.get("IndexName") == self.index_name:
+                    # ACTIVE alone is not "ready": while Backfilling is true,
+                    # SearchVectors returns an error. Require explicit ACTIVE
+                    # and Backfilling false/absent; never assume a missing
+                    # status means ready.
+                    if idx.get("IndexStatus") == "ACTIVE" and not idx.get(
+                        "Backfilling", False
+                    ):
+                        return
+            time.sleep(5)
+        raise TimeoutError(
+            f"Vector index '{self.index_name}' on table '{self.table_name}' "
+            f"did not become ACTIVE within {timeout}s."
+        )
+
+    def _ensure_provisioned(self, *, dimensions: int) -> None:
+        """Create the table and/or vector index if configured to do so."""
+        indexes = self._get_table_vector_indexes()
+        if indexes is None:
+            if not self.create_table_if_not_exist:
+                raise ValueError(
+                    f"DynamoDB table '{self.table_name}' does not exist and "
+                    "create_table_if_not_exist is False."
+                )
+            self._create_table(dimensions=dimensions)
+            return
+        for idx in indexes:
+            if idx.get("IndexName") == self.index_name:
+                existing_dims = idx.get("Dimensions")
+                if existing_dims is not None and existing_dims != dimensions:
+                    raise ValueError(
+                        f"Vector index '{self.index_name}' has Dimensions="
+                        f"{existing_dims} but the embedding model returned "
+                        f"{dimensions}-dimensional vectors. Use a matching "
+                        "embedding model or a different index."
+                    )
+                return
+        if not self.create_table_if_not_exist:
+            raise ValueError(
+                f"Vector index '{self.index_name}' does not exist on table "
+                f"'{self.table_name}' and create_table_if_not_exist is False."
+            )
+        self._create_vector_index(dimensions=dimensions)
+
+    # ------------------------------------------------------------------
+    # Write path
+    # ------------------------------------------------------------------
+
+    def add_texts(
+        self,
+        texts: Iterable[str],
+        metadatas: Optional[List[dict]] = None,
+        *,
+        ids: Optional[List[str]] = None,
+        batch_size: int = 25,
+        **kwargs: Any,
+    ) -> List[str]:
+        """Embed texts and write them as DynamoDB items.
+
+        Args:
+            texts: Iterable of strings to add.
+            metadatas: Optional list of metadata dicts, one per text.
+            ids: Optional list of item IDs; generated when omitted.
+            batch_size: Items per BatchWriteItem call (service max is 25).
+            kwargs: Additional keyword arguments.
+
+        Returns:
+            List of IDs of the added texts.
+        """
+        texts_list = list(texts)
+        if metadatas is not None and len(metadatas) != len(texts_list):
+            raise ValueError("Number of metadatas must match number of texts")
+        if ids is not None:
+            if len(ids) != len(texts_list):
+                raise ValueError("Number of ids must match number of texts")
+            if len(set(ids)) != len(ids):
+                raise ValueError(
+                    "ids must be unique: BatchWriteItem rejects a batch "
+                    "containing duplicate keys"
+                )
+        if not texts_list:
+            return []
+        if batch_size < 1 or batch_size > 25:
+            raise ValueError("batch_size must be between 1 and 25 (service limit)")
+
+        vectors = self._embedding.embed_documents(texts_list)
+        dims = len(vectors[0])
+        if any(len(v) != dims for v in vectors):
+            raise ValueError("Embedding model returned vectors of unequal length")
+        if dims < 1 or dims > 4096:
+            raise ValueError(
+                f"Embedding dimension {dims} outside the supported range "
+                "1..4096 for DynamoDB vector indexes"
+            )
+        self._ensure_provisioned(dimensions=dims)
+
+        result_ids = list(ids) if ids else [uuid.uuid4().hex for _ in texts_list]
+        requests = []
+        for text, metadata, vec, id_ in zip(
+            texts_list,
+            metadatas or [{}] * len(texts_list),
+            vectors,
+            result_ids,
+        ):
+            item = {
+                _PK_ATTR: {"S": id_},
+                _CONTENT_ATTR: {"S": text},
+                _METADATA_ATTR: self._serializer.serialize(
+                    _to_dynamodb_compatible(
+                        json.loads(json.dumps(metadata, default=str))
+                    )
+                ),
+                _VECTOR_ATTR: {"L": [{"N": str(v)} for v in vec]},
+            }
+            requests.append({"PutRequest": {"Item": item}})
+
+        for i in range(0, len(requests), batch_size):
+            batch = requests[i : i + batch_size]
+            resp = self.client.batch_write_item(RequestItems={self.table_name: batch})
+            # Retry unprocessed items rather than silently dropping documents.
+            unprocessed = resp.get("UnprocessedItems", {}).get(self.table_name)
+            attempts = 0
+            while unprocessed:
+                attempts += 1
+                if attempts > 8:
+                    raise RuntimeError(
+                        f"BatchWriteItem left {len(unprocessed)} unprocessed "
+                        f"items after {attempts} retries."
+                    )
+                delay = min(2**attempts * 0.05, 2.0)
+                time.sleep(random.uniform(0, delay))
+                resp = self.client.batch_write_item(
+                    RequestItems={self.table_name: unprocessed}
+                )
+                unprocessed = resp.get("UnprocessedItems", {}).get(self.table_name)
+        return result_ids
+
+    def delete(self, ids: Optional[list[str]] = None, **kwargs: Any) -> Optional[bool]:
+        """Delete documents by ID.
+
+        Args:
+            ids: List of document IDs to delete. Required; deleting the whole
+                table is deliberately not supported through this API.
+            kwargs: Additional keyword arguments.
+
+        Returns:
+            True when the delete requests were issued.
+        """
+        if not ids:
+            raise ValueError(
+                "ids is required; DynamoDBVectorStore does not delete the "
+                "table. Use the AWS API to delete the table itself."
+            )
+        unique_ids = list(dict.fromkeys(ids))
+        for i in range(0, len(unique_ids), 25):
+            requests = [
+                {"DeleteRequest": {"Key": {_PK_ATTR: {"S": id_}}}}
+                for id_ in unique_ids[i : i + 25]
+            ]
+            resp = self.client.batch_write_item(
+                RequestItems={self.table_name: requests}
+            )
+            unprocessed = resp.get("UnprocessedItems", {}).get(self.table_name)
+            attempts = 0
+            while unprocessed:
+                attempts += 1
+                if attempts > 8:
+                    raise RuntimeError(
+                        f"BatchWriteItem left {len(unprocessed)} unprocessed "
+                        f"deletes after {attempts} retries."
+                    )
+                delay = min(2**attempts * 0.05, 2.0)
+                time.sleep(random.uniform(0, delay))
+                resp = self.client.batch_write_item(
+                    RequestItems={self.table_name: unprocessed}
+                )
+                unprocessed = resp.get("UnprocessedItems", {}).get(self.table_name)
+        return True
+
+    def get_by_ids(self, ids: Sequence[str], /) -> list[Document]:
+        """Get documents by their IDs.
+
+        Args:
+            ids: Sequence of document IDs.
+
+        Returns:
+            List of ``Document`` objects; IDs that don't exist are skipped.
+        """
+        docs: list[Document] = []
+        # De-dupe while preserving order: the base contract requires
+        # tolerating duplicate ids (returning fewer documents), and
+        # BatchGetItem rejects duplicate keys within one request.
+        unique_ids = list(dict.fromkeys(ids))
+        for i in range(0, len(unique_ids), 100):
+            chunk = unique_ids[i : i + 100]
+            resp = self.client.batch_get_item(
+                RequestItems={
+                    self.table_name: {"Keys": [{_PK_ATTR: {"S": id_}} for id_ in chunk]}
+                }
+            )
+            found = {
+                item[_PK_ATTR]["S"]: item
+                for item in resp.get("Responses", {}).get(self.table_name, [])
+            }
+            for id_ in chunk:
+                if id_ in found:
+                    docs.append(self._item_to_document(found[id_]))
+        return docs
+
+    # ------------------------------------------------------------------
+    # Search path
+    # ------------------------------------------------------------------
+
+    def similarity_search(
+        self, query: str, k: int = 4, **kwargs: Any
+    ) -> list[Document]:
+        """Return the documents most similar to the query text.
+
+        Args:
+            query: Input text.
+            k: Number of documents to return (service max is 100).
+            kwargs: Additional keyword arguments.
+
+        Returns:
+            List of ``Document`` objects most similar to the query.
+        """
+        return [
+            doc for doc, _ in self.similarity_search_with_score(query, k=k, **kwargs)
+        ]
+
+    def similarity_search_with_score(
+        self, query: str, k: int = 4, **kwargs: Any
+    ) -> list[tuple[Document, float]]:
+        """Similarity search returning (document, score) tuples.
+
+        The score is the raw ``Score`` returned by the vector index for the
+        configured ``distance_function``: for COSINE and EUCLIDEAN it is a
+        distance (lower is closer); for DOT_PRODUCT it is a similarity
+        (higher is more similar, and may be negative). Results are always
+        ordered most-similar first.
+
+        Args:
+            query: Input text.
+            k: Number of documents to return (service max is 100).
+            kwargs: Additional keyword arguments.
+
+        Returns:
+            List of tuples of (document, distance).
+        """
+        query_vector = self._embedding.embed_query(query)
+        return self.similarity_search_with_score_by_vector(query_vector, k=k, **kwargs)
+
+    def similarity_search_by_vector(
+        self, embedding: list[float], k: int = 4, **kwargs: Any
+    ) -> list[Document]:
+        """Return the documents most similar to the given embedding."""
+        return [
+            doc
+            for doc, _ in self.similarity_search_with_score_by_vector(
+                embedding, k=k, **kwargs
+            )
+        ]
+
+    def similarity_search_with_score_by_vector(
+        self, embedding: list[float], k: int = 4, **kwargs: Any
+    ) -> list[tuple[Document, float]]:
+        """Similarity search by vector returning (document, score) tuples.
+
+        See ``similarity_search_with_score`` for the score semantics.
+        """
+        if kwargs.get("filter") is not None:
+            raise ValueError(
+                "DynamoDBVectorStore does not support metadata filtering: the "
+                "vector index is created without a filterable SearchSchema. "
+                "Remove the 'filter' argument (silently ignoring it would "
+                "return unfiltered results)."
+            )
+        if k < 1 or k > _MAX_TOP_K:
+            raise ValueError(
+                f"k must be between 1 and {_MAX_TOP_K} (SearchVectors TopK limit)"
+            )
+        resp = self.client.search_vectors(
+            TableName=self.table_name,
+            IndexName=self.index_name,
+            SearchVector=[{"N": str(v)} for v in embedding],
+            TopK=k,
+        )
+        results = []
+        for r in resp.get("SearchResults", []):
+            doc = self._item_to_document(r["Item"])
+            results.append((doc, float(r["Score"])))
+        return results
+
+    def _select_relevance_score_fn(self) -> Callable[[float], float]:
+        """Distance-to-relevance conversion for the configured metric."""
+        if self.relevance_score_fn:
+            return self.relevance_score_fn
+        if self.distance_function == "EUCLIDEAN":
+            return _euclidean_relevance_score_fn
+        if self.distance_function == "DOT_PRODUCT":
+            # For DOT_PRODUCT the service Score is already higher == more
+            # similar (and can be negative/unbounded). Squash monotonically
+            # into (0, 1) so relevance ordering is preserved and LangChain's
+            # [0, 1] range expectations hold.
+            return lambda score: 1.0 / (1.0 + math.exp(-score))
+        return _cosine_relevance_score_fn
+
+    # ------------------------------------------------------------------
+    # Construction helpers
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_texts(  # type: ignore[override]
+        cls,
+        texts: list[str],
+        embedding: Embeddings,
+        metadatas: Optional[list[dict]] = None,
+        *,
+        ids: Optional[list[str]] = None,
+        table_name: str,
+        **kwargs: Any,
+    ) -> DynamoDBVectorStore:
+        """Create a store, provision the table/index, and add the texts.
+
+        Args:
+            texts: Texts to add.
+            embedding: Embedding function.
+            metadatas: Optional list of metadata dicts.
+            ids: Optional list of IDs.
+            table_name: Name of the DynamoDB table.
+            kwargs: Passed through to the constructor.
+
+        Returns:
+            An initialized ``DynamoDBVectorStore`` containing the texts.
+        """
+        store = cls(table_name=table_name, embedding=embedding, **kwargs)
+        store.add_texts(texts, metadatas=metadatas, ids=ids)
+        return store
+
+    def _item_to_document(self, item: dict[str, Any]) -> Document:
+        metadata = item.get(_METADATA_ATTR)
+        return Document(
+            id=item[_PK_ATTR]["S"],
+            page_content=item.get(_CONTENT_ATTR, {}).get("S", ""),
+            metadata=_from_dynamodb_types(self._deserializer.deserialize(metadata))
+            if metadata
+            else {},
+        )

--- a/libs/aws/pyproject.toml
+++ b/libs/aws/pyproject.toml
@@ -13,7 +13,7 @@ version = "1.6.4"
 requires-python = ">=3.10"
 dependencies = [
     "langchain-core>=1.4.7",
-    "boto3>=1.43.32",
+    "boto3>=1.43.64",
     "pydantic>=2.10.6,<3",
     "numpy>=1.0.0,<3",
 ]

--- a/libs/aws/tests/unit_tests/vectorstores/test_dynamodb.py
+++ b/libs/aws/tests/unit_tests/vectorstores/test_dynamodb.py
@@ -443,3 +443,159 @@ class TestReviewRegressions:
             [Document(page_content="hello", id="doc-1", metadata={"a": 1})]
         )
         assert ids == ["doc-1"]
+
+
+class TestPartitionScoping:
+    """A SearchSchema HASH element scopes each search to one partition value.
+
+    It is immutable after index creation, and once present the service requires
+    SearchConditionExpression on every SearchVectors call.
+    """
+
+    def _describe(self, hash_attr: str | None = None) -> dict:
+        idx: dict = {
+            "IndexName": "documents-vector-index",
+            "IndexStatus": "ACTIVE",
+            "Dimensions": 4,
+            "DistanceFunction": "COSINE",
+        }
+        if hash_attr is not None:
+            idx["SearchSchema"] = [
+                {"AttributeName": hash_attr, "SearchSchemaElementType": "HASH"}
+            ]
+        return {"Table": {"VectorIndexes": [idx]}}
+
+    def test_index_spec_omits_search_schema_by_default(self, mock_client: Mock) -> None:
+        store = _make_store(mock_client)
+        assert "SearchSchema" not in store._vector_index_spec(4)
+
+    def test_index_spec_declares_hash_element(self, mock_client: Mock) -> None:
+        store = _make_store(mock_client, partition_attribute="category")
+        spec = store._vector_index_spec(4)
+        assert spec["SearchSchema"] == [
+            {"AttributeName": "category", "SearchSchemaElementType": "HASH"}
+        ]
+
+    def test_partition_attribute_is_promoted_to_top_level(
+        self, mock_client: Mock
+    ) -> None:
+        """A SearchSchema element must name a top-level attribute."""
+        mock_client.describe_table.return_value = self._describe("category")
+        store = _make_store(mock_client, partition_attribute="category")
+        store.add_texts(["hello"], metadatas=[{"category": "shoes"}])
+        item = mock_client.batch_write_item.call_args.kwargs["RequestItems"]["docs"][0][
+            "PutRequest"
+        ]["Item"]
+        assert item["category"] == {"S": "shoes"}
+        # still present in metadata so Documents round-trip unchanged
+        assert item["metadata"]["M"]["category"] == {"S": "shoes"}
+
+    def test_write_without_partition_value_raises(self, mock_client: Mock) -> None:
+        """An item missing the partition key is unreachable by any search."""
+        mock_client.describe_table.return_value = self._describe("category")
+        store = _make_store(mock_client, partition_attribute="category")
+        with pytest.raises(ValueError, match="missing 'category'"):
+            store.add_texts(["hello"], metadatas=[{"other": "x"}])
+
+    def test_write_falls_back_to_default_partition_value(
+        self, mock_client: Mock
+    ) -> None:
+        mock_client.describe_table.return_value = self._describe("category")
+        store = _make_store(
+            mock_client,
+            partition_attribute="category",
+            default_partition_value="general",
+        )
+        store.add_texts(["hello"])
+        item = mock_client.batch_write_item.call_args.kwargs["RequestItems"]["docs"][0][
+            "PutRequest"
+        ]["Item"]
+        assert item["category"] == {"S": "general"}
+
+    def test_search_sends_condition_expression(self, mock_client: Mock) -> None:
+        mock_client.describe_table.return_value = self._describe("category")
+        mock_client.search_vectors.return_value = {"SearchResults": []}
+        store = _make_store(mock_client, partition_attribute="category")
+        store.similarity_search("q", k=3, filter={"category": "shoes"})
+        kwargs = mock_client.search_vectors.call_args.kwargs
+        assert kwargs["SearchConditionExpression"] == "#pk = :pk"
+        assert kwargs["ExpressionAttributeNames"] == {"#pk": "category"}
+        assert kwargs["ExpressionAttributeValues"] == {":pk": {"S": "shoes"}}
+
+    def test_search_without_partition_value_raises(self, mock_client: Mock) -> None:
+        """The service requires the condition once a HASH element exists."""
+        store = _make_store(mock_client, partition_attribute="category")
+        with pytest.raises(ValueError, match="every search must supply"):
+            store.similarity_search("q")
+
+    def test_search_uses_default_partition_value(self, mock_client: Mock) -> None:
+        mock_client.search_vectors.return_value = {"SearchResults": []}
+        store = _make_store(
+            mock_client,
+            partition_attribute="category",
+            default_partition_value="general",
+        )
+        store.similarity_search("q")
+        kwargs = mock_client.search_vectors.call_args.kwargs
+        assert kwargs["ExpressionAttributeValues"] == {":pk": {"S": "general"}}
+
+    def test_unsupported_filter_key_raises(self, mock_client: Mock) -> None:
+        """Inline filters are not implemented; do not silently drop keys."""
+        store = _make_store(mock_client, partition_attribute="category")
+        with pytest.raises(ValueError, match="Unsupported filter keys"):
+            store.similarity_search("q", filter={"category": "shoes", "lang": "en"})
+
+    def test_unpartitioned_store_still_sends_no_condition(
+        self, mock_client: Mock
+    ) -> None:
+        """Negative control: the global-search path is unchanged."""
+        mock_client.search_vectors.return_value = {"SearchResults": []}
+        store = _make_store(mock_client)
+        store.similarity_search("q")
+        assert "SearchConditionExpression" not in (
+            mock_client.search_vectors.call_args.kwargs
+        )
+
+    def test_filter_still_rejected_without_partition_attribute(
+        self, mock_client: Mock
+    ) -> None:
+        store = _make_store(mock_client)
+        with pytest.raises(ValueError, match="does not support metadata filtering"):
+            store.similarity_search("q", filter={"category": "shoes"})
+
+    def test_default_without_attribute_raises(self, mock_client: Mock) -> None:
+        with pytest.raises(ValueError, match="requires partition_attribute"):
+            _make_store(mock_client, default_partition_value="general")
+
+    def test_reserved_partition_attribute_raises(self, mock_client: Mock) -> None:
+        with pytest.raises(ValueError, match="collides"):
+            _make_store(mock_client, partition_attribute="page_content")
+
+    def test_schema_mismatch_configured_but_index_has_none(
+        self, mock_client: Mock
+    ) -> None:
+        mock_client.describe_table.return_value = self._describe(None)
+        store = _make_store(mock_client, partition_attribute="category")
+        with pytest.raises(ValueError, match="without a SearchSchema partition key"):
+            store.add_texts(["hello"], metadatas=[{"category": "shoes"}])
+
+    def test_schema_mismatch_index_has_one_but_store_does_not(
+        self, mock_client: Mock
+    ) -> None:
+        mock_client.describe_table.return_value = self._describe("category")
+        store = _make_store(mock_client)
+        with pytest.raises(ValueError, match="has a SearchSchema partition key"):
+            store.add_texts(["hello"])
+
+    def test_schema_mismatch_different_attribute(self, mock_client: Mock) -> None:
+        mock_client.describe_table.return_value = self._describe("country")
+        store = _make_store(mock_client, partition_attribute="category")
+        with pytest.raises(ValueError, match="partition key on 'country'"):
+            store.add_texts(["hello"], metadatas=[{"category": "shoes"}])
+
+    def test_matching_schema_is_accepted(self, mock_client: Mock) -> None:
+        """Negative control: a matching schema neither raises nor recreates."""
+        mock_client.describe_table.return_value = self._describe("category")
+        store = _make_store(mock_client, partition_attribute="category")
+        store.add_texts(["hello"], metadatas=[{"category": "shoes"}])
+        mock_client.update_table.assert_not_called()

--- a/libs/aws/tests/unit_tests/vectorstores/test_dynamodb.py
+++ b/libs/aws/tests/unit_tests/vectorstores/test_dynamodb.py
@@ -1,0 +1,402 @@
+"""Unit tests for DynamoDBVectorStore.
+
+Fully mocked boto3 client; no live AWS calls. Covers:
+- provisioning (table create, index retrofit, create_table_if_not_exist=False)
+- add_texts (embedding, batching, unprocessed-item retry, validation)
+- similarity search (TopK bounds, distance passthrough, document mapping)
+- relevance score conversion per distance function
+- delete / get_by_ids
+"""
+
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+from langchain_core.embeddings import Embeddings
+
+from langchain_aws.vectorstores.dynamodb import DynamoDBVectorStore
+from langchain_aws.vectorstores.dynamodb.base import _MAX_TOP_K
+
+
+class FakeEmbeddings(Embeddings):
+    """Deterministic embeddings satisfying the Embeddings interface."""
+
+    def __init__(self, dim: int = 4) -> None:
+        self.dim = dim
+
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        return [[float(len(t) % 7 + i) for i in range(self.dim)] for t in texts]
+
+    def embed_query(self, text: str) -> list[float]:
+        return [float(len(text) % 7 + i) for i in range(self.dim)]
+
+
+@pytest.fixture
+def mock_client() -> Mock:
+    client = Mock()
+    client.get_waiter = Mock(return_value=Mock())
+    client.batch_write_item.return_value = {}
+    client.describe_table.return_value = {
+        "Table": {
+            "VectorIndexes": [
+                {"IndexName": "documents-vector-index", "IndexStatus": "ACTIVE"}
+            ]
+        }
+    }
+    return client
+
+
+def _make_store(mock_client: Mock, **kwargs: Any) -> DynamoDBVectorStore:
+    return DynamoDBVectorStore(
+        table_name="docs",
+        embedding=FakeEmbeddings(),
+        client=mock_client,
+        **kwargs,
+    )
+
+
+class TestProvisioning:
+    def test_creates_table_when_absent(self, mock_client: Mock) -> None:
+        from botocore.exceptions import ClientError
+
+        mock_client.describe_table.side_effect = [
+            ClientError(
+                {"Error": {"Code": "ResourceNotFoundException"}}, "DescribeTable"
+            ),
+            {
+                "Table": {
+                    "VectorIndexes": [
+                        {
+                            "IndexName": "documents-vector-index",
+                            "IndexStatus": "ACTIVE",
+                        }
+                    ]
+                }
+            },
+        ]
+        store = _make_store(mock_client)
+        store.add_texts(["hello"])
+        params = mock_client.create_table.call_args.kwargs
+        assert params["TableName"] == "docs"
+        spec = params["VectorIndexes"][0]
+        assert spec["Dimensions"] == 4
+        assert spec["DistanceFunction"] == "COSINE"
+        # Document store searches globally: no SearchSchema partition pinning
+        assert "SearchSchema" not in spec
+
+    def test_retrofits_index_on_existing_table(self, mock_client: Mock) -> None:
+        mock_client.describe_table.side_effect = [
+            {"Table": {"VectorIndexes": []}},
+            {
+                "Table": {
+                    "VectorIndexes": [
+                        {
+                            "IndexName": "documents-vector-index",
+                            "IndexStatus": "ACTIVE",
+                        }
+                    ]
+                }
+            },
+        ]
+        store = _make_store(mock_client)
+        store.add_texts(["hello"])
+        params = mock_client.update_table.call_args.kwargs
+        assert "Create" in params["VectorIndexUpdates"][0]
+
+    def test_no_autocreate_raises(self, mock_client: Mock) -> None:
+        from botocore.exceptions import ClientError
+
+        mock_client.describe_table.side_effect = ClientError(
+            {"Error": {"Code": "ResourceNotFoundException"}}, "DescribeTable"
+        )
+        store = _make_store(mock_client, create_table_if_not_exist=False)
+        with pytest.raises(ValueError, match="does not exist"):
+            store.add_texts(["hello"])
+
+
+class TestAddTexts:
+    def test_writes_items_with_embedding(self, mock_client: Mock) -> None:
+        store = _make_store(mock_client)
+        ids = store.add_texts(["hello", "world"], metadatas=[{"a": 1}, {"a": 2}])
+        assert len(ids) == 2
+        batch = mock_client.batch_write_item.call_args.kwargs["RequestItems"]["docs"]
+        assert len(batch) == 2
+        item = batch[0]["PutRequest"]["Item"]
+        assert item["page_content"]["S"] == "hello"
+        assert len(item["embedding"]["L"]) == 4
+
+    def test_mismatched_metadata_raises(self, mock_client: Mock) -> None:
+        store = _make_store(mock_client)
+        with pytest.raises(ValueError, match="metadatas"):
+            store.add_texts(["a", "b"], metadatas=[{}])
+
+    def test_mismatched_ids_raises(self, mock_client: Mock) -> None:
+        store = _make_store(mock_client)
+        with pytest.raises(ValueError, match="ids"):
+            store.add_texts(["a", "b"], ids=["only-one"])
+
+    def test_unprocessed_items_are_retried(self, mock_client: Mock) -> None:
+        store = _make_store(mock_client)
+        first = {
+            "UnprocessedItems": {"docs": [{"PutRequest": {"Item": {"id": {"S": "x"}}}}]}
+        }
+        mock_client.batch_write_item.side_effect = [first, {}]
+        store.add_texts(["hello"])
+        assert mock_client.batch_write_item.call_count == 2
+
+    def test_empty_texts_noop(self, mock_client: Mock) -> None:
+        store = _make_store(mock_client)
+        assert store.add_texts([]) == []
+        mock_client.batch_write_item.assert_not_called()
+
+
+class TestSearch:
+    def _search_response(self) -> dict:
+        return {
+            "SearchResults": [
+                {
+                    "Item": {
+                        "id": {"S": "doc1"},
+                        "page_content": {"S": "hello"},
+                        "metadata": {"M": {"a": {"N": "1"}}},
+                    },
+                    "Score": 0.25,
+                }
+            ]
+        }
+
+    def test_similarity_search_maps_documents(self, mock_client: Mock) -> None:
+        mock_client.search_vectors.return_value = self._search_response()
+        store = _make_store(mock_client)
+        docs = store.similarity_search("greeting", k=1)
+        assert docs[0].id == "doc1"
+        assert docs[0].page_content == "hello"
+        assert docs[0].metadata == {"a": 1}
+        kwargs = mock_client.search_vectors.call_args.kwargs
+        assert kwargs["TopK"] == 1
+        assert kwargs["IndexName"] == "documents-vector-index"
+
+    def test_with_score_returns_raw_distance(self, mock_client: Mock) -> None:
+        mock_client.search_vectors.return_value = self._search_response()
+        store = _make_store(mock_client)
+        [(_, score)] = store.similarity_search_with_score("greeting", k=1)
+        assert score == 0.25
+
+    def test_k_bounds_enforced(self, mock_client: Mock) -> None:
+        store = _make_store(mock_client)
+        with pytest.raises(ValueError, match="TopK"):
+            store.similarity_search("q", k=_MAX_TOP_K + 1)
+        with pytest.raises(ValueError, match="TopK"):
+            store.similarity_search("q", k=0)
+
+
+class TestRelevanceScores:
+    def test_cosine(self, mock_client: Mock) -> None:
+        fn = _make_store(mock_client)._select_relevance_score_fn()
+        assert fn(0.0) == 1.0  # identical
+        assert fn(2.0) == 0.0  # opposite
+
+    def test_euclidean(self, mock_client: Mock) -> None:
+        store = _make_store(mock_client, distance_function="EUCLIDEAN")
+        fn = store._select_relevance_score_fn()
+        assert fn(0.0) == 1.0
+        assert fn(1.0) == 0.5
+
+    def test_dot_product_preserves_ranking(self, mock_client: Mock) -> None:
+        # DOT_PRODUCT Score is a similarity (higher == more similar); the
+        # relevance conversion must preserve that ordering and stay in (0, 1).
+        store = _make_store(mock_client, distance_function="DOT_PRODUCT")
+        fn = store._select_relevance_score_fn()
+        assert fn(3.0) > fn(-1.0) > fn(-5.0)
+        assert 0.0 < fn(-5.0) and fn(3.0) < 1.0
+
+    def test_override(self, mock_client: Mock) -> None:
+        store = _make_store(mock_client, relevance_score_fn=lambda d: 42.0)
+        assert store._select_relevance_score_fn()(0.1) == 42.0
+
+
+class TestDeleteAndGet:
+    def test_delete_requires_ids(self, mock_client: Mock) -> None:
+        store = _make_store(mock_client)
+        with pytest.raises(ValueError, match="ids is required"):
+            store.delete()
+
+    def test_delete_batches(self, mock_client: Mock) -> None:
+        store = _make_store(mock_client)
+        assert store.delete(ids=[f"id{i}" for i in range(30)]) is True
+        assert mock_client.batch_write_item.call_count == 2  # 25 + 5
+
+    def test_get_by_ids_skips_missing(self, mock_client: Mock) -> None:
+        mock_client.batch_get_item.return_value = {
+            "Responses": {
+                "docs": [
+                    {
+                        "id": {"S": "a"},
+                        "page_content": {"S": "text-a"},
+                        "metadata": {"M": {}},
+                    }
+                ]
+            }
+        }
+        store = _make_store(mock_client)
+        docs = store.get_by_ids(["a", "missing"])
+        assert len(docs) == 1
+        assert docs[0].id == "a"
+
+
+class TestFromTexts:
+    def test_from_texts_provisions_and_adds(self, mock_client: Mock) -> None:
+        store = DynamoDBVectorStore.from_texts(
+            ["hello", "world"],
+            embedding=FakeEmbeddings(),
+            table_name="docs",
+            client=mock_client,
+        )
+        assert isinstance(store, DynamoDBVectorStore)
+        assert mock_client.batch_write_item.called
+
+
+class TestReviewRegressions:
+    """Regressions pinned from the pre-PR critical review."""
+
+    def test_float_metadata_roundtrips(self, mock_client: Mock) -> None:
+        store = _make_store(mock_client)
+        store.add_texts(["hello"], metadatas=[{"score": 0.5, "n": 2, "tags": [1.5]}])
+        item = mock_client.batch_write_item.call_args.kwargs["RequestItems"]["docs"][0][
+            "PutRequest"
+        ]["Item"]
+        # Serialized without TypeError; floats became DynamoDB numbers
+        meta = item["metadata"]["M"]
+        assert meta["score"]["N"] == "0.5"
+        assert meta["n"]["N"] == "2"
+
+    def test_metadata_decimals_normalized_on_read(self, mock_client: Mock) -> None:
+        mock_client.search_vectors.return_value = {
+            "SearchResults": [
+                {
+                    "Item": {
+                        "id": {"S": "d1"},
+                        "page_content": {"S": "x"},
+                        "metadata": {"M": {"score": {"N": "0.5"}, "n": {"N": "2"}}},
+                    },
+                    "Score": 0.1,
+                }
+            ]
+        }
+        store = _make_store(mock_client)
+        [doc] = store.similarity_search("q", k=1)
+        assert doc.metadata == {"score": 0.5, "n": 2}
+        assert isinstance(doc.metadata["score"], float)
+        assert isinstance(doc.metadata["n"], int)
+
+    def test_duplicate_ids_rejected_on_add(self, mock_client: Mock) -> None:
+        store = _make_store(mock_client)
+        with pytest.raises(ValueError, match="unique"):
+            store.add_texts(["a", "b"], ids=["dup", "dup"])
+
+    def test_get_by_ids_tolerates_duplicates(self, mock_client: Mock) -> None:
+        mock_client.batch_get_item.return_value = {
+            "Responses": {
+                "docs": [
+                    {
+                        "id": {"S": "a"},
+                        "page_content": {"S": "t"},
+                        "metadata": {"M": {}},
+                    }
+                ]
+            }
+        }
+        store = _make_store(mock_client)
+        docs = store.get_by_ids(["a", "a"])
+        assert len(docs) == 1
+        keys = mock_client.batch_get_item.call_args.kwargs["RequestItems"]["docs"][
+            "Keys"
+        ]
+        assert keys == [{"id": {"S": "a"}}]
+
+    def test_filter_kwarg_rejected_loudly(self, mock_client: Mock) -> None:
+        store = _make_store(mock_client)
+        with pytest.raises(ValueError, match="filter"):
+            store.similarity_search("q", k=1, filter={"genre": "scifi"})
+        with pytest.raises(ValueError, match="filter"):
+            store.similarity_search_with_score("q", k=1, filter={"a": 1})
+
+    def test_mmr_raises_not_implemented(self, mock_client: Mock) -> None:
+        store = _make_store(mock_client)
+        with pytest.raises(NotImplementedError):
+            store.max_marginal_relevance_search("q", k=1)
+
+    def test_wait_respects_backfilling(self, mock_client: Mock) -> None:
+        mock_client.describe_table.side_effect = [
+            {
+                "Table": {
+                    "VectorIndexes": [
+                        {
+                            "IndexName": "documents-vector-index",
+                            "IndexStatus": "ACTIVE",
+                            "Backfilling": True,
+                        }
+                    ]
+                }
+            },
+            {
+                "Table": {
+                    "VectorIndexes": [
+                        {
+                            "IndexName": "documents-vector-index",
+                            "IndexStatus": "ACTIVE",
+                            "Backfilling": False,
+                        }
+                    ]
+                }
+            },
+        ]
+        store = _make_store(mock_client)
+        store._wait_for_vector_index(timeout=60)
+        assert mock_client.describe_table.call_count == 2
+
+    def test_dims_mismatch_against_existing_index_raises(
+        self, mock_client: Mock
+    ) -> None:
+        mock_client.describe_table.return_value = {
+            "Table": {
+                "VectorIndexes": [
+                    {
+                        "IndexName": "documents-vector-index",
+                        "IndexStatus": "ACTIVE",
+                        "Dimensions": 8,
+                    }
+                ]
+            }
+        }
+        store = _make_store(mock_client)  # FakeEmbeddings emits 4 dims
+        with pytest.raises(ValueError, match="Dimensions"):
+            store.add_texts(["hello"])
+
+    def test_by_vector_direct(self, mock_client: Mock) -> None:
+        mock_client.search_vectors.return_value = {
+            "SearchResults": [
+                {
+                    "Item": {
+                        "id": {"S": "d1"},
+                        "page_content": {"S": "x"},
+                        "metadata": {"M": {}},
+                    },
+                    "Score": 0.3,
+                }
+            ]
+        }
+        store = _make_store(mock_client)
+        [(doc, score)] = store.similarity_search_with_score_by_vector(
+            [0.0, 1.0, 0.0, 0.1], k=1
+        )
+        assert doc.id == "d1" and score == 0.3
+
+    def test_add_documents_and_from_documents_path(self, mock_client: Mock) -> None:
+        from langchain_core.documents import Document
+
+        store = _make_store(mock_client)
+        ids = store.add_documents(
+            [Document(page_content="hello", id="doc-1", metadata={"a": 1})]
+        )
+        assert ids == ["doc-1"]

--- a/libs/aws/tests/unit_tests/vectorstores/test_dynamodb.py
+++ b/libs/aws/tests/unit_tests/vectorstores/test_dynamodb.py
@@ -519,7 +519,7 @@ class TestPartitionScoping:
         store.similarity_search("q", k=3, filter={"category": "shoes"})
         kwargs = mock_client.search_vectors.call_args.kwargs
         assert kwargs["SearchConditionExpression"] == "#pk = :pk"
-        assert kwargs["ExpressionAttributeNames"] == {"#pk": "category"}
+        assert kwargs["ExpressionAttributeNames"]["#pk"] == "category"
         assert kwargs["ExpressionAttributeValues"] == {":pk": {"S": "shoes"}}
 
     def test_search_without_partition_value_raises(self, mock_client: Mock) -> None:
@@ -599,3 +599,65 @@ class TestPartitionScoping:
         store = _make_store(mock_client, partition_attribute="category")
         store.add_texts(["hello"], metadatas=[{"category": "shoes"}])
         mock_client.update_table.assert_not_called()
+
+
+class TestProjectionExpression:
+    """SearchVectors responses are capped at 16 MB with no pagination, so bound
+    what comes back to the attributes a Document actually needs. Unlike the
+    index projection this is a per-request choice, so it costs no immutability.
+    """
+
+    def test_search_bounds_returned_attributes(self, mock_client: Mock) -> None:
+        mock_client.search_vectors.return_value = {"SearchResults": []}
+        store = _make_store(mock_client)
+        store.similarity_search("q")
+        kwargs = mock_client.search_vectors.call_args.kwargs
+        assert kwargs["ProjectionExpression"] == "#id, #c, #m"
+        assert kwargs["ExpressionAttributeNames"] == {
+            "#id": "id",
+            "#c": "page_content",
+            "#m": "metadata",
+        }
+
+    def test_projection_covers_everything_a_document_needs(
+        self, mock_client: Mock
+    ) -> None:
+        """A projected item must still round-trip into a full Document."""
+        mock_client.search_vectors.return_value = {
+            "SearchResults": [
+                {
+                    "Item": {
+                        "id": {"S": "d1"},
+                        "page_content": {"S": "hello"},
+                        "metadata": {"M": {"lang": {"S": "en"}}},
+                    },
+                    "Score": 0.1,
+                }
+            ]
+        }
+        store = _make_store(mock_client)
+        docs = store.similarity_search("q")
+        assert docs[0].id == "d1"
+        assert docs[0].page_content == "hello"
+        assert docs[0].metadata == {"lang": "en"}
+
+    def test_partition_names_merge_with_projection_names(
+        self, mock_client: Mock
+    ) -> None:
+        """Both riders share one ExpressionAttributeNames map; neither wins."""
+        mock_client.search_vectors.return_value = {"SearchResults": []}
+        store = _make_store(
+            mock_client,
+            partition_attribute="category",
+            default_partition_value="general",
+        )
+        store.similarity_search("q")
+        kwargs = mock_client.search_vectors.call_args.kwargs
+        assert kwargs["ExpressionAttributeNames"] == {
+            "#id": "id",
+            "#c": "page_content",
+            "#m": "metadata",
+            "#pk": "category",
+        }
+        assert kwargs["SearchConditionExpression"] == "#pk = :pk"
+        assert kwargs["ProjectionExpression"] == "#id, #c, #m"

--- a/libs/aws/tests/unit_tests/vectorstores/test_dynamodb.py
+++ b/libs/aws/tests/unit_tests/vectorstores/test_dynamodb.py
@@ -373,6 +373,49 @@ class TestReviewRegressions:
         with pytest.raises(ValueError, match="Dimensions"):
             store.add_texts(["hello"])
 
+    def test_distance_function_mismatch_against_existing_index_raises(
+        self, mock_client: Mock
+    ) -> None:
+        """A store pointed at an index with a different metric must fail loudly.
+
+        The service scores using the index's DistanceFunction, but relevance
+        conversion keys off the store's own setting, so a mismatch would
+        otherwise return wrongly-scaled scores with no error.
+        """
+        mock_client.describe_table.return_value = {
+            "Table": {
+                "VectorIndexes": [
+                    {
+                        "IndexName": "documents-vector-index",
+                        "IndexStatus": "ACTIVE",
+                        "Dimensions": 4,
+                        "DistanceFunction": "COSINE",
+                    }
+                ]
+            }
+        }
+        store = _make_store(mock_client, distance_function="EUCLIDEAN")
+        with pytest.raises(ValueError, match="DistanceFunction"):
+            store.add_texts(["hello"])
+
+    def test_matching_distance_function_is_accepted(self, mock_client: Mock) -> None:
+        """Negative control: the same metric must not raise."""
+        mock_client.describe_table.return_value = {
+            "Table": {
+                "VectorIndexes": [
+                    {
+                        "IndexName": "documents-vector-index",
+                        "IndexStatus": "ACTIVE",
+                        "Dimensions": 4,
+                        "DistanceFunction": "EUCLIDEAN",
+                    }
+                ]
+            }
+        }
+        store = _make_store(mock_client, distance_function="EUCLIDEAN")
+        store.add_texts(["hello"])
+        assert mock_client.batch_write_item.called
+
     def test_by_vector_direct(self, mock_client: Mock) -> None:
         mock_client.search_vectors.return_value = {
             "SearchResults": [

--- a/libs/aws/tests/unit_tests/vectorstores/test_dynamodb.py
+++ b/libs/aws/tests/unit_tests/vectorstores/test_dynamodb.py
@@ -661,3 +661,104 @@ class TestProjectionExpression:
         }
         assert kwargs["SearchConditionExpression"] == "#pk = :pk"
         assert kwargs["ProjectionExpression"] == "#id, #c, #m"
+
+
+class TestPartitionAttributeDefinitions:
+    """A SearchSchema element must be declared in AttributeDefinitions.
+
+    Omitting it makes both CreateTable and UpdateTable fail with "One element in
+    SearchSchema is not defined in attribute definitions". This differs from the
+    key-only rule for base tables, where non-key attributes must NOT be
+    declared, so it is easy to get wrong in either direction.
+    """
+
+    def test_create_table_declares_partition_attribute(self, mock_client: Mock) -> None:
+        from botocore.exceptions import ClientError
+
+        mock_client.describe_table.side_effect = [
+            ClientError(
+                {"Error": {"Code": "ResourceNotFoundException", "Message": "x"}},
+                "DescribeTable",
+            ),
+            {
+                "Table": {
+                    "VectorIndexes": [
+                        {
+                            "IndexName": "documents-vector-index",
+                            "IndexStatus": "ACTIVE",
+                        }
+                    ]
+                }
+            },
+        ]
+        store = _make_store(mock_client, partition_attribute="category")
+        store.add_texts(["hello"], metadatas=[{"category": "shoes"}])
+        defs = mock_client.create_table.call_args.kwargs["AttributeDefinitions"]
+        assert {"AttributeName": "category", "AttributeType": "S"} in defs
+        assert {"AttributeName": "id", "AttributeType": "S"} in defs
+
+    def test_create_table_omits_it_when_unpartitioned(self, mock_client: Mock) -> None:
+        """Negative control: a non-key attribute must not be declared."""
+        from botocore.exceptions import ClientError
+
+        mock_client.describe_table.side_effect = [
+            ClientError(
+                {"Error": {"Code": "ResourceNotFoundException", "Message": "x"}},
+                "DescribeTable",
+            ),
+            {
+                "Table": {
+                    "VectorIndexes": [
+                        {
+                            "IndexName": "documents-vector-index",
+                            "IndexStatus": "ACTIVE",
+                        }
+                    ]
+                }
+            },
+        ]
+        store = _make_store(mock_client)
+        store.add_texts(["hello"])
+        defs = mock_client.create_table.call_args.kwargs["AttributeDefinitions"]
+        assert defs == [{"AttributeName": "id", "AttributeType": "S"}]
+
+    def test_retrofit_declares_partition_attribute(self, mock_client: Mock) -> None:
+        """UpdateTable needs the declaration too, not just CreateTable."""
+        mock_client.describe_table.side_effect = [
+            {"Table": {"VectorIndexes": [{"IndexName": "other-index"}]}},
+            {
+                "Table": {
+                    "VectorIndexes": [
+                        {
+                            "IndexName": "documents-vector-index",
+                            "IndexStatus": "ACTIVE",
+                        }
+                    ]
+                }
+            },
+        ]
+        store = _make_store(mock_client, partition_attribute="category")
+        store.add_texts(["hello"], metadatas=[{"category": "shoes"}])
+        kwargs = mock_client.update_table.call_args.kwargs
+        assert kwargs["AttributeDefinitions"] == [
+            {"AttributeName": "category", "AttributeType": "S"}
+        ]
+
+    def test_retrofit_omits_it_when_unpartitioned(self, mock_client: Mock) -> None:
+        """Negative control: no declaration to make without a partition key."""
+        mock_client.describe_table.side_effect = [
+            {"Table": {"VectorIndexes": [{"IndexName": "other-index"}]}},
+            {
+                "Table": {
+                    "VectorIndexes": [
+                        {
+                            "IndexName": "documents-vector-index",
+                            "IndexStatus": "ACTIVE",
+                        }
+                    ]
+                }
+            },
+        ]
+        store = _make_store(mock_client)
+        store.add_texts(["hello"])
+        assert "AttributeDefinitions" not in mock_client.update_table.call_args.kwargs

--- a/libs/aws/uv.lock
+++ b/libs/aws/uv.lock
@@ -226,16 +226,16 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.43.57"
+version = "1.43.64"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/30/324319a914752e4021358ccf8252c04364eb8358f9d41d9c3f021959b363/boto3-1.43.57.tar.gz", hash = "sha256:549c95e45f9b04cf0c69727632dbdda23b84dcd3d0ed7981c6aaff72ef9cb5af", size = 112690, upload-time = "2026-07-27T19:31:09.32Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/da/d5ca15f34a567f2d027df23395315983bd7ee35011e93c1cca12b7f89823/boto3-1.43.64.tar.gz", hash = "sha256:fc7522c3ed97d38176e0b1366406bca0fc8c888ae8d416bf953477b3f015a7b2", size = 112655, upload-time = "2026-08-04T20:12:42.45Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/a4/2c4ee25556a997a81ea01073962cf8351da3707412c584d053b3861d09e8/boto3-1.43.57-py3-none-any.whl", hash = "sha256:115ed9cac409d9b57e2437b52fdb4286660d12a2bd44a0f48d530e68623d09a7", size = 140028, upload-time = "2026-07-27T19:31:07.226Z" },
+    { url = "https://files.pythonhosted.org/packages/15/94/14cf3ec553edf78e5196289087ac52862c87ac179fa1cfdf1022ec366b79/boto3-1.43.64-py3-none-any.whl", hash = "sha256:2b555e63ece57cffb1ab1666fa6c23a0957e61f9d19ea8424d6c884124c3fd98", size = 140024, upload-time = "2026-08-04T20:12:41.147Z" },
 ]
 
 [[package]]
@@ -265,16 +265,16 @@ essential = [
 
 [[package]]
 name = "botocore"
-version = "1.43.57"
+version = "1.43.64"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0b/92/1f8a454cf90bcb0c0e32a25817441cb7f3702fdd76710d7018abad12a2fc/botocore-1.43.57.tar.gz", hash = "sha256:001a5653bebc03b862bde2da63bad4adb0b30072a3f247aba4daae5aa097b546", size = 15739550, upload-time = "2026-07-27T19:30:57.916Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/67/0e39203c5c67f750874478cf89124486044580ec5cb391eec8eb13cf25b8/botocore-1.43.64.tar.gz", hash = "sha256:a2bb131f48111094fae0a2c896b42593797e935d9c22abb2ebae4290c6dbb5ea", size = 15842274, upload-time = "2026-08-04T20:12:31.598Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/7a/1cfe9c296df0fa6e0143c8622b10f21fa8fb9cce25450e9a8e5cf6523e4b/botocore-1.43.57-py3-none-any.whl", hash = "sha256:319c6d79f66c3f3f2b538f7dcdc90e410a15a7bfced1db06479134947e629482", size = 15424433, upload-time = "2026-07-27T19:30:55.08Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/d1/f27d1a4fb571e102828a4672cb3d19e0409275eb92c701b67a85879c0b04/botocore-1.43.64-py3-none-any.whl", hash = "sha256:f0a01c47d631ab95589c244566bca971294724b21862de1c12c7c3b0de236272", size = 15525459, upload-time = "2026-08-04T20:12:28.58Z" },
 ]
 
 [[package]]
@@ -1119,7 +1119,7 @@ requires-dist = [
     { name = "aws-sdk-bedrock-runtime", marker = "python_full_version >= '3.12' and extra == 'nova-sonic'" },
     { name = "beautifulsoup4", marker = "extra == 'tools'", specifier = ">=4.13.4" },
     { name = "bedrock-agentcore", marker = "python_full_version >= '3.10' and extra == 'tools'", specifier = ">=1.4.0" },
-    { name = "boto3", specifier = ">=1.43.32" },
+    { name = "boto3", specifier = ">=1.43.64" },
     { name = "langchain-anthropic", marker = "extra == 'anthropic'" },
     { name = "langchain-core", specifier = ">=1.4.7" },
     { name = "langchain-openai", marker = "extra == 'openai'", specifier = ">=1.0.0" },


### PR DESCRIPTION
Documents are stored as DynamoDB items and searched via a table-level vector index (SearchVectors, approximate nearest neighbor). No separate vector database: the same table serves operational data and retrieval.

- add_texts embeds via embed_documents, writes through BatchWriteItem with unprocessed-item retry and the 25-item service batch limit
- similarity_search / _with_score / _by_vector via SearchVectors; raw distance surfaced as the score, TopK bounds (1..100) enforced loudly
- relevance score conversion per distance function (COSINE, EUCLIDEAN, DOT_PRODUCT) for similarity_search_with_relevance_scores
- setup provisions the table + index, or retrofits the index onto an existing table via UpdateTable VectorIndexUpdates; no SearchSchema so search is global over the corpus
- vector index is eventually consistent (GSI model), documented
- 19 unit tests, fully mocked; ruff/format/mypy clean