### PR TITLE
fix(langgraph-checkpoint-aws): mark patched orphan tool_call placeholders with a provenance flag

### DIFF
--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/agentcore/helpers.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/agentcore/helpers.py
@@ -617,6 +617,7 @@ def patch_orphan_tool_calls(messages: list[Any]) -> list[Any]:
                             name=tc_name,
                             tool_call_id=tc_id,
                             status="error",
+                            additional_kwargs={"orphan_tool_call_placeholder": True},
                         )
                     )
 

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_patch_orphan_tool_calls.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_patch_orphan_tool_calls.py
@@ -99,3 +99,37 @@ class TestPatchOrphanToolCalls:
         assert result[1].status == "error"
         assert result[2].tool_call_id == "orphan_2"
         assert result[2].status == "error"
+
+    def test_orphan_placeholder_carries_provenance_flag(self):
+        messages = [
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {"id": "orphan_123", "name": "get_weather", "args": {}},
+                ],
+            ),
+        ]
+
+        result = patch_orphan_tool_calls(messages)
+
+        assert len(result) == 2
+        assert result[1].additional_kwargs["orphan_tool_call_placeholder"] is True
+
+    def test_real_tool_message_not_flagged(self):
+        messages = [
+            AIMessage(
+                content="",
+                tool_calls=[{"id": "tool_123", "name": "get_weather", "args": {}}],
+            ),
+            ToolMessage(
+                content="Sunny, 75F",
+                tool_call_id="tool_123",
+                additional_kwargs={"some_provider_key": "value"},
+            ),
+        ]
+
+        result = patch_orphan_tool_calls(messages)
+
+        assert len(result) == 2
+        assert isinstance(result[1], ToolMessage)
+        assert "orphan_tool_call_placeholder" not in result[1].additional_kwargs


### PR DESCRIPTION
Fixes #1209

The placeholder ToolMessage for orphaned tool_calls carried no marker: it's regenerated on every read and looks like an ordinary error result, so consumers can't tell "synthetic" from "real" and a mid-flight race stays silent.

The issue's other option (gating on an in-flight signal) needs a schema field that doesn't exist — pending writes only land after the tool returns — so I went with the additive one: mark the placeholder. `additional_kwargs` already carries checkpoint metadata in this module (`event_id`), so it's the natural place.

Diff is one line in `patch_orphan_tool_calls` plus two tests (placeholder is flagged, a real ToolMessage isn't). Mutation: reverting the source hunk fails the new test, restores 9/9; agentcore suite 123 passed; lint clean; CI green.

Worth noting this makes the ambiguity detectable, not resolved — eliminating it needs the schema-level in-flight signal, left as a follow-up.

Part of this work was done using an AI coding assistant; tests and the final diff were manually reviewed.