### PR TITLE
feat(aws): credential-derived auth for ChatOpenAIMantle

### DIFF
--- a/libs/aws/langchain_aws/chat_models/openai.py
+++ b/libs/aws/langchain_aws/chat_models/openai.py
@@ -31,6 +31,10 @@ from typing_extensions import Self
 
 from langchain_aws._version import _add_langchain_aws_version
 from langchain_aws.data._profiles import _PROFILES
+from langchain_aws.utils import (
+    _BEDROCK_API_KEY_MAX_TTL_SECONDS,
+    _BedrockApiKeyProvider,
+)
 
 _MANTLE_BASE_URL_TEMPLATE = "https://bedrock-mantle.{region}.api.aws/v1"
 
@@ -43,18 +47,29 @@ def _get_default_model_profile(model_name: str) -> ModelProfile:
     return default.copy()
 
 
+def _plain_secret(value: Any) -> str | None:
+    """Return the plain string for a ``SecretStr``/``str``/``None`` value."""
+    if value is None:
+        return None
+    if isinstance(value, SecretStr):
+        return value.get_secret_value()
+    return str(value)
+
+
 class ChatOpenAIMantle(BaseChatOpenAI):
     """OpenAI-compatible GPT/open-weight models via the Amazon Bedrock Mantle endpoint.
 
     Talks to the ``bedrock-mantle`` OpenAI-compatible endpoint
     (``bedrock-mantle.{region}.api.aws``) using the OpenAI Python SDK.
     Authentication uses an Amazon Bedrock API key (bearer token) rather than
-    AWS SigV4.
+    AWS SigV4. Provide it directly (``bedrock_api_key`` /
+    ``AWS_BEARER_TOKEN_BEDROCK``), or omit it and let short-term keys be derived
+    from your AWS credentials and refreshed transparently.
 
     See the [LangChain docs for `ChatOpenAI`](https://docs.langchain.com/oss/python/integrations/chat/openai)
     for tutorials and feature walkthroughs — the same features apply here.
 
-    Example:
+    Example (static bearer token):
         ```python
         # pip install "langchain-aws[openai]"
         # export AWS_BEARER_TOKEN_BEDROCK="your-bedrock-api-key"
@@ -65,6 +80,21 @@ class ChatOpenAIMantle(BaseChatOpenAI):
         model = ChatOpenAIMantle(
             model="openai.gpt-oss-120b",
             region_name="us-east-1",
+        )
+        model.invoke("What is 2 + 2?")
+        ```
+
+    Example (derive short-term keys from AWS credentials):
+        ```python
+        # pip install "langchain-aws[openai]"
+        # Uses the standard boto3 credential chain (env, profile, role, IRSA).
+
+        from langchain_aws import ChatOpenAIMantle
+
+        model = ChatOpenAIMantle(
+            model="openai.gpt-oss-120b",
+            region_name="us-east-1",
+            # optionally: credentials_profile_name="my-profile"
         )
         model.invoke("What is 2 + 2?")
         ```
@@ -92,6 +122,47 @@ class ChatOpenAIMantle(BaseChatOpenAI):
 
     If not provided, read from the ``AWS_BEARER_TOKEN_BEDROCK`` environment
     variable. Sent as the OpenAI ``api_key``.
+
+    When no static key is available (neither this field nor
+    ``AWS_BEARER_TOKEN_BEDROCK``), short-term keys are derived from AWS
+    credentials instead — see ``aws_access_key_id`` below.
+    """
+
+    aws_access_key_id: SecretStr | None = Field(
+        default_factory=secret_from_env("AWS_ACCESS_KEY_ID", default=None)
+    )
+    """AWS access key id used to derive short-term Bedrock API keys.
+
+    Only used when no static ``bedrock_api_key``/``AWS_BEARER_TOKEN_BEDROCK`` is
+    set. If provided, ``aws_secret_access_key`` must also be provided. When
+    omitted, the standard boto3 credential chain (profile, env, IMDS, IRSA, ...)
+    is used. Read from ``AWS_ACCESS_KEY_ID`` when not provided.
+    """
+
+    aws_secret_access_key: SecretStr | None = Field(
+        default_factory=secret_from_env("AWS_SECRET_ACCESS_KEY", default=None)
+    )
+    """AWS secret access key used to derive short-term Bedrock API keys.
+
+    Read from ``AWS_SECRET_ACCESS_KEY`` when not provided.
+    """
+
+    aws_session_token: SecretStr | None = Field(
+        default_factory=secret_from_env("AWS_SESSION_TOKEN", default=None)
+    )
+    """AWS session token for temporary credentials.
+
+    Read from ``AWS_SESSION_TOKEN`` when not provided.
+    """
+
+    credentials_profile_name: str | None = None
+    """Named AWS profile to resolve credentials from when deriving short-term keys."""
+
+    api_key_ttl_seconds: int = _BEDROCK_API_KEY_MAX_TTL_SECONDS
+    """Requested lifetime (seconds) for derived short-term Bedrock API keys.
+
+    Capped by Bedrock's server-side maximum and by the underlying credential
+    lifetime for refreshable credentials (AssumeRole, SSO, IRSA, ...).
     """
 
     @model_validator(mode="before")
@@ -133,11 +204,35 @@ class ChatOpenAIMantle(BaseChatOpenAI):
             values["base_url"] = _MANTLE_BASE_URL_TEMPLATE.format(region=region)
 
         # Route the Bedrock API key into the OpenAI ``api_key`` slot unless the
-        # caller already set one explicitly.
+        # caller already set one explicitly. Precedence:
+        #   1. explicit ``api_key``/``openai_api_key`` -> untouched
+        #   2. static bearer key (``bedrock_api_key`` / ``AWS_BEARER_TOKEN_BEDROCK``)
+        #   3. AWS credentials -> a ``_BedrockApiKeyProvider`` callable that mints
+        #      and transparently refreshes short-term keys. ``langchain_openai``
+        #      accepts a callable ``api_key`` and resolves it per request.
         if not values.get("api_key") and not values.get("openai_api_key"):
-            key = values.get("bedrock_api_key") or os.getenv("AWS_BEARER_TOKEN_BEDROCK")
-            if key:
-                values["api_key"] = key
+            static_key = values.get("bedrock_api_key") or os.getenv(
+                "AWS_BEARER_TOKEN_BEDROCK"
+            )
+            if static_key:
+                values["api_key"] = static_key
+            elif region:
+                # No static token: derive short-term keys from AWS credentials.
+                # Explicitly-passed creds/profile are forwarded; otherwise the
+                # provider falls back to the default boto3 credential chain
+                # (which also covers the AWS_* env vars) at first use.
+                values["api_key"] = _BedrockApiKeyProvider(
+                    region=region,
+                    ttl_seconds=values.get(
+                        "api_key_ttl_seconds", _BEDROCK_API_KEY_MAX_TTL_SECONDS
+                    ),
+                    aws_access_key_id=_plain_secret(values.get("aws_access_key_id")),
+                    aws_secret_access_key=_plain_secret(
+                        values.get("aws_secret_access_key")
+                    ),
+                    aws_session_token=_plain_secret(values.get("aws_session_token")),
+                    credentials_profile_name=values.get("credentials_profile_name"),
+                )
 
         return values
 

--- a/libs/aws/langchain_aws/utils.py
+++ b/libs/aws/langchain_aws/utils.py
@@ -1,7 +1,10 @@
 import logging
 import os
 import re
+import threading
+import time
 from abc import abstractmethod
+from datetime import timedelta
 from typing import Any, Dict, Generic, Iterator, List, Literal, Optional, TypeVar, Union
 
 from botocore.exceptions import BotoCoreError, UnknownServiceError
@@ -552,3 +555,225 @@ def trim_message_whitespace(messages: List[Any]) -> List[Any]:
                     last_message.content[j] = block_dict
 
     return messages
+
+
+class _StaticCredentialProvider:
+    """Wraps resolved botocore credentials in the shape ``provide_token`` expects.
+
+    ``aws_bedrock_token_generator.provide_token`` accepts an
+    ``aws_credentials_provider`` that must expose a ``.load()`` method
+    returning a ``botocore.credentials.Credentials`` (or subclass). This
+    class adapts a pre-resolved credentials object to that contract.
+    """
+
+    METHOD = "explicit"
+
+    def __init__(self, credentials: Any) -> None:
+        self._credentials = credentials
+
+    def load(self) -> Any:
+        return self._credentials
+
+
+#: Server-side maximum lifetime (in seconds) of a short-term Bedrock API
+#: key issued by ``aws-bedrock-token-generator``. Bedrock rejects longer
+#: expiries at the token-verification layer, so this is both the default
+#: and the upper-bound of the ``ttl_seconds`` knob.
+_BEDROCK_API_KEY_MAX_TTL_SECONDS = 43200  # 12 h
+
+
+class _BedrockApiKeyProvider:
+    """Generates and caches short-term Bedrock API keys.
+
+    Uses ``aws-bedrock-token-generator`` to produce short-term API keys from
+    AWS credentials.  Keys are cached and regenerated when near expiry.
+
+    The instance is callable (sync) and also exposes an ``async_call`` method
+    for use with async clients.
+
+    This is the shared building block behind bearer-token authentication for
+    the Bedrock Mantle chat models (``ChatOpenAIMantle`` /
+    ``ChatAnthropicMantle``): rather than requiring a manually-minted static
+    ``AWS_BEARER_TOKEN_BEDROCK``, it derives short-term keys from ordinary AWS
+    credentials (explicit keys, a named profile, or the default chain) and
+    transparently refreshes them.
+
+    See: https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-generate.html
+    """
+
+    # Matches botocore's _DEFAULT_ADVISORY_REFRESH_TIMEOUT (900s) and
+    # _DEFAULT_MANDATORY_REFRESH_TIMEOUT (600s) for credential refresh.
+    _ADVISORY_REFRESH_SECONDS = 900  # try to refresh 15 min before expiry
+    _MANDATORY_REFRESH_SECONDS = 600  # must refresh 10 min before expiry
+
+    def __init__(
+        self,
+        region: str,
+        *,
+        ttl_seconds: int = _BEDROCK_API_KEY_MAX_TTL_SECONDS,
+        aws_access_key_id: Optional[str] = None,
+        aws_secret_access_key: Optional[str] = None,
+        aws_session_token: Optional[str] = None,
+        credentials_profile_name: Optional[str] = None,
+    ) -> None:
+        self._region = region
+        self._ttl_seconds = ttl_seconds
+        self._aws_access_key_id = aws_access_key_id
+        self._aws_secret_access_key = aws_secret_access_key
+        self._aws_session_token = aws_session_token
+        self._credentials_profile_name = credentials_profile_name
+        self._token: str = ""
+        self._expires_at: float = 0.0
+        self._lock = threading.Lock()
+
+    def __call__(self) -> str:
+        """Return a cached API key, refreshing if near expiry.
+
+        Follows botocore's ``RefreshableCredentials._refresh`` pattern:
+        - Outside advisory window: return cached token immediately.
+        - Advisory window (15-10 min before expiry): try non-blocking
+          refresh. If lock is held or refresh fails, return old token.
+        - Mandatory window (<10 min before expiry): block until refresh
+          completes or raise on failure.
+        """
+        if not self._refresh_needed(self._ADVISORY_REFRESH_SECONDS):
+            return self._token
+
+        if self._lock.acquire(blocking=False):
+            try:
+                # Re-check: another thread may have refreshed before we
+                # acquired the lock.
+                if not self._refresh_needed(self._ADVISORY_REFRESH_SECONDS):
+                    return self._token
+                is_mandatory = self._refresh_needed(self._MANDATORY_REFRESH_SECONDS)
+                self._protected_refresh(is_mandatory=is_mandatory)
+                return self._token
+            finally:
+                self._lock.release()
+        elif self._refresh_needed(self._MANDATORY_REFRESH_SECONDS):
+            # Token is close to expiry - must block until refreshed.
+            with self._lock:
+                # Re-check: another thread may have refreshed while we
+                # were waiting for the lock.
+                if not self._refresh_needed(self._MANDATORY_REFRESH_SECONDS):
+                    return self._token
+                self._protected_refresh(is_mandatory=True)
+                return self._token
+
+        # Another thread is refreshing; return current token. self._token is
+        # never empty here because when it is, _refresh_needed() returns True
+        # for the mandatory threshold, so the elif branch above always
+        # triggers and blocks until a token exists.
+        return self._token
+
+    def _refresh_needed(self, refresh_in: int) -> bool:
+        """Check if a refresh is needed within ``refresh_in`` seconds."""
+        if not self._token:
+            return True
+        return time.monotonic() >= self._expires_at - refresh_in
+
+    def _protected_refresh(self, *, is_mandatory: bool) -> None:
+        """Attempt to refresh the token. Only raises if mandatory."""
+        try:
+            self._do_refresh()
+        except Exception:
+            if is_mandatory:
+                raise
+            logger.debug(
+                "Advisory refresh failed, using existing token.",
+                exc_info=True,
+            )
+
+    async def async_call(self) -> str:
+        """Async-compatible version that returns a cached API key.
+
+        Offloads to a thread to avoid blocking the event loop if a
+        token refresh (network call) is needed.
+        """
+        import asyncio
+
+        return await asyncio.to_thread(self)
+
+    @staticmethod
+    def _credentials_seconds_remaining(credentials: Any) -> Optional[int]:
+        """Return remaining lifetime (s) for ``RefreshableCredentials``.
+
+        Uses botocore's ``_seconds_remaining`` - a private method, but
+        stable across botocore versions and the one botocore's own auth
+        code uses internally. If botocore ever renames or removes it,
+        the resulting ``AttributeError`` is swallowed and the caller
+        degrades to its configured TTL.
+
+        Args:
+            credentials: A boto3 / botocore ``Credentials`` instance
+                (any subclass).
+
+        Returns:
+            Remaining seconds if the credentials are a
+            ``RefreshableCredentials`` and report a positive value;
+            ``None`` for static credentials or on any error.
+        """
+        from botocore.credentials import RefreshableCredentials
+
+        if not isinstance(credentials, RefreshableCredentials):
+            return None
+        try:
+            remaining = credentials._seconds_remaining()  # type: ignore[attr-defined]
+        except Exception:
+            logger.debug(
+                "RefreshableCredentials._seconds_remaining() raised; "
+                "falling back to configured TTL.",
+                exc_info=True,
+            )
+            return None
+        return int(remaining) if remaining > 0 else None
+
+    def _do_refresh(self) -> None:
+        from aws_bedrock_token_generator import provide_token
+        from botocore.credentials import Credentials
+        from botocore.session import Session as BotocoreSession
+
+        # Resolve credentials with precedence:
+        # explicit access_key + secret_key > profile > default chain.
+        credentials: Any = None
+        if self._aws_access_key_id and self._aws_secret_access_key:
+            credentials = Credentials(
+                access_key=self._aws_access_key_id,
+                secret_key=self._aws_secret_access_key,
+                token=self._aws_session_token,
+            )
+        else:
+            try:
+                if self._credentials_profile_name:
+                    session = BotocoreSession(profile=self._credentials_profile_name)
+                else:
+                    session = BotocoreSession()
+                credentials = session.get_credentials()
+            except Exception:
+                logger.debug(
+                    "Could not resolve credentials via botocore session; "
+                    "provide_token will fall back to its own default chain.",
+                    exc_info=True,
+                )
+                credentials = None
+
+        # Cap TTL by underlying credential lifetime for refreshable creds
+        # (AssumeRole, SSO, IRSA, etc.). Static creds have no expiry
+        # metadata so we use the configured TTL directly.
+        effective_ttl = self._ttl_seconds
+        remaining = self._credentials_seconds_remaining(credentials)
+        if remaining is not None:
+            effective_ttl = min(self._ttl_seconds, remaining)
+
+        # Wrap the resolved credentials in a CredentialProvider shape so
+        # provide_token uses them; passing None lets provide_token fall
+        # back to its own default resolution.
+        provider = _StaticCredentialProvider(credentials) if credentials else None
+
+        token = provide_token(
+            region=self._region,
+            expiry=timedelta(seconds=effective_ttl),
+            aws_credentials_provider=provider,
+        )
+        self._token = token
+        self._expires_at = time.monotonic() + effective_ttl

--- a/libs/aws/pyproject.toml
+++ b/libs/aws/pyproject.toml
@@ -24,8 +24,8 @@ Repository = "https://github.com/langchain-ai/langchain-aws"
 
 [project.optional-dependencies]
 tools = ["bedrock-agentcore>=1.4.0; python_version>='3.10'", "playwright>=1.53.0", "beautifulsoup4>=4.13.4"]
-anthropic = ["langchain-anthropic", "anthropic[bedrock]"]
-openai = ["langchain-openai>=1.0.0", "openai>=1.106.0"]
+anthropic = ["langchain-anthropic", "anthropic[bedrock]", "aws-bedrock-token-generator>=1.1.0"]
+openai = ["langchain-openai>=1.0.0", "openai>=1.106.0", "aws-bedrock-token-generator>=1.1.0"]
 valkey = ["valkey-glide-sync>=2.0.0"]
 nova-sonic = ["aws-sdk-bedrock-runtime; python_version>='3.12'"]
 
@@ -47,6 +47,7 @@ test = [
     "bedrock-agentcore>=1.4.0",
     "playwright>=1.53.0",
     "beautifulsoup4>=4.13.4",
+    "aws-bedrock-token-generator>=1.1.0",
 ]
 test_integration = [
     "langchain-anthropic",

--- a/libs/aws/tests/integration_tests/chat_models/test_openai.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_openai.py
@@ -1,14 +1,24 @@
 """Standard LangChain integration tests for ChatOpenAIMantle.
 
-These hit the live Amazon Bedrock Mantle endpoint, so they are skipped unless a
-Bedrock API key is available via ``AWS_BEARER_TOKEN_BEDROCK``. Unskip in CI once
-the test account has ``bedrock-mantle`` API permissions configured.
+These hit the live Amazon Bedrock Mantle endpoint and are skipped by default.
+Two independent live checks are provided:
 
-Run locally with::
+1. ``TestOpenAIMantleIntegration`` — the standard suite, run with a static
+   Bedrock API key::
 
-    AWS_REGION=us-east-1 AWS_BEARER_TOKEN_BEDROCK=... \\
-        uv run --group test --group test_integration \\
-        pytest tests/integration_tests/chat_models/test_openai.py -v
+       AWS_REGION=us-east-1 AWS_BEARER_TOKEN_BEDROCK=... \\
+           uv run --group test --group test_integration \\
+           pytest tests/integration_tests/chat_models/test_openai.py -v
+
+2. ``test_credential_derived_auth_live`` — the credential-derived path, which
+   mints and refreshes a short-term key from ordinary AWS credentials (no static
+   token needed). Run with an opt-in flag plus any AWS credentials for a
+   Mantle-enabled account::
+
+       MANTLE_CREDS_E2E=1 AWS_REGION=us-east-1 \\
+           uv run --group test --group test_integration \\
+           pytest tests/integration_tests/chat_models/test_openai.py \\
+           -k credential_derived -v
 """
 
 import os
@@ -19,14 +29,25 @@ from langchain_core.language_models import BaseChatModel
 from langchain_tests.integration_tests import ChatModelIntegrationTests
 
 from langchain_aws import ChatOpenAIMantle
+from langchain_aws.utils import _BedrockApiKeyProvider
 
-# Skip the whole module until a Bedrock Mantle API key (and, in CI, the
+# Static-key path: skip until a Bedrock Mantle API key (and, in CI, the
 # corresponding account permissions) is available.
-pytestmark = pytest.mark.skipif(
+requires_static_key = pytest.mark.skipif(
     not os.getenv("AWS_BEARER_TOKEN_BEDROCK"),
     reason=(
         "Requires a Bedrock Mantle API key in AWS_BEARER_TOKEN_BEDROCK. "
         "Unskip in CI once the test account has bedrock-mantle API permissions."
+    ),
+)
+
+# Credential-derived path: opt-in via a simple flag. Needs only ambient AWS
+# credentials + region for a Mantle-enabled account (no static bearer token).
+requires_aws_creds = pytest.mark.skipif(
+    not os.getenv("MANTLE_CREDS_E2E"),
+    reason=(
+        "Set MANTLE_CREDS_E2E=1 (with AWS credentials + region for a "
+        "Mantle-enabled account) to run the credential-derived auth check."
     ),
 )
 
@@ -35,6 +56,7 @@ pytestmark = pytest.mark.skipif(
 MODEL_NAME = "openai.gpt-oss-120b"
 
 
+@requires_static_key
 class TestOpenAIMantleIntegration(ChatModelIntegrationTests):
     @property
     def chat_model_class(self) -> Type[BaseChatModel]:
@@ -75,3 +97,34 @@ class TestOpenAIMantleIntegration(ChatModelIntegrationTests):
     @property
     def has_structured_output(self) -> bool:
         return False
+
+
+@requires_aws_creds
+def test_credential_derived_auth_live() -> None:
+    """End-to-end: derive a short-term Bedrock key from AWS creds and invoke.
+
+    With no static ``AWS_BEARER_TOKEN_BEDROCK``, ``ChatOpenAIMantle`` installs a
+    ``_BedrockApiKeyProvider`` that mints (and transparently refreshes) a
+    short-term Bedrock API key from the ambient AWS credential chain (env,
+    profile, assumed role, IRSA). This is the credential-derived counterpart to
+    the static-key ``TestOpenAIMantleIntegration`` suite above.
+    """
+    assert not os.getenv("AWS_BEARER_TOKEN_BEDROCK"), (
+        "Unset AWS_BEARER_TOKEN_BEDROCK to exercise the credential-derived path."
+    )
+
+    model = ChatOpenAIMantle(
+        model=MODEL_NAME,
+        region_name=os.getenv("AWS_REGION", "us-east-1"),
+    )
+
+    # The creds-derived provider (not a static key) must be installed and must
+    # mint a real short-term key from the ambient AWS credentials.
+    provider = model.openai_api_key
+    assert isinstance(provider, _BedrockApiKeyProvider)
+    token = provider()
+    assert isinstance(token, str) and token
+
+    response = model.invoke("What is 2 + 2? Reply with just the number.")
+    assert isinstance(response.content, str)
+    assert "4" in response.content

--- a/libs/aws/tests/unit_tests/chat_models/test_openai.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_openai.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, SecretStr
 from pytest import MonkeyPatch
 
 from langchain_aws import ChatOpenAIMantle
+from langchain_aws.utils import _BedrockApiKeyProvider
 
 MODEL_NAME = "openai.gpt-oss-120b"
 
@@ -245,3 +246,87 @@ def test_inherits_openai_features() -> None:
         "_agenerate",
     ):
         assert hasattr(model, attr)
+
+
+# ---------------------------------------------------------------------------
+# Credential-derived (short-term key) authentication path
+# ---------------------------------------------------------------------------
+
+
+def test_provider_installed_when_no_static_key() -> None:
+    """With no static bearer key, a _BedrockApiKeyProvider is used as api_key."""
+    with MonkeyPatch().context() as m:
+        m.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+        m.setenv("AWS_REGION", "us-east-1")
+        model = ChatOpenAIMantle(
+            model=MODEL_NAME,
+            aws_access_key_id=SecretStr("AKIA_TEST"),
+            aws_secret_access_key=SecretStr("SECRET_TEST"),
+            aws_session_token=SecretStr("TOKEN_TEST"),
+        )
+
+    provider = model.openai_api_key
+    assert isinstance(provider, _BedrockApiKeyProvider)
+    assert model.openai_api_base == "https://bedrock-mantle.us-east-1.api.aws/v1"
+    # Explicitly-passed creds are forwarded to the provider.
+    assert provider._region == "us-east-1"
+    assert provider._aws_access_key_id == "AKIA_TEST"
+    assert provider._aws_secret_access_key == "SECRET_TEST"
+    assert provider._aws_session_token == "TOKEN_TEST"
+
+
+def test_static_key_takes_precedence_over_creds() -> None:
+    """A static bedrock_api_key wins over AWS credentials."""
+    with MonkeyPatch().context() as m:
+        m.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+        m.setenv("AWS_REGION", "us-east-1")
+        model = ChatOpenAIMantle(
+            model=MODEL_NAME,
+            bedrock_api_key=SecretStr("bearer-abc"),
+            aws_access_key_id=SecretStr("AKIA_TEST"),
+            aws_secret_access_key=SecretStr("SECRET_TEST"),
+        )
+    assert cast("SecretStr", model.openai_api_key).get_secret_value() == "bearer-abc"
+
+
+def test_explicit_api_key_not_overridden_by_provider() -> None:
+    """An explicit api_key is left untouched (no provider installed)."""
+    with MonkeyPatch().context() as m:
+        m.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+        m.setenv("AWS_REGION", "us-east-1")
+        model = ChatOpenAIMantle(model=MODEL_NAME, api_key=SecretStr("explicit"))
+    assert cast("SecretStr", model.openai_api_key).get_secret_value() == "explicit"
+
+
+def test_provider_forwards_profile_and_ttl() -> None:
+    """Profile name and requested TTL are forwarded; default chain otherwise."""
+    with MonkeyPatch().context() as m:
+        m.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+        m.delenv("AWS_ACCESS_KEY_ID", raising=False)
+        m.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+        m.setenv("AWS_REGION", "us-east-1")
+        model = ChatOpenAIMantle(
+            model=MODEL_NAME,
+            credentials_profile_name="my-profile",
+            api_key_ttl_seconds=1800,
+        )
+    provider = model.openai_api_key
+    assert isinstance(provider, _BedrockApiKeyProvider)
+    assert provider._credentials_profile_name == "my-profile"
+    assert provider._ttl_seconds == 1800
+    assert provider._aws_access_key_id is None
+
+
+def test_installed_provider_mints_token_when_called() -> None:
+    """The installed provider returns a minted short-term key when invoked."""
+    with MonkeyPatch().context() as m:
+        m.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+        m.setenv("AWS_REGION", "us-east-1")
+        model = ChatOpenAIMantle(
+            model=MODEL_NAME,
+            aws_access_key_id=SecretStr("AKIA_TEST"),
+            aws_secret_access_key=SecretStr("SECRET_TEST"),
+        )
+    provider = cast("_BedrockApiKeyProvider", model.openai_api_key)
+    with patch("aws_bedrock_token_generator.provide_token", return_value="tok-xyz"):
+        assert provider() == "tok-xyz"

--- a/libs/aws/tests/unit_tests/test_utils.py
+++ b/libs/aws/tests/unit_tests/test_utils.py
@@ -1,4 +1,6 @@
 import os
+import time
+from datetime import timedelta
 from typing import Any, Dict, Generator, List, Tuple
 from unittest import mock
 
@@ -9,6 +11,9 @@ from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
 from pydantic import SecretStr
 
 from langchain_aws.utils import (
+    _BEDROCK_API_KEY_MAX_TTL_SECONDS,
+    _BedrockApiKeyProvider,
+    _StaticCredentialProvider,
     count_tokens_api_supported_for_model,
     create_aws_client,
     parse_model_provider,
@@ -1130,3 +1135,153 @@ def test_bedrock_runtime_session_region_fallback(
 
     call_kwargs = config_cls.call_args[1]
     assert call_kwargs["region"] == "sa-east-1"
+
+
+# ---------------------------------------------------------------------------
+# _StaticCredentialProvider / _BedrockApiKeyProvider tests
+# ---------------------------------------------------------------------------
+
+
+def _make_provider(**overrides: Any) -> _BedrockApiKeyProvider:
+    """Build a provider with explicit static creds unless overridden."""
+    params: Dict[str, Any] = {
+        "region": "us-east-1",
+        "aws_access_key_id": "AKIA_TEST",
+        "aws_secret_access_key": "SECRET_TEST",
+    }
+    params.update(overrides)
+    return _BedrockApiKeyProvider(**params)
+
+
+def test_static_credential_provider_load() -> None:
+    creds = object()
+    provider = _StaticCredentialProvider(creds)
+    assert provider.load() is creds
+    assert provider.METHOD == "explicit"
+
+
+def test_bedrock_api_key_provider_generates_and_caches() -> None:
+    with mock.patch(
+        "aws_bedrock_token_generator.provide_token", return_value="tok-1"
+    ) as m_provide:
+        provider = _make_provider(aws_session_token="TOKEN_TEST")
+
+        # First call mints the token.
+        assert provider() == "tok-1"
+        # Second call (well within TTL) returns the cached token, no re-mint.
+        assert provider() == "tok-1"
+        m_provide.assert_called_once()
+
+        kwargs = m_provide.call_args[1]
+        assert kwargs["region"] == "us-east-1"
+        assert kwargs["expiry"] == timedelta(seconds=_BEDROCK_API_KEY_MAX_TTL_SECONDS)
+
+        cred_provider = kwargs["aws_credentials_provider"]
+        assert isinstance(cred_provider, _StaticCredentialProvider)
+        loaded = cred_provider.load()
+        assert loaded.access_key == "AKIA_TEST"
+        assert loaded.secret_key == "SECRET_TEST"
+        assert loaded.token == "TOKEN_TEST"
+
+
+def test_bedrock_api_key_provider_profile_resolution() -> None:
+    fake_creds = object()
+    fake_session = mock.MagicMock()
+    fake_session.get_credentials.return_value = fake_creds
+
+    with (
+        mock.patch(
+            "aws_bedrock_token_generator.provide_token", return_value="tok"
+        ) as m_provide,
+        mock.patch("botocore.session.Session", return_value=fake_session) as m_session,
+    ):
+        provider = _BedrockApiKeyProvider(
+            region="us-west-2", credentials_profile_name="my-profile"
+        )
+        assert provider() == "tok"
+
+    m_session.assert_called_once_with(profile="my-profile")
+    cred_provider = m_provide.call_args[1]["aws_credentials_provider"]
+    assert isinstance(cred_provider, _StaticCredentialProvider)
+    assert cred_provider.load() is fake_creds
+
+
+def test_bedrock_api_key_provider_default_chain_when_unresolvable() -> None:
+    """If botocore can't resolve creds, provider is None (default chain)."""
+    fake_session = mock.MagicMock()
+    fake_session.get_credentials.return_value = None
+
+    with (
+        mock.patch(
+            "aws_bedrock_token_generator.provide_token", return_value="tok"
+        ) as m_provide,
+        mock.patch("botocore.session.Session", return_value=fake_session),
+    ):
+        provider = _BedrockApiKeyProvider(region="us-east-1")
+        assert provider() == "tok"
+
+    assert m_provide.call_args[1]["aws_credentials_provider"] is None
+
+
+def test_bedrock_api_key_provider_refreshes_when_near_expiry() -> None:
+    with mock.patch(
+        "aws_bedrock_token_generator.provide_token",
+        side_effect=["tok-1", "tok-2"],
+    ) as m_provide:
+        provider = _make_provider(ttl_seconds=1000)
+        assert provider() == "tok-1"
+
+        # Force the cached token into the mandatory-refresh window.
+        provider._expires_at = time.monotonic() + 100
+        assert provider() == "tok-2"
+        assert m_provide.call_count == 2
+
+
+def test_bedrock_api_key_provider_caps_ttl_to_cred_lifetime() -> None:
+    with (
+        mock.patch(
+            "aws_bedrock_token_generator.provide_token", return_value="tok"
+        ) as m_provide,
+        mock.patch.object(
+            _BedrockApiKeyProvider,
+            "_credentials_seconds_remaining",
+            return_value=300,
+        ),
+    ):
+        provider = _make_provider(ttl_seconds=10000)
+        provider()
+
+    assert m_provide.call_args[1]["expiry"] == timedelta(seconds=300)
+
+
+def test_bedrock_api_key_provider_advisory_failure_keeps_token() -> None:
+    with mock.patch(
+        "aws_bedrock_token_generator.provide_token",
+        side_effect=["tok-1", RuntimeError("boom")],
+    ):
+        provider = _make_provider(ttl_seconds=1000)
+        assert provider() == "tok-1"
+
+        # Advisory window (needs refresh) but not yet mandatory: 700s remaining.
+        provider._expires_at = time.monotonic() + 700
+        # Refresh fails but is non-mandatory, so the stale token is returned.
+        assert provider() == "tok-1"
+
+
+def test_bedrock_api_key_provider_mandatory_failure_raises() -> None:
+    with mock.patch(
+        "aws_bedrock_token_generator.provide_token",
+        side_effect=["tok-1", RuntimeError("boom")],
+    ):
+        provider = _make_provider(ttl_seconds=1000)
+        assert provider() == "tok-1"
+
+        provider._expires_at = time.monotonic() + 100  # mandatory window
+        with pytest.raises(RuntimeError, match="boom"):
+            provider()
+
+
+async def test_bedrock_api_key_provider_async_call() -> None:
+    with mock.patch("aws_bedrock_token_generator.provide_token", return_value="tok"):
+        provider = _make_provider()
+        assert await provider.async_call() == "tok"

--- a/libs/aws/uv.lock
+++ b/libs/aws/uv.lock
@@ -120,13 +120,25 @@ wheels = [
 ]
 
 [[package]]
+name = "aws-bedrock-token-generator"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/39/cf1c2e12bc5a84af0f96a546481213f81fa6e7927d2bbabd81758c6558ca/aws_bedrock_token_generator-1.1.0.tar.gz", hash = "sha256:95ccb07f63a91ac486561f6df05cc4e04784c8ff5086dc687ed9c5fd3ab1b5ba", size = 19123, upload-time = "2025-07-29T19:53:19.511Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/fd/745ece98870c3824d294bcdce5dc5e15381188a41bc80832c246b205e40e/aws_bedrock_token_generator-1.1.0-py3-none-any.whl", hash = "sha256:bd12854f7c7e52dde5d980d369379f12d0cc5f0855099d87f38688b0f9de5cd4", size = 10291, upload-time = "2025-07-29T19:53:18.704Z" },
+]
+
+[[package]]
 name = "aws-sdk-bedrock-runtime"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "smithy-aws-core", extra = ["eventstream", "json"], marker = "python_full_version >= '3.12'" },
-    { name = "smithy-core", marker = "python_full_version >= '3.12'" },
-    { name = "smithy-http", extra = ["awscrt"], marker = "python_full_version >= '3.12'" },
+    { name = "smithy-aws-core", extra = ["eventstream", "json"] },
+    { name = "smithy-core" },
+    { name = "smithy-http", extra = ["awscrt"] },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cf/87/9838dcccf9f77fbc9668b8e6813169118495e0bd6a44d97adc797773c5c7/aws_sdk_bedrock_runtime-0.8.0.tar.gz", hash = "sha256:a6e67f435a1a597bac4d61841eeceae095fd0caaaef78e5d7bf11878018a32b2", size = 171881, upload-time = "2026-07-31T22:25:09.29Z" }
 wheels = [
@@ -642,7 +654,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1057,12 +1069,14 @@ dependencies = [
 [package.optional-dependencies]
 anthropic = [
     { name = "anthropic", extra = ["bedrock"] },
+    { name = "aws-bedrock-token-generator" },
     { name = "langchain-anthropic" },
 ]
 nova-sonic = [
     { name = "aws-sdk-bedrock-runtime", marker = "python_full_version >= '3.12'" },
 ]
 openai = [
+    { name = "aws-bedrock-token-generator" },
     { name = "langchain-openai" },
     { name = "openai" },
 ]
@@ -1085,6 +1099,7 @@ lint = [
 ]
 test = [
     { name = "anthropic", extra = ["bedrock"] },
+    { name = "aws-bedrock-token-generator" },
     { name = "beautifulsoup4" },
     { name = "bedrock-agentcore" },
     { name = "langchain" },
@@ -1116,6 +1131,8 @@ typing = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic", extras = ["bedrock"], marker = "extra == 'anthropic'" },
+    { name = "aws-bedrock-token-generator", marker = "extra == 'anthropic'", specifier = ">=1.1.0" },
+    { name = "aws-bedrock-token-generator", marker = "extra == 'openai'", specifier = ">=1.1.0" },
     { name = "aws-sdk-bedrock-runtime", marker = "python_full_version >= '3.12' and extra == 'nova-sonic'" },
     { name = "beautifulsoup4", marker = "extra == 'tools'", specifier = ">=4.13.4" },
     { name = "bedrock-agentcore", marker = "python_full_version >= '3.10' and extra == 'tools'", specifier = ">=1.4.0" },
@@ -1139,6 +1156,7 @@ dev = [
 lint = [{ name = "ruff", specifier = ">=0.13.0" }]
 test = [
     { name = "anthropic", extras = ["bedrock"] },
+    { name = "aws-bedrock-token-generator", specifier = ">=1.1.0" },
     { name = "beautifulsoup4", specifier = ">=4.13.4" },
     { name = "bedrock-agentcore", specifier = ">=1.4.0" },
     { name = "langchain", specifier = ">=1.0.0" },
@@ -2537,9 +2555,9 @@ name = "smithy-aws-core"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aws-sdk-signers", marker = "python_full_version >= '3.12'" },
-    { name = "smithy-core", marker = "python_full_version >= '3.12'" },
-    { name = "smithy-http", marker = "python_full_version >= '3.12'" },
+    { name = "aws-sdk-signers" },
+    { name = "smithy-core" },
+    { name = "smithy-http" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8a/f4/e73c518fb41e8a47b75df6a715732faf306897e4fca6eeba5d077416a4bf/smithy_aws_core-0.8.0.tar.gz", hash = "sha256:c99c6765ed2fe7e96d24c177a154b9b94aa7aa15761f613d38c54be4e779f27d", size = 30909, upload-time = "2026-07-31T22:24:57.927Z" }
 wheels = [
@@ -2548,10 +2566,10 @@ wheels = [
 
 [package.optional-dependencies]
 eventstream = [
-    { name = "smithy-aws-event-stream", marker = "python_full_version >= '3.12'" },
+    { name = "smithy-aws-event-stream" },
 ]
 json = [
-    { name = "smithy-json", marker = "python_full_version >= '3.12'" },
+    { name = "smithy-json" },
 ]
 
 [[package]]
@@ -2559,7 +2577,7 @@ name = "smithy-aws-event-stream"
 version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "smithy-core", marker = "python_full_version >= '3.12'" },
+    { name = "smithy-core" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/0e/6efb3a4ed92c0f1ada6de060ac92e7115a1e34d0ab1fb99a6056734a88ea/smithy_aws_event_stream-0.3.0.tar.gz", hash = "sha256:a0e227367a973144e205a075d0a424f95c92f26656a1018d08900da2ae547c49", size = 12818, upload-time = "2026-05-05T18:04:14.317Z" }
 wheels = [
@@ -2580,7 +2598,7 @@ name = "smithy-http"
 version = "0.4.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "smithy-core", marker = "python_full_version >= '3.12'" },
+    { name = "smithy-core" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1e/d1/b857d2b9d8aef45a978d99d6f1818ba0cbcc4375b4fd06a90928787c4688/smithy_http-0.4.3.tar.gz", hash = "sha256:74022d52f2b6d62d2fc40194b0143304ceac6ac0da510cf100621afa7ed76232", size = 30002, upload-time = "2026-07-31T22:24:55.997Z" }
 wheels = [
@@ -2589,7 +2607,7 @@ wheels = [
 
 [package.optional-dependencies]
 awscrt = [
-    { name = "awscrt", marker = "python_full_version >= '3.12'" },
+    { name = "awscrt" },
 ]
 
 [[package]]
@@ -2597,8 +2615,8 @@ name = "smithy-json"
 version = "0.2.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ijson", marker = "python_full_version >= '3.12'" },
-    { name = "smithy-core", marker = "python_full_version >= '3.12'" },
+    { name = "ijson" },
+    { name = "smithy-core" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/6c/418b5687d8933b7a135d5e1a98c61fe814b98f72517dbae0e666860cb876/smithy_json-0.2.3.tar.gz", hash = "sha256:686e9b55a36dacb08e472732b358573ef78009055e05e9fce2e806d61490b2b3", size = 7805, upload-time = "2026-06-23T04:04:47.71Z" }
 wheels = [


### PR DESCRIPTION
## Summary

Adds a shared `_BedrockApiKeyProvider` utility (`langchain_aws.utils`) that mints and transparently refreshes **short-term Bedrock API keys from the standard AWS credential chain** (via `aws-bedrock-token-generator`), and wires it into `ChatOpenAIMantle`.

When no static Bedrock API key is provided, authentication is now derived from ordinary AWS credentials — explicit keys, a named profile, or the default chain (env / assumed role / IRSA) — instead of requiring a manually-minted `AWS_BEARER_TOKEN_BEDROCK`. Keys are cached and refreshed near expiry, with the TTL capped by the underlying credential lifetime.

Auth precedence (fully backward compatible):
`api_key` (explicit) → static `bedrock_api_key` / `AWS_BEARER_TOKEN_BEDROCK` → credential-derived provider.

The `_BedrockApiKeyProvider` implementation is derived from @rishabhagrawal1's work in the closed PR #1018, abstracted here into a shared utility for reuse across the Bedrock Mantle chat models. It is the credential-refresh follow-up noted in #1189.

## Reviewer verification

The credential-derived path has a dedicated, opt-in live integration test — no static bearer token needed, just AWS credentials + a region for a Mantle-enabled account. From `libs/aws/`:

```
MANTLE_CREDS_E2E=1 AWS_REGION=us-east-1 \
  uv run --group test --group test_integration \
  pytest tests/integration_tests/chat_models/test_openai.py -k credential_derived -v
```

It asserts the credential-derived provider is installed, mints a real short-term key from your AWS credentials, and invokes `openai.gpt-oss-120b`. The static-key standard suite is unchanged; unit tests (mocked) cover generation, caching, and refresh behavior.
