### PR TITLE
test(aws): Strip Bedrock API key var from unit test env

### DIFF
--- a/libs/aws/Makefile
+++ b/libs/aws/Makefile
@@ -24,10 +24,10 @@ integration_test integration_tests: TEST_FILE = tests/integration_tests/
 PYTHON_FILES=.
 
 tests: ## Run all unit tests
-	env -u AWS_ACCESS_KEY_ID -u AWS_SECRET_ACCESS_KEY -u AWS_SESSION_TOKEN -u BEDROCK_AWS_ACCESS_KEY_ID -u BEDROCK_AWS_SECRET_ACCESS_KEY uv run --group test pytest --disable-socket --allow-unix-socket $(TEST_FILE)
+	env -u AWS_ACCESS_KEY_ID -u AWS_SECRET_ACCESS_KEY -u AWS_SESSION_TOKEN -u AWS_BEARER_TOKEN_BEDROCK -u BEDROCK_AWS_ACCESS_KEY_ID -u BEDROCK_AWS_SECRET_ACCESS_KEY uv run --group test pytest --disable-socket --allow-unix-socket $(TEST_FILE)
 
 test:  ## Run individual unit test: make test TEST_FILE=tests/unit_test/test.py
-	env -u AWS_ACCESS_KEY_ID -u AWS_SECRET_ACCESS_KEY -u AWS_SESSION_TOKEN -u BEDROCK_AWS_ACCESS_KEY_ID -u BEDROCK_AWS_SECRET_ACCESS_KEY uv run --group test pytest --disable-socket --allow-unix-socket $(TEST_FILE)
+	env -u AWS_ACCESS_KEY_ID -u AWS_SECRET_ACCESS_KEY -u AWS_SESSION_TOKEN -u AWS_BEARER_TOKEN_BEDROCK -u BEDROCK_AWS_ACCESS_KEY_ID -u BEDROCK_AWS_SECRET_ACCESS_KEY uv run --group test pytest --disable-socket --allow-unix-socket $(TEST_FILE)
 
 integration_tests: ## Run all integration tests
 	uv run --group test --group test_integration pytest -n auto --benchmark-disable $(TEST_FILE)
@@ -45,7 +45,7 @@ coverage_integration_test: ## Run specific integration test with coverage: make 
 	uv run --group test --group test_integration pytest --cov=langchain_aws --cov-report=html --cov-report=term-missing --cov-branch $(TEST_FILE)
 
 coverage_tests: ## Run unit tests with coverage
-	env -u AWS_ACCESS_KEY_ID -u AWS_SECRET_ACCESS_KEY -u AWS_SESSION_TOKEN -u BEDROCK_AWS_ACCESS_KEY_ID -u BEDROCK_AWS_SECRET_ACCESS_KEY uv run --group test pytest --cov=langchain_aws --cov-report=html --cov-report=term-missing --cov-branch tests/unit_tests/
+	env -u AWS_ACCESS_KEY_ID -u AWS_SECRET_ACCESS_KEY -u AWS_SESSION_TOKEN -u AWS_BEARER_TOKEN_BEDROCK -u BEDROCK_AWS_ACCESS_KEY_ID -u BEDROCK_AWS_SECRET_ACCESS_KEY uv run --group test pytest --cov=langchain_aws --cov-report=html --cov-report=term-missing --cov-branch tests/unit_tests/
 
 coverage_report: ## Generate coverage report
 	uv run --group test coverage report


### PR DESCRIPTION
Fixing an issue where `test_chat_anthropic_bedrock_client_initialization` fails when a Bedrock API key var is already present in the local env (the Anthropic SDK's `AnthropicBedrock` client picks it up and explicitly rejects it while we try to pass SigV4 creds explicitly). 

The Makefile's unit test target cmds are now updated to include `-u AWS_BEARER_TOKEN_BEDROCK`, as we already do fo for the other AWS cred env vars.