### PR TITLE
fix(langgraph-checkpoint-aws): validate an existing vector index in setup()

### DIFF
--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/store/dynamodb/table.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/store/dynamodb/table.py
@@ -14,7 +14,7 @@ from typing import Any, cast
 
 from botocore.exceptions import ClientError
 
-from .exceptions import TableCreationError
+from .exceptions import TableCreationError, ValidationError
 from .vector import _VECTOR_ATTR, _VECTOR_INDEX_NAME
 
 logger = logging.getLogger(__name__)
@@ -61,9 +61,18 @@ class DynamoDBTableSetupMixin:
                     "list[dict[str, Any]]",
                     resp["Table"].get("VectorIndexes", []),
                 )
-                index_names = [i["IndexName"] for i in existing_indexes]
-                if _VECTOR_INDEX_NAME not in index_names:
+                existing = next(
+                    (
+                        i
+                        for i in existing_indexes
+                        if i.get("IndexName") == _VECTOR_INDEX_NAME
+                    ),
+                    None,
+                )
+                if existing is None:
                     self._create_vector_index()
+                else:
+                    self._validate_existing_vector_index(existing)
 
         except ClientError as e:
             if e.response["Error"]["Code"] == "ResourceNotFoundException":
@@ -138,6 +147,45 @@ class DynamoDBTableSetupMixin:
             raise TableCreationError(
                 f"Failed to create table '{self.table_name}': {e}"
             ) from e
+
+    def _validate_existing_vector_index(self, index: dict[str, Any]) -> None:
+        """Check an existing vector index matches this store's configuration.
+
+        ``Dimensions`` and ``DistanceFunction`` are immutable after index
+        creation, so a store configured differently from the index it points at
+        cannot be reconciled at runtime. Both mismatches are silent by default:
+        a wrong dimension count fails later at write time with a service-level
+        error that doesn't name the index, and a wrong distance function never
+        fails at all. The service scores using the index's metric while
+        ``_distance_to_score`` converts using this store's setting, so
+        ``search()`` returns wrongly-scaled scores in the right order.
+
+        Raises:
+            ValidationError: If dimensions or distance function disagree.
+        """
+        existing_dims = index.get("Dimensions")
+        if existing_dims is not None and existing_dims != self._dims:
+            raise ValidationError(
+                f"Vector index '{_VECTOR_INDEX_NAME}' on table "
+                f"'{self.table_name}' has Dimensions={existing_dims} but this "
+                f"store is configured for {self._dims}. Index dimensions "
+                "cannot be changed after creation. Set index 'dims' to "
+                f"{existing_dims}, use an embedding model with that output "
+                "size, or point the store at a different table."
+            )
+
+        existing_fn = index.get("DistanceFunction")
+        if existing_fn is not None and existing_fn != self._distance_function:
+            raise ValidationError(
+                f"Vector index '{_VECTOR_INDEX_NAME}' on table "
+                f"'{self.table_name}' has DistanceFunction={existing_fn} but "
+                f"this store is configured for {self._distance_function}. The "
+                "index metric cannot be changed after creation, and searches "
+                f"would be scored by {existing_fn} while scores were converted "
+                f"for {self._distance_function}. Set index "
+                f"'distance_function' to '{existing_fn}' or point the store at "
+                "a different table."
+            )
 
     def _create_vector_index(self) -> None:
         """Add a vector index to an existing table via UpdateTable."""

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/store/dynamodb/test_vector_store.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/store/dynamodb/test_vector_store.py
@@ -283,6 +283,61 @@ def _active(name=_VECTOR_INDEX_NAME, status="ACTIVE"):
     return {"Table": {"VectorIndexes": [{"IndexName": name, "IndexStatus": status}]}}
 
 
+class TestExistingIndexValidation:
+    """setup() previously matched on IndexName alone, so a store pointed at an
+    index with different geometry was accepted. Dimensions and DistanceFunction
+    are immutable after creation, and a distance mismatch never fails: the
+    service scores by the index metric while _distance_to_score converts for
+    the store's setting, silently returning wrongly-scaled scores."""
+
+    def _describe(self, **index_fields):
+        idx = {"IndexName": _VECTOR_INDEX_NAME, "IndexStatus": "ACTIVE"}
+        idx.update(index_fields)
+        return {"Table": {"VectorIndexes": [idx]}}
+
+    def test_dims_mismatch_raises(self, mock_client):
+        store = _store_with_index(mock_client, dim=4)
+        mock_client.describe_table.return_value = self._describe(
+            Dimensions=1024, DistanceFunction="COSINE"
+        )
+        with pytest.raises(ValidationError, match="Dimensions"):
+            store.setup()
+
+    def test_distance_function_mismatch_raises(self, mock_client):
+        store = _store_with_index(mock_client, dim=4, distance="EUCLIDEAN")
+        mock_client.describe_table.return_value = self._describe(
+            Dimensions=4, DistanceFunction="COSINE"
+        )
+        with pytest.raises(ValidationError, match="DistanceFunction"):
+            store.setup()
+
+    def test_matching_index_is_accepted(self, mock_client):
+        """Negative control: a matching index must not raise or recreate."""
+        store = _store_with_index(mock_client, dim=4, distance="EUCLIDEAN")
+        mock_client.describe_table.return_value = self._describe(
+            Dimensions=4, DistanceFunction="EUCLIDEAN"
+        )
+        store.setup()
+        mock_client.update_table.assert_not_called()
+
+    def test_index_without_geometry_fields_is_accepted(self, mock_client):
+        """DescribeTable omitting the fields must not fail the store."""
+        store = _store_with_index(mock_client, dim=4)
+        mock_client.describe_table.return_value = _active()
+        store.setup()
+        mock_client.update_table.assert_not_called()
+
+    def test_absent_index_is_still_created(self, mock_client):
+        """The create path must survive the refactor from name matching."""
+        store = _store_with_index(mock_client, dim=4)
+        mock_client.describe_table.side_effect = [
+            {"Table": {"VectorIndexes": [{"IndexName": "other-index"}]}},
+            _active(),
+        ]
+        store.setup()
+        assert mock_client.update_table.called
+
+
 class TestCreateVectorIndex:
     """_create_vector_index mutates infrastructure; pin its request shape
     and failure modes."""


### PR DESCRIPTION
`DynamoDBStore.setup()` matched an existing vector index on `IndexName` alone, so a store pointed at a table whose index was created with different geometry was accepted silently. `Dimensions` and `DistanceFunction` are both immutable after index creation, so neither can be reconciled at runtime.

Both mismatches were silent, in different ways:

- **Dimensions.** A wrong count passed `setup()` and also passed the store's put-time check, which compares the embedding model's output against the *configured* `dims` rather than against the index. It then failed later at write time with a service error that does not name the index.
- **DistanceFunction.** This never failed at all. The service scores using the index's metric, while `_distance_to_score` converts using the store's configured metric, so `search()` returns wrongly-scaled scores in the correct order. Any caller thresholding on `score` to decide whether a memory is relevant gets silently wrong answers.

`setup()` now looks the index up by name and validates both fields, raising `ValidationError` that names the existing value, the configured value, and the fix. An index whose description omits those fields is accepted unchanged.

### Testing

Five unit tests: both mismatches raise, a matching index neither raises nor recreates, a description without geometry fields is accepted, and a negative control confirms the create path still fires when the index is absent (that path was refactored away from name matching).

Gates on this branch: 1077 unit tests pass, `ruff check` clean, `ruff format --check` clean, `mypy` clean on both `langgraph_checkpoint_aws` and `tests`.

### Context

Found while addressing the same defect class in the `DynamoDBVectorStore` review (#1200), where @michaelnchin reproduced the distance-function case: two stores over one table, the second set to `EUCLIDEAN` against a `COSINE` index, returning 0.69 vs 0.62 for the same document and query. The equivalent fix for that PR is in its own branch. This one covers the `DynamoDBStore` shipped in #1199.
