### PR TITLE
fix(aws): ignore unsupported cross-provider AI blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,11 @@ celerybeat.pid
 # Environments
 .env
 .envrc
+.env.*
+*.pem
+*.key
+*.crt
+credentials.json
 .venv*
 venv*
 env/

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -17,6 +17,7 @@ from typing import (
     Mapping,
     Optional,
     Sequence,
+    Set,
     Tuple,
     Type,
     TypeVar,
@@ -88,16 +89,29 @@ from langchain_aws.utils import (
 
 logger = logging.getLogger(__name__)
 
-# These Converse content blocks are represented as ``non_standard`` by
-# langchain-core because they do not have a LangChain content block type.
-_BEDROCK_NON_STANDARD_CONTENT_BLOCK_KEYS = frozenset(
+# Top-level keys of a Converse ContentBlock. Blocks keyed only by these are
+# native to Bedrock even when langchain-core wraps them as ``non_standard``
+# for lack of a matching LangChain content block type.
+_BEDROCK_CONTENT_BLOCK_KEYS = frozenset(
     {
         "cachePoint",
         "citationsContent",
+        "document",
         "guardContent",
+        "image",
+        "json",
+        "reasoningContent",
         "redactedContent",
+        "text",
+        "toolResult",
+        "toolUse",
+        "video",
     }
 )
+
+# Block types already reported as dropped, so each distinct type warns once per
+# process instead of on every request that replays the same history.
+_warned_dropped_block_types: Set[str] = set()
 
 _MAX_CACHE_POINTS = 4
 _MODEL_PROFILES = cast("ModelProfileRegistry", _PROFILES)
@@ -2283,6 +2297,8 @@ def _messages_to_bedrock(
         elif isinstance(msg, AIMessage):
             content = _upsert_tool_calls_to_bedrock_content(content, msg.tool_calls)
             if not content:
+                # Every block was dropped as unsupported, and Bedrock rejects an
+                # empty content list.
                 content = [{"text": EMPTY_CONTENT}]
             bedrock_messages.append({"role": "assistant", "content": content})
         elif isinstance(msg, SystemMessage):
@@ -2857,7 +2873,9 @@ def _lc_content_to_bedrock(
                 {
                     "toolResult": {
                         "toolUseId": block["toolUseId"],
-                        "content": _lc_content_to_bedrock(block["content"]),
+                        "content": _lc_content_to_bedrock(
+                            block["content"], drop_unsupported=drop_unsupported
+                        ),
                         "status": "error" if block.get("isError") else "success",
                     }
                 }
@@ -2868,7 +2886,9 @@ def _lc_content_to_bedrock(
                 {
                     "toolResult": {
                         "toolUseId": block["toolUseId"],
-                        "content": _lc_content_to_bedrock(block["content"]),
+                        "content": _lc_content_to_bedrock(
+                            block["content"], drop_unsupported=drop_unsupported
+                        ),
                         "status": "error" if block.get("isError") else "success",
                     }
                 }
@@ -2920,10 +2940,7 @@ def _lc_content_to_bedrock(
             # content_blocks wrapped it.
             bedrock_content.append(block["value"])
         elif drop_unsupported:
-            logger.debug(
-                "Dropping unsupported AI message content block type: %s",
-                block["type"],
-            )
+            _log_dropped_block(block)
         else:
             raise ValueError(f"Unsupported content block type:\n{block}")
     # drop empty text blocks
@@ -2931,11 +2948,31 @@ def _lc_content_to_bedrock(
 
 
 def _is_bedrock_non_standard_content_block(value: Any) -> bool:
-    """Return whether a normalized non-standard block is native to Bedrock."""
+    """Return whether a normalized non-standard block is native to Bedrock.
+
+    A block qualifies when every key is a Converse ContentBlock key, so that
+    combined blocks (e.g. ``{"text": ..., "cachePoint": ...}``) are recognized
+    while foreign provider blocks are not.
+    """
     return (
         isinstance(value, dict)
-        and len(value) == 1
-        and next(iter(value)) in _BEDROCK_NON_STANDARD_CONTENT_BLOCK_KEYS
+        and bool(value)
+        and value.keys() <= _BEDROCK_CONTENT_BLOCK_KEYS
+    )
+
+
+def _log_dropped_block(block: Dict[str, Any]) -> None:
+    """Report a content block dropped because Bedrock has no equivalent."""
+    block_type = block["type"]
+    if block_type in _warned_dropped_block_types:
+        logger.debug("Dropping unsupported content block: %s", block)
+        return
+    _warned_dropped_block_types.add(block_type)
+    logger.warning(
+        "Dropping unsupported content block of type %r: Bedrock has no "
+        "equivalent, so it cannot be sent. Further blocks of this type are "
+        "logged at debug level.",
+        block_type,
     )
 
 

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -17,7 +17,6 @@ from typing import (
     Mapping,
     Optional,
     Sequence,
-    Set,
     Tuple,
     Type,
     TypeVar,
@@ -96,6 +95,7 @@ logger = logging.getLogger(__name__)
 #
 # Keep in sync with the botocore `bedrock-runtime` service model; a member
 # missing here is silently dropped from assistant turns.
+# `test__bedrock_content_block_keys_match_botocore` fails when the two drift.
 _BEDROCK_CONTENT_BLOCK_KEYS = frozenset(
     {
         "audio",
@@ -115,13 +115,6 @@ _BEDROCK_CONTENT_BLOCK_KEYS = frozenset(
         "video",
     }
 )
-
-# Dropped-block keys already reported, so each distinct kind of block warns once
-# per process instead of on every request that replays the same history. Grows
-# unbounded in principle, but is bounded in practice by the block vocabulary a
-# process actually sees. Mutated without a lock: a lost race costs a duplicate
-# warning, nothing more.
-_warned_dropped_block_types: Set[str] = set()
 
 _MAX_CACHE_POINTS = 4
 _MODEL_PROFILES = cast("ModelProfileRegistry", _PROFILES)
@@ -2292,6 +2285,11 @@ def _messages_to_bedrock(
         bedrock_system.extend(sys_param_to_bedrock)
 
     for msg_idx, msg in enumerate(messages):
+        # Dropping is scoped to assistant turns: that is where replayed
+        # cross-provider history shows up, and where a rejected block would
+        # otherwise fail a request the caller cannot repair. Other roles keep
+        # raising, so a block this module simply does not handle yet stays a
+        # loud bug rather than silently vanishing from the prompt.
         content = _lc_content_to_bedrock(
             msg.content, drop_unsupported=isinstance(msg, AIMessage)
         )
@@ -2323,7 +2321,7 @@ def _messages_to_bedrock(
                     msg_idx,
                     msg.content,
                 )
-                content = [{"text": EMPTY_CONTENT}]
+                content = _empty_content_fallback(content)
             bedrock_messages.append({"role": "assistant", "content": content})
         elif isinstance(msg, SystemMessage):
             bedrock_system.extend(content)
@@ -2346,9 +2344,7 @@ def _messages_to_bedrock(
                 [
                     {
                         "toolResult": {
-                            # Cache points move outside the toolResult, which
-                            # can leave nothing behind for Bedrock to accept.
-                            "content": tool_result_content or [{"text": EMPTY_CONTENT}],
+                            "content": _empty_content_fallback(tool_result_content),
                             "toolUseId": msg.tool_call_id,
                             "status": msg.status,
                         }
@@ -2736,6 +2732,19 @@ def _format_search_result_block(block: dict) -> dict:
     return {"searchResult": search_result}
 
 
+def _empty_content_fallback(
+    blocks: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Return `blocks`, or a placeholder text block when it is empty.
+
+    Bedrock rejects an empty content list, but content can legitimately empty
+    out on the way here — cache points move outside their `toolResult`, empty
+    text blocks are stripped, unsupported blocks are dropped. A fresh list is
+    returned each call because callers extend the result in place.
+    """
+    return blocks or [{"text": EMPTY_CONTENT}]
+
+
 def _lc_content_to_bedrock(
     content: Union[str, List[Union[str, Dict[str, Any]]]],
     *,
@@ -2894,33 +2903,17 @@ def _lc_content_to_bedrock(
                     }
                 }
             )
-        elif block["type"] == "tool_result":
+        # Server tools use the same toolResult format as regular tools.
+        elif block["type"] in ("tool_result", "server_tool_result"):
             bedrock_content.append(
                 {
                     "toolResult": {
                         "toolUseId": block["toolUseId"],
-                        # Bedrock requires every toolResult to carry a block,
-                        # and dropping unsupported content can empty it.
-                        "content": _lc_content_to_bedrock(
-                            block["content"], drop_unsupported=drop_unsupported
-                        )
-                        or [{"text": EMPTY_CONTENT}],
-                        "status": "error" if block.get("isError") else "success",
-                    }
-                }
-            )
-        elif block["type"] == "server_tool_result":
-            # System tools use toolResult format (same as regular tools)
-            bedrock_content.append(
-                {
-                    "toolResult": {
-                        "toolUseId": block["toolUseId"],
-                        # Bedrock requires every toolResult to carry a block,
-                        # and dropping unsupported content can empty it.
-                        "content": _lc_content_to_bedrock(
-                            block["content"], drop_unsupported=drop_unsupported
-                        )
-                        or [{"text": EMPTY_CONTENT}],
+                        "content": _empty_content_fallback(
+                            _lc_content_to_bedrock(
+                                block["content"], drop_unsupported=drop_unsupported
+                            )
+                        ),
                         "status": "error" if block.get("isError") else "success",
                     }
                 }
@@ -2972,7 +2965,16 @@ def _lc_content_to_bedrock(
                 bedrock_content.append(block["value"])
             else:
                 _log_dropped_block(block)
-        elif drop_unsupported and _is_droppable_block(block):
+        # A well-formed block with no Bedrock equivalent — another provider's
+        # content replayed into a Bedrock call — is droppable. Anything
+        # structurally broken (a non-`str` `type`, or the `non_standard` block
+        # without a `value` that fell through above) signals a bug in whatever
+        # built it, so it keeps raising instead of disappearing.
+        elif (
+            drop_unsupported
+            and isinstance(block["type"], str)
+            and block["type"] != "non_standard"
+        ):
             _log_dropped_block(block)
         else:
             raise ValueError(f"Unsupported content block type:\n{block}")
@@ -2999,59 +3001,50 @@ def _bedrock_non_standard_content_blocks(value: Any) -> Optional[List[Dict[str, 
     return [{key: item} for key, item in value.items()]
 
 
-def _is_droppable_block(block: Dict[str, Any]) -> bool:
-    """Return whether an unhandled block is safe to drop rather than reject.
-
-    Dropping is for well-formed blocks that simply have no Bedrock equivalent,
-    such as another provider's content replayed into a Bedrock call. A block
-    that is structurally broken — a non-string `type`, or a `non_standard`
-    block with no `value` — signals a bug in whatever built it, so it keeps
-    raising instead of disappearing.
-    """
-    block_type = block["type"]
-    if not isinstance(block_type, str):
-        return False
-    return block_type != "non_standard"
-
-
 def _dropped_block_key(block: Dict[str, Any]) -> str:
     """Return the dedupe key identifying a dropped block's kind.
 
     Cross-provider blocks nearly all arrive typed `non_standard`, so keying on
     `type` alone would let the first one mute every later provider block. Key
-    those on their payload instead, so each distinct kind is reported once.
+    those on their payload's own type instead, so each distinct kind is
+    reported once. The key deliberately stays low-cardinality: it seeds a
+    process-lifetime memo, so deriving it from arbitrary payload contents would
+    let it grow without bound.
     """
-    block_type = str(block["type"])
+    block_type = block["type"]
     if block_type != "non_standard":
         return block_type
     value = block.get("value")
-    if isinstance(value, dict):
-        inner_type = value.get("type")
-        if isinstance(inner_type, str):
-            return f"non_standard:{inner_type}"
-        return "non_standard:" + ",".join(sorted(str(key) for key in value))
-    return f"non_standard:{type(value).__name__}"
+    inner_type = value.get("type") if isinstance(value, dict) else None
+    if not isinstance(inner_type, str):
+        inner_type = type(value).__name__
+    return f"non_standard:{inner_type}"
 
 
-def _log_dropped_block(block: Dict[str, Any]) -> None:
-    """Report a content block dropped because Bedrock has no equivalent.
+@functools.cache
+def _warn_dropped_block_type(block_key: str) -> None:
+    """Warn that blocks of this kind are being dropped, once per process.
 
-    Warns once per distinct kind of block per process; repeats drop to debug
-    level. Blocks may carry reasoning text, tool payloads, or other user data,
-    so the block itself is logged only at debug level to keep it out of the
-    warning logs a typical production config enables.
+    Cached so a replayed history warns once instead of on every request. Reset
+    with `_warn_dropped_block_type.cache_clear()`.
     """
-    block_key = _dropped_block_key(block)
-    logger.debug("Dropping unsupported content block: %s", block)
-    if block_key in _warned_dropped_block_types:
-        return
-    _warned_dropped_block_types.add(block_key)
     logger.warning(
         "Dropping unsupported content block of type %r: Bedrock has no "
         "equivalent, so it cannot be sent. Further blocks of this type are "
         "logged at debug level.",
         block_key,
     )
+
+
+def _log_dropped_block(block: Dict[str, Any]) -> None:
+    """Report a content block dropped because Bedrock has no equivalent.
+
+    Blocks may carry reasoning text, tool payloads, or other user data, so the
+    block itself is logged only at debug level to keep it out of the warning
+    logs a typical production config enables.
+    """
+    logger.debug("Dropping unsupported content block: %s", block)
+    _warn_dropped_block_type(_dropped_block_key(block))
 
 
 def _bedrock_to_lc(content: List[Dict[str, Any]]) -> List[Dict[str, Any]]:

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -2943,8 +2943,10 @@ def _lc_content_to_bedrock(
             _log_dropped_block(block)
         else:
             raise ValueError(f"Unsupported content block type:\n{block}")
-    # drop empty text blocks
-    return [block for block in bedrock_content if block.get("text", True)]
+    # Drop empty text blocks. Unsupported nested tool-result content can leave
+    # this list empty; Bedrock requires every toolResult to contain a block.
+    bedrock_content = [block for block in bedrock_content if block.get("text", True)]
+    return bedrock_content or [{"text": EMPTY_CONTENT}]
 
 
 def _is_bedrock_non_standard_content_block(value: Any) -> bool:

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -89,11 +89,12 @@ from langchain_aws.utils import (
 
 logger = logging.getLogger(__name__)
 
-# Top-level keys of a Converse ContentBlock. Blocks keyed only by these are
-# native to Bedrock even when langchain-core wraps them as `non_standard`
-# for lack of a matching LangChain content block type.
+# Top-level members of the Converse ContentBlock union. These native Bedrock
+# blocks can be wrapped as `non_standard` when langchain-core has no matching
+# content block type.
 _BEDROCK_CONTENT_BLOCK_KEYS = frozenset(
     {
+        "audio",
         "cachePoint",
         "citationsContent",
         "document",
@@ -102,7 +103,10 @@ _BEDROCK_CONTENT_BLOCK_KEYS = frozenset(
         "json",
         "reasoningContent",
         "redactedContent",
+        "searchResult",
         "text",
+        "toolAddition",
+        "toolRemoval",
         "toolResult",
         "toolUse",
         "video",
@@ -2925,20 +2929,17 @@ def _lc_content_to_bedrock(
                         }
                     }
                 )
-        elif (
-            block["type"] == "non_standard"
-            and "value" in block
-            and (
-                not drop_unsupported
-                or _is_bedrock_non_standard_content_block(block["value"])
-            )
-        ):
+        elif block["type"] == "non_standard" and "value" in block:
             # langchain-core's content_blocks property wraps provider-specific
             # blocks (e.g. cachePoint, guardContent) that lack a recognized
             # "type" key as {"type": "non_standard", "value": <original>}.
             # Unwrap to restore the original block — it was valid in .content before
             # content_blocks wrapped it.
-            bedrock_content.append(block["value"])
+            non_standard_blocks = _bedrock_non_standard_content_blocks(block["value"])
+            if not drop_unsupported or non_standard_blocks is not None:
+                bedrock_content.extend(non_standard_blocks or [block["value"]])
+            else:
+                _log_dropped_block(block)
         elif drop_unsupported:
             _log_dropped_block(block)
         else:
@@ -2949,18 +2950,20 @@ def _lc_content_to_bedrock(
     return bedrock_content or [{"text": EMPTY_CONTENT}]
 
 
-def _is_bedrock_non_standard_content_block(value: Any) -> bool:
-    """Return whether a normalized non-standard block is native to Bedrock.
+def _bedrock_non_standard_content_blocks(value: Any) -> Optional[List[Dict[str, Any]]]:
+    """Return valid Converse blocks reconstructed from a normalized value.
 
-    A block qualifies when every key is a Converse ContentBlock key, so that
-    combined blocks (e.g. `{"text": ..., "cachePoint": ...}`) are recognized
-    while foreign provider blocks are not.
+    Converse `ContentBlock` is a union, so a normalized value with multiple
+    Bedrock members must be expanded into one block per member before sending
+    it to Bedrock.
     """
-    return (
+    if not (
         isinstance(value, dict)
-        and bool(value)
+        and value
         and value.keys() <= _BEDROCK_CONTENT_BLOCK_KEYS
-    )
+    ):
+        return None
+    return [{key: item} for key, item in value.items()]
 
 
 def _log_dropped_block(block: Dict[str, Any]) -> None:

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -2314,9 +2314,13 @@ def _messages_to_bedrock(
                 # sees rather than merely trimming one block from it.
                 logger.warning(
                     "Assistant message at index %d has no content Bedrock can "
-                    "accept; sending %r in its place. Original content: %s",
+                    "accept; sending %r in its place.",
                     msg_idx,
                     EMPTY_CONTENT,
+                )
+                logger.debug(
+                    "Assistant message at index %d held %s",
+                    msg_idx,
                     msg.content,
                 )
                 content = [{"text": EMPTY_CONTENT}]
@@ -3032,20 +3036,21 @@ def _dropped_block_key(block: Dict[str, Any]) -> str:
 def _log_dropped_block(block: Dict[str, Any]) -> None:
     """Report a content block dropped because Bedrock has no equivalent.
 
-    Warns once per distinct kind of block per process, logging the block itself
-    so the loss can be diagnosed; repeats drop to debug level.
+    Warns once per distinct kind of block per process; repeats drop to debug
+    level. Blocks may carry reasoning text, tool payloads, or other user data,
+    so the block itself is logged only at debug level to keep it out of the
+    warning logs a typical production config enables.
     """
     block_key = _dropped_block_key(block)
+    logger.debug("Dropping unsupported content block: %s", block)
     if block_key in _warned_dropped_block_types:
-        logger.debug("Dropping unsupported content block: %s", block)
         return
     _warned_dropped_block_types.add(block_key)
     logger.warning(
         "Dropping unsupported content block of type %r: Bedrock has no "
         "equivalent, so it cannot be sent. Further blocks of this type are "
-        "logged at debug level. Block: %s",
+        "logged at debug level.",
         block_key,
-        block,
     )
 
 

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -89,9 +89,13 @@ from langchain_aws.utils import (
 
 logger = logging.getLogger(__name__)
 
-# Top-level members of the Converse ContentBlock union. These native Bedrock
-# blocks can be wrapped as `non_standard` when langchain-core has no matching
-# content block type.
+# Members of the Converse `ContentBlock` union, plus `json` from
+# `ToolResultContentBlock` because this module builds tool result content with
+# the same helper. Native Bedrock blocks reach us wrapped as `non_standard`
+# whenever langchain-core has no matching content block type.
+#
+# Keep in sync with the botocore `bedrock-runtime` service model; a member
+# missing here is silently dropped from assistant turns.
 _BEDROCK_CONTENT_BLOCK_KEYS = frozenset(
     {
         "audio",
@@ -102,7 +106,6 @@ _BEDROCK_CONTENT_BLOCK_KEYS = frozenset(
         "image",
         "json",
         "reasoningContent",
-        "redactedContent",
         "searchResult",
         "text",
         "toolAddition",
@@ -113,8 +116,11 @@ _BEDROCK_CONTENT_BLOCK_KEYS = frozenset(
     }
 )
 
-# Block types already reported as dropped, so each distinct type warns once per
-# process instead of on every request that replays the same history.
+# Dropped-block keys already reported, so each distinct kind of block warns once
+# per process instead of on every request that replays the same history. Grows
+# unbounded in principle, but is bounded in practice by the block vocabulary a
+# process actually sees. Mutated without a lock: a lost race costs a duplicate
+# warning, nothing more.
 _warned_dropped_block_types: Set[str] = set()
 
 _MAX_CACHE_POINTS = 4
@@ -2285,7 +2291,7 @@ def _messages_to_bedrock(
                 sys_param_to_bedrock.append(s)
         bedrock_system.extend(sys_param_to_bedrock)
 
-    for msg in messages:
+    for msg_idx, msg in enumerate(messages):
         content = _lc_content_to_bedrock(
             msg.content, drop_unsupported=isinstance(msg, AIMessage)
         )
@@ -2301,8 +2307,18 @@ def _messages_to_bedrock(
         elif isinstance(msg, AIMessage):
             content = _upsert_tool_calls_to_bedrock_content(content, msg.tool_calls)
             if not content:
-                # Every block was dropped as unsupported, and Bedrock rejects an
-                # empty content list.
+                # Nothing survived: blocks may have been dropped as unsupported,
+                # or held only unsigned reasoning or empty text. Bedrock rejects
+                # an empty content list, so stand in a placeholder — and say so
+                # unconditionally, since an erased turn changes what the model
+                # sees rather than merely trimming one block from it.
+                logger.warning(
+                    "Assistant message at index %d has no content Bedrock can "
+                    "accept; sending %r in its place. Original content: %s",
+                    msg_idx,
+                    EMPTY_CONTENT,
+                    msg.content,
+                )
                 content = [{"text": EMPTY_CONTENT}]
             bedrock_messages.append({"role": "assistant", "content": content})
         elif isinstance(msg, SystemMessage):
@@ -2326,7 +2342,9 @@ def _messages_to_bedrock(
                 [
                     {
                         "toolResult": {
-                            "content": tool_result_content,
+                            # Cache points move outside the toolResult, which
+                            # can leave nothing behind for Bedrock to accept.
+                            "content": tool_result_content or [{"text": EMPTY_CONTENT}],
                             "toolUseId": msg.tool_call_id,
                             "status": msg.status,
                         }
@@ -2877,9 +2895,12 @@ def _lc_content_to_bedrock(
                 {
                     "toolResult": {
                         "toolUseId": block["toolUseId"],
+                        # Bedrock requires every toolResult to carry a block,
+                        # and dropping unsupported content can empty it.
                         "content": _lc_content_to_bedrock(
                             block["content"], drop_unsupported=drop_unsupported
-                        ),
+                        )
+                        or [{"text": EMPTY_CONTENT}],
                         "status": "error" if block.get("isError") else "success",
                     }
                 }
@@ -2890,9 +2911,12 @@ def _lc_content_to_bedrock(
                 {
                     "toolResult": {
                         "toolUseId": block["toolUseId"],
+                        # Bedrock requires every toolResult to carry a block,
+                        # and dropping unsupported content can empty it.
                         "content": _lc_content_to_bedrock(
                             block["content"], drop_unsupported=drop_unsupported
-                        ),
+                        )
+                        or [{"text": EMPTY_CONTENT}],
                         "status": "error" if block.get("isError") else "success",
                     }
                 }
@@ -2933,29 +2957,34 @@ def _lc_content_to_bedrock(
             # langchain-core's content_blocks property wraps provider-specific
             # blocks (e.g. cachePoint, guardContent) that lack a recognized
             # "type" key as {"type": "non_standard", "value": <original>}.
-            # Unwrap to restore the original block — it was valid in .content before
-            # content_blocks wrapped it.
-            non_standard_blocks = _bedrock_non_standard_content_blocks(block["value"])
-            if not drop_unsupported or non_standard_blocks is not None:
-                bedrock_content.extend(non_standard_blocks or [block["value"]])
+            # Unwrap to restore the original block — it was valid in .content
+            # before content_blocks wrapped it. On assistant turns the payload
+            # must be Bedrock-native; anything else came from another provider
+            # and is dropped rather than sent on to fail server-side.
+            native_blocks = _bedrock_non_standard_content_blocks(block["value"])
+            if native_blocks is not None:
+                bedrock_content.extend(native_blocks)
+            elif not drop_unsupported:
+                bedrock_content.append(block["value"])
             else:
                 _log_dropped_block(block)
-        elif drop_unsupported:
+        elif drop_unsupported and _is_droppable_block(block):
             _log_dropped_block(block)
         else:
             raise ValueError(f"Unsupported content block type:\n{block}")
-    # Drop empty text blocks. Unsupported nested tool-result content can leave
-    # this list empty; Bedrock requires every toolResult to contain a block.
-    bedrock_content = [block for block in bedrock_content if block.get("text", True)]
-    return bedrock_content or [{"text": EMPTY_CONTENT}]
+    # drop empty text blocks
+    return [block for block in bedrock_content if block.get("text", True)]
 
 
 def _bedrock_non_standard_content_blocks(value: Any) -> Optional[List[Dict[str, Any]]]:
-    """Return valid Converse blocks reconstructed from a normalized value.
+    """Return Converse blocks reconstructed from a normalized non-standard payload.
 
-    Converse `ContentBlock` is a union, so a normalized value with multiple
-    Bedrock members must be expanded into one block per member before sending
-    it to Bedrock.
+    `value` is the payload unwrapped from a `non_standard` block, not the block
+    itself. Converse `ContentBlock` is a union, so a payload carrying several
+    Bedrock members is expanded into one single-member block per key.
+
+    Returns `None` when the payload is not Bedrock-native — a non-dict, an empty
+    dict, or a dict holding any key Converse does not define.
     """
     if not (
         isinstance(value, dict)
@@ -2966,18 +2995,57 @@ def _bedrock_non_standard_content_blocks(value: Any) -> Optional[List[Dict[str, 
     return [{key: item} for key, item in value.items()]
 
 
-def _log_dropped_block(block: Dict[str, Any]) -> None:
-    """Report a content block dropped because Bedrock has no equivalent."""
+def _is_droppable_block(block: Dict[str, Any]) -> bool:
+    """Return whether an unhandled block is safe to drop rather than reject.
+
+    Dropping is for well-formed blocks that simply have no Bedrock equivalent,
+    such as another provider's content replayed into a Bedrock call. A block
+    that is structurally broken — a non-string `type`, or a `non_standard`
+    block with no `value` — signals a bug in whatever built it, so it keeps
+    raising instead of disappearing.
+    """
     block_type = block["type"]
-    if block_type in _warned_dropped_block_types:
+    if not isinstance(block_type, str):
+        return False
+    return block_type != "non_standard"
+
+
+def _dropped_block_key(block: Dict[str, Any]) -> str:
+    """Return the dedupe key identifying a dropped block's kind.
+
+    Cross-provider blocks nearly all arrive typed `non_standard`, so keying on
+    `type` alone would let the first one mute every later provider block. Key
+    those on their payload instead, so each distinct kind is reported once.
+    """
+    block_type = str(block["type"])
+    if block_type != "non_standard":
+        return block_type
+    value = block.get("value")
+    if isinstance(value, dict):
+        inner_type = value.get("type")
+        if isinstance(inner_type, str):
+            return f"non_standard:{inner_type}"
+        return "non_standard:" + ",".join(sorted(str(key) for key in value))
+    return f"non_standard:{type(value).__name__}"
+
+
+def _log_dropped_block(block: Dict[str, Any]) -> None:
+    """Report a content block dropped because Bedrock has no equivalent.
+
+    Warns once per distinct kind of block per process, logging the block itself
+    so the loss can be diagnosed; repeats drop to debug level.
+    """
+    block_key = _dropped_block_key(block)
+    if block_key in _warned_dropped_block_types:
         logger.debug("Dropping unsupported content block: %s", block)
         return
-    _warned_dropped_block_types.add(block_type)
+    _warned_dropped_block_types.add(block_key)
     logger.warning(
         "Dropping unsupported content block of type %r: Bedrock has no "
         "equivalent, so it cannot be sent. Further blocks of this type are "
-        "logged at debug level.",
-        block_type,
+        "logged at debug level. Block: %s",
+        block_key,
+        block,
     )
 
 

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -88,6 +88,17 @@ from langchain_aws.utils import (
 
 logger = logging.getLogger(__name__)
 
+# These Converse content blocks are represented as ``non_standard`` by
+# langchain-core because they do not have a LangChain content block type.
+_BEDROCK_NON_STANDARD_CONTENT_BLOCK_KEYS = frozenset(
+    {
+        "cachePoint",
+        "citationsContent",
+        "guardContent",
+        "redactedContent",
+    }
+)
+
 _MAX_CACHE_POINTS = 4
 _MODEL_PROFILES = cast("ModelProfileRegistry", _PROFILES)
 
@@ -2897,7 +2908,10 @@ def _lc_content_to_bedrock(
         elif (
             block["type"] == "non_standard"
             and "value" in block
-            and not drop_unsupported
+            and (
+                not drop_unsupported
+                or _is_bedrock_non_standard_content_block(block["value"])
+            )
         ):
             # langchain-core's content_blocks property wraps provider-specific
             # blocks (e.g. cachePoint, guardContent) that lack a recognized
@@ -2914,6 +2928,15 @@ def _lc_content_to_bedrock(
             raise ValueError(f"Unsupported content block type:\n{block}")
     # drop empty text blocks
     return [block for block in bedrock_content if block.get("text", True)]
+
+
+def _is_bedrock_non_standard_content_block(value: Any) -> bool:
+    """Return whether a normalized non-standard block is native to Bedrock."""
+    return (
+        isinstance(value, dict)
+        and len(value) == 1
+        and next(iter(value)) in _BEDROCK_NON_STANDARD_CONTENT_BLOCK_KEYS
+    )
 
 
 def _bedrock_to_lc(content: List[Dict[str, Any]]) -> List[Dict[str, Any]]:

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -90,7 +90,7 @@ from langchain_aws.utils import (
 logger = logging.getLogger(__name__)
 
 # Top-level keys of a Converse ContentBlock. Blocks keyed only by these are
-# native to Bedrock even when langchain-core wraps them as ``non_standard``
+# native to Bedrock even when langchain-core wraps them as `non_standard`
 # for lack of a matching LangChain content block type.
 _BEDROCK_CONTENT_BLOCK_KEYS = frozenset(
     {
@@ -2951,7 +2951,7 @@ def _is_bedrock_non_standard_content_block(value: Any) -> bool:
     """Return whether a normalized non-standard block is native to Bedrock.
 
     A block qualifies when every key is a Converse ContentBlock key, so that
-    combined blocks (e.g. ``{"text": ..., "cachePoint": ...}``) are recognized
+    combined blocks (e.g. `{"text": ..., "cachePoint": ...}`) are recognized
     while foreign provider blocks are not.
     """
     return (

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -2257,7 +2257,9 @@ def _messages_to_bedrock(
         bedrock_system.extend(sys_param_to_bedrock)
 
     for msg in messages:
-        content = _lc_content_to_bedrock(msg.content)
+        content = _lc_content_to_bedrock(
+            msg.content, drop_unsupported=isinstance(msg, AIMessage)
+        )
         if isinstance(msg, HumanMessage):
             # If there's a human, tool, human message sequence, the
             # tool message will be merged with the first human message, so the second
@@ -2269,6 +2271,8 @@ def _messages_to_bedrock(
                 bedrock_messages.append({"role": "user", "content": content})
         elif isinstance(msg, AIMessage):
             content = _upsert_tool_calls_to_bedrock_content(content, msg.tool_calls)
+            if not content:
+                content = [{"text": EMPTY_CONTENT}]
             bedrock_messages.append({"role": "assistant", "content": content})
         elif isinstance(msg, SystemMessage):
             bedrock_system.extend(content)
@@ -2681,6 +2685,8 @@ def _format_search_result_block(block: dict) -> dict:
 
 def _lc_content_to_bedrock(
     content: Union[str, List[Union[str, Dict[str, Any]]]],
+    *,
+    drop_unsupported: bool = False,
 ) -> List[Dict[str, Any]]:
     if isinstance(content, str):
         if not content or content.isspace():
@@ -2888,13 +2894,22 @@ def _lc_content_to_bedrock(
                         }
                     }
                 )
-        elif block["type"] == "non_standard" and "value" in block:
+        elif (
+            block["type"] == "non_standard"
+            and "value" in block
+            and not drop_unsupported
+        ):
             # langchain-core's content_blocks property wraps provider-specific
             # blocks (e.g. cachePoint, guardContent) that lack a recognized
             # "type" key as {"type": "non_standard", "value": <original>}.
             # Unwrap to restore the original block — it was valid in .content before
             # content_blocks wrapped it.
             bedrock_content.append(block["value"])
+        elif drop_unsupported:
+            logger.debug(
+                "Dropping unsupported AI message content block type: %s",
+                block["type"],
+            )
         else:
             raise ValueError(f"Unsupported content block type:\n{block}")
     # drop empty text blocks

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -723,8 +723,8 @@ def test__messages_to_bedrock_preserves_ai_cache_point() -> None:
     ]
 
 
-def test__messages_to_bedrock_preserves_ai_combined_cache_point_block() -> None:
-    """Preserve blocks that pair a payload with a cache point."""
+def test__messages_to_bedrock_splits_ai_combined_cache_point_block() -> None:
+    """Split normalized values into valid single-member Bedrock blocks."""
     messages = [
         HumanMessage(content="What is 2 + 2?"),
         AIMessage(
@@ -743,9 +743,46 @@ def test__messages_to_bedrock_preserves_ai_combined_cache_point_block() -> None:
         {"role": "user", "content": [{"text": "What is 2 + 2?"}]},
         {
             "role": "assistant",
-            "content": [{"text": "4", "cachePoint": {"type": "default"}}],
+            "content": [
+                {"text": "4"},
+                {"cachePoint": {"type": "default"}},
+            ],
         },
     ]
+
+
+def test__messages_to_bedrock_preserves_ai_audio_block() -> None:
+    """Keep Bedrock-native blocks not represented by a core content type."""
+    messages = [
+        HumanMessage(content="Play this audio."),
+        AIMessage(
+            content=[
+                {
+                    "type": "non_standard",
+                    "value": {
+                        "audio": {
+                            "format": "wav",
+                            "source": {"bytes": b"audio"},
+                        }
+                    },
+                }
+            ]
+        ),
+    ]
+
+    actual_messages, _ = _messages_to_bedrock(messages)
+
+    assert actual_messages[1] == {
+        "role": "assistant",
+        "content": [
+            {
+                "audio": {
+                    "format": "wav",
+                    "source": {"bytes": b"audio"},
+                }
+            }
+        ],
+    }
 
 
 def test__messages_to_bedrock_drops_foreign_block_nested_in_tool_result() -> None:

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -782,6 +782,37 @@ def test__messages_to_bedrock_drops_foreign_block_nested_in_tool_result() -> Non
     }
 
 
+def test__messages_to_bedrock_replaces_dropped_nested_tool_result_content() -> None:
+    """Tool results remain valid when all nested content is unsupported."""
+    messages = [
+        HumanMessage(content="What is the weather in Paris?"),
+        AIMessage(
+            content=[
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "call_abc",
+                    "content": [{"type": "foreign_provider_block"}],
+                }
+            ]
+        ),
+    ]
+
+    actual_messages, _ = _messages_to_bedrock(messages)
+
+    assert actual_messages[1] == {
+        "role": "assistant",
+        "content": [
+            {
+                "toolResult": {
+                    "toolUseId": "call_abc",
+                    "content": [{"text": "."}],
+                    "status": "success",
+                }
+            }
+        ],
+    }
+
+
 def test__messages_to_bedrock_warns_once_per_dropped_block_type(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -37,6 +37,8 @@ from syrupy import SnapshotAssertion
 
 from langchain_aws import ChatBedrockConverse
 from langchain_aws.chat_models.bedrock_converse import (
+    _BEDROCK_CONTENT_BLOCK_KEYS,
+    EMPTY_CONTENT,
     _bedrock_to_lc,
     _camel_to_snake,
     _camel_to_snake_keys,
@@ -663,6 +665,14 @@ def test__messages_to_bedrock_ignores_foreign_function_call_block() -> None:
     assert actual_system == []
 
 
+@pytest.fixture(autouse=True)
+def _reset_dropped_block_warnings() -> Iterator[None]:
+    """Isolate the process-wide warn-once state from test ordering."""
+    _warned_dropped_block_types.clear()
+    yield
+    _warned_dropped_block_types.clear()
+
+
 def test__messages_to_bedrock_ignores_foreign_reasoning_block() -> None:
     messages = [
         HumanMessage(content="What is 2 + 2?"),
@@ -842,7 +852,7 @@ def test__messages_to_bedrock_replaces_dropped_nested_tool_result_content() -> N
             {
                 "toolResult": {
                     "toolUseId": "call_abc",
-                    "content": [{"text": "."}],
+                    "content": [{"text": EMPTY_CONTENT}],
                     "status": "success",
                 }
             }
@@ -850,11 +860,24 @@ def test__messages_to_bedrock_replaces_dropped_nested_tool_result_content() -> N
     }
 
 
+def _dropped_block_warnings(caplog: pytest.LogCaptureFixture) -> List[str]:
+    """Return warnings about individual dropped blocks.
+
+    Filters out the separate warning about an assistant turn left with no
+    usable content, which is emitted unconditionally.
+    """
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno == logging.WARNING
+        and "Dropping unsupported content block" in record.getMessage()
+    ]
+
+
 def test__messages_to_bedrock_warns_once_per_dropped_block_type(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Silent content loss is surfaced, without warning on every replayed turn."""
-    _warned_dropped_block_types.discard("foreign_provider_block")
     messages = [
         HumanMessage(content="Hello"),
         AIMessage(content=[{"type": "foreign_provider_block"}]),
@@ -867,9 +890,66 @@ def test__messages_to_bedrock_warns_once_per_dropped_block_type(
     ):
         _messages_to_bedrock(messages)
 
-    warnings_logged = [r for r in caplog.records if r.levelno == logging.WARNING]
+    warnings_logged = _dropped_block_warnings(caplog)
     assert len(warnings_logged) == 1
-    assert "foreign_provider_block" in warnings_logged[0].getMessage()
+    assert "foreign_provider_block" in warnings_logged[0]
+    # The block itself is logged, not just its type, so the loss is diagnosable
+    # from the first occurrence.
+    assert "{'type': 'foreign_provider_block'}" in warnings_logged[0]
+
+
+def test__messages_to_bedrock_warns_per_distinct_non_standard_block(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Cross-provider blocks share a type, so dedupe keys off their payload."""
+    messages = [
+        HumanMessage(content="Hello"),
+        AIMessage(
+            content=[
+                {"type": "non_standard", "value": {"type": "openai_annotation"}},
+                {"type": "non_standard", "value": {"type": "google_grounding"}},
+                {"type": "non_standard", "value": {"type": "openai_annotation"}},
+            ]
+        ),
+    ]
+
+    with caplog.at_level(
+        logging.WARNING, logger="langchain_aws.chat_models.bedrock_converse"
+    ):
+        _messages_to_bedrock(messages)
+
+    warnings_logged = _dropped_block_warnings(caplog)
+    assert len(warnings_logged) == 2
+    assert "openai_annotation" in warnings_logged[0]
+    assert "google_grounding" in warnings_logged[1]
+
+
+def test__messages_to_bedrock_warns_when_assistant_turn_is_erased(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Losing a whole turn changes what the model sees, so always report it."""
+    messages = [
+        HumanMessage(content="Hello"),
+        AIMessage(content=[{"type": "foreign_provider_block"}]),
+        HumanMessage(content="Again"),
+        AIMessage(content=[{"type": "foreign_provider_block"}]),
+    ]
+
+    with caplog.at_level(
+        logging.WARNING, logger="langchain_aws.chat_models.bedrock_converse"
+    ):
+        _messages_to_bedrock(messages)
+
+    erased = [
+        record.getMessage()
+        for record in caplog.records
+        if "has no content Bedrock can accept" in record.getMessage()
+    ]
+    # Reported for every erased turn, unlike the deduped per-block warning, and
+    # naming the message so it can be found in a long replayed history.
+    assert len(erased) == 2
+    assert "index 1" in erased[0]
+    assert "index 3" in erased[1]
 
 
 def test__messages_to_bedrock_replaces_dropped_only_content() -> None:
@@ -890,7 +970,7 @@ def test__messages_to_bedrock_replaces_dropped_only_content() -> None:
 
     assert actual_messages == [
         {"role": "user", "content": [{"text": "Search for the weather."}]},
-        {"role": "assistant", "content": [{"text": "."}]},
+        {"role": "assistant", "content": [{"text": EMPTY_CONTENT}]},
     ]
 
 
@@ -910,6 +990,219 @@ def test__messages_to_bedrock_rejects_unsupported_non_ai_content(
 ) -> None:
     with pytest.raises(ValueError, match="Unsupported content block type"):
         _messages_to_bedrock([message])
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        HumanMessage(
+            content=[{"type": "non_standard", "value": {"type": "provider_metadata"}}]
+        ),
+        SystemMessage(
+            content=[{"type": "non_standard", "value": {"type": "provider_metadata"}}]
+        ),
+        ToolMessage(
+            content=[{"type": "non_standard", "value": {"type": "provider_metadata"}}],
+            tool_call_id="call_abc",
+        ),
+    ],
+)
+def test__messages_to_bedrock_passes_through_non_ai_non_standard(
+    message: BaseMessage,
+) -> None:
+    """Only assistant turns are filtered; other roles keep the historic passthrough.
+
+    A ToolMessage nests the block inside its toolResult, so compare on the
+    serialized output rather than the top-level content list.
+    """
+    actual_messages, actual_system = _messages_to_bedrock([message])
+
+    emitted = json.dumps(actual_system or actual_messages, default=str)
+    assert '"type": "provider_metadata"' in emitted
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        {"text": "4", "openaiAnnotations": [{"kind": "url"}]},
+        {"cachePoint": {"type": "default"}, "geminiThought": "hidden"},
+    ],
+)
+def test__messages_to_bedrock_drops_partially_native_ai_block(
+    value: Dict[str, Any],
+) -> None:
+    """A payload is native only if *every* key is; a stray key taints the block.
+
+    Forwarding one of these would reach Bedrock and fail validation, which is
+    the crash this filtering exists to prevent.
+    """
+    messages = [AIMessage(content=[{"type": "non_standard", "value": value}])]
+
+    actual_messages, _ = _messages_to_bedrock(messages)
+
+    assert actual_messages == [
+        {"role": "assistant", "content": [{"text": EMPTY_CONTENT}]}
+    ]
+
+
+@pytest.mark.parametrize("value", [{}, "a string", ["a", "list"], None, 7])
+def test__messages_to_bedrock_drops_degenerate_ai_non_standard_value(
+    value: Any,
+) -> None:
+    """Malformed payloads are dropped, not forwarded or raised on."""
+    messages = [AIMessage(content=[{"type": "non_standard", "value": value}])]
+
+    actual_messages, _ = _messages_to_bedrock(messages)
+
+    assert actual_messages == [
+        {"role": "assistant", "content": [{"text": EMPTY_CONTENT}]}
+    ]
+
+
+@pytest.mark.parametrize(
+    "block",
+    [
+        # A `non_standard` block must carry its payload; one without `value` is
+        # a bug in whatever built it, not another provider's content.
+        {"type": "non_standard"},
+        {"type": {"not": "a string"}},
+        {"type": ["also", "not", "a", "string"]},
+    ],
+)
+def test__messages_to_bedrock_rejects_malformed_ai_block(block: Dict[str, Any]) -> None:
+    """Structurally broken blocks keep raising, even where dropping applies."""
+    with pytest.raises(ValueError, match="Unsupported content block type"):
+        _messages_to_bedrock([AIMessage(content=[block])])
+
+
+@pytest.mark.parametrize("key", sorted(_BEDROCK_CONTENT_BLOCK_KEYS))
+def test__messages_to_bedrock_preserves_every_native_block_key(key: str) -> None:
+    """Every allowlisted key survives an assistant turn.
+
+    Pins the allowlist against silent shrinkage: dropping a real `ContentBlock`
+    member discards assistant content instead of sending it.
+    """
+    payload = {"marker": key}
+    messages = [AIMessage(content=[{"type": "non_standard", "value": {key: payload}}])]
+
+    actual_messages, _ = _messages_to_bedrock(messages)
+
+    assert actual_messages == [{"role": "assistant", "content": [{key: payload}]}]
+
+
+@pytest.mark.parametrize("block_type", ["tool_result", "server_tool_result"])
+def test__messages_to_bedrock_drops_foreign_block_in_tool_results(
+    block_type: str,
+) -> None:
+    """Both tool result branches propagate dropping into nested content."""
+    messages = [
+        AIMessage(
+            content=[
+                {
+                    "type": block_type,
+                    "tool_use_id": "call_abc",
+                    "content": [
+                        {"type": "text", "text": "Sunny"},
+                        {"type": "foreign_provider_block"},
+                    ],
+                }
+            ]
+        ),
+    ]
+
+    actual_messages, _ = _messages_to_bedrock(messages)
+
+    assert actual_messages[0] == {
+        "role": "assistant",
+        "content": [
+            {
+                "toolResult": {
+                    "toolUseId": "call_abc",
+                    "content": [{"text": "Sunny"}],
+                    "status": "success",
+                }
+            }
+        ],
+    }
+
+
+def test__messages_to_bedrock_keeps_tool_calls_when_content_dropped() -> None:
+    """Tool calls repopulate the turn, so no placeholder is needed."""
+    messages = [
+        AIMessage(
+            content=[{"type": "foreign_provider_block"}],
+            tool_calls=[
+                {
+                    "name": "get_weather",
+                    "args": {"city": "Paris"},
+                    "id": "call_abc",
+                    "type": "tool_call",
+                }
+            ],
+        ),
+    ]
+
+    actual_messages, _ = _messages_to_bedrock(messages)
+
+    assert actual_messages == [
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "toolUse": {
+                        "toolUseId": "call_abc",
+                        "input": {"city": "Paris"},
+                        "name": "get_weather",
+                    }
+                }
+            ],
+        }
+    ]
+
+
+def test__messages_to_bedrock_keeps_cache_point_only_tool_result_valid() -> None:
+    """Cache points move outside the toolResult, which must not be left empty."""
+    messages = [
+        ToolMessage(
+            content=[{"cachePoint": {"type": "default"}}],
+            tool_call_id="call_abc",
+            status="success",
+        ),
+    ]
+
+    actual_messages, _ = _messages_to_bedrock(messages)
+
+    assert actual_messages == [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "toolResult": {
+                        "content": [{"text": EMPTY_CONTENT}],
+                        "toolUseId": "call_abc",
+                        "status": "success",
+                    }
+                },
+                {"cachePoint": {"type": "default"}},
+            ],
+        }
+    ]
+
+
+def test__messages_to_bedrock_leaves_empty_system_content_empty() -> None:
+    """The tool result placeholder must not leak into the system prompt.
+
+    An unsigned reasoning block contributes nothing; a system message built only
+    from one should stay empty rather than gain a stray `EMPTY_CONTENT` block.
+    """
+    messages = [
+        SystemMessage(content=[{"type": "thinking", "thinking": "unsigned"}]),
+        HumanMessage(content="Hi"),
+    ]
+
+    _, actual_system = _messages_to_bedrock(messages)
+
+    assert actual_system == []
 
 
 def test_messages_to_bedrock_with_cache_point() -> None:

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -605,6 +605,134 @@ def test__messages_to_bedrock() -> None:
     assert expected_system == actual_system
 
 
+def test__messages_to_bedrock_ignores_foreign_function_call_block() -> None:
+    messages = [
+        HumanMessage(content="What is the weather in Paris?"),
+        AIMessage(
+            content=[
+                {
+                    "type": "function_call",
+                    "id": "fc_1",
+                    "call_id": "call_abc",
+                    "name": "get_weather",
+                    "arguments": '{"city": "Paris"}',
+                }
+            ],
+            tool_calls=[
+                ToolCall(
+                    name="get_weather",
+                    args={"city": "Paris"},
+                    id="call_abc",
+                    type="tool_call",
+                )
+            ],
+        ),
+        ToolMessage(content="Sunny", tool_call_id="call_abc"),
+    ]
+
+    actual_messages, actual_system = _messages_to_bedrock(messages)
+
+    assert actual_messages == [
+        {"role": "user", "content": [{"text": "What is the weather in Paris?"}]},
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "toolUse": {
+                        "toolUseId": "call_abc",
+                        "input": {"city": "Paris"},
+                        "name": "get_weather",
+                    }
+                }
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "toolResult": {
+                        "content": [{"text": "Sunny"}],
+                        "toolUseId": "call_abc",
+                        "status": "success",
+                    }
+                }
+            ],
+        },
+    ]
+    assert actual_system == []
+
+
+def test__messages_to_bedrock_ignores_foreign_reasoning_block() -> None:
+    messages = [
+        HumanMessage(content="What is 2 + 2?"),
+        AIMessage(
+            content=[
+                {
+                    "type": "reasoning",
+                    "reasoning": "Add the numbers.",
+                    "extras": {"signature": "google-signature"},
+                },
+                {
+                    "type": "non_standard",
+                    "value": {"type": "provider_metadata", "data": "foreign"},
+                },
+                {"type": "text", "text": "4"},
+            ],
+            response_metadata={
+                "output_version": "v1",
+                "model_provider": "google_genai",
+            },
+        ),
+    ]
+
+    actual_messages, _ = _messages_to_bedrock(messages)
+
+    assert actual_messages == [
+        {"role": "user", "content": [{"text": "What is 2 + 2?"}]},
+        {"role": "assistant", "content": [{"text": "4"}]},
+    ]
+
+
+def test__messages_to_bedrock_replaces_dropped_only_content() -> None:
+    messages = [
+        HumanMessage(content="Search for the weather."),
+        AIMessage(
+            content=[
+                {
+                    "type": "web_search_call",
+                    "id": "search_1",
+                    "status": "completed",
+                }
+            ]
+        ),
+    ]
+
+    actual_messages, _ = _messages_to_bedrock(messages)
+
+    assert actual_messages == [
+        {"role": "user", "content": [{"text": "Search for the weather."}]},
+        {"role": "assistant", "content": [{"text": "."}]},
+    ]
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        HumanMessage(content=[{"type": "foreign_provider_block"}]),
+        SystemMessage(content=[{"type": "foreign_provider_block"}]),
+        ToolMessage(
+            content=[{"type": "foreign_provider_block"}],
+            tool_call_id="call_abc",
+        ),
+    ],
+)
+def test__messages_to_bedrock_rejects_unsupported_non_ai_content(
+    message: BaseMessage,
+) -> None:
+    with pytest.raises(ValueError, match="Unsupported content block type"):
+        _messages_to_bedrock([message])
+
+
 def test_messages_to_bedrock_with_cache_point() -> None:
     messages = [
         HumanMessage(content=["Hello!", {"cachePoint": {"type": "default"}}]),

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -59,6 +59,7 @@ from langchain_aws.chat_models.bedrock_converse import (
     _snake_to_camel_keys,
     _split_inline_reasoning,
     _strip_null_anyof,
+    _warned_dropped_block_types,
 )
 from langchain_aws.function_calling import convert_to_anthropic_tool
 
@@ -720,6 +721,87 @@ def test__messages_to_bedrock_preserves_ai_cache_point() -> None:
             ],
         },
     ]
+
+
+def test__messages_to_bedrock_preserves_ai_combined_cache_point_block() -> None:
+    """Preserve blocks that pair a payload with a cache point."""
+    messages = [
+        HumanMessage(content="What is 2 + 2?"),
+        AIMessage(
+            content=[
+                {
+                    "type": "non_standard",
+                    "value": {"text": "4", "cachePoint": {"type": "default"}},
+                },
+            ]
+        ),
+    ]
+
+    actual_messages, _ = _messages_to_bedrock(messages)
+
+    assert actual_messages == [
+        {"role": "user", "content": [{"text": "What is 2 + 2?"}]},
+        {
+            "role": "assistant",
+            "content": [{"text": "4", "cachePoint": {"type": "default"}}],
+        },
+    ]
+
+
+def test__messages_to_bedrock_drops_foreign_block_nested_in_tool_result() -> None:
+    """Dropping applies inside tool result content, not just at the top level."""
+    messages = [
+        HumanMessage(content="What is the weather in Paris?"),
+        AIMessage(
+            content=[
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "call_abc",
+                    "content": [
+                        {"type": "text", "text": "Sunny"},
+                        {"type": "foreign_provider_block"},
+                    ],
+                }
+            ]
+        ),
+    ]
+
+    actual_messages, _ = _messages_to_bedrock(messages)
+
+    assert actual_messages[1] == {
+        "role": "assistant",
+        "content": [
+            {
+                "toolResult": {
+                    "toolUseId": "call_abc",
+                    "content": [{"text": "Sunny"}],
+                    "status": "success",
+                }
+            }
+        ],
+    }
+
+
+def test__messages_to_bedrock_warns_once_per_dropped_block_type(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Silent content loss is surfaced, without warning on every replayed turn."""
+    _warned_dropped_block_types.discard("foreign_provider_block")
+    messages = [
+        HumanMessage(content="Hello"),
+        AIMessage(content=[{"type": "foreign_provider_block"}]),
+        HumanMessage(content="Again"),
+        AIMessage(content=[{"type": "foreign_provider_block"}]),
+    ]
+
+    with caplog.at_level(
+        logging.WARNING, logger="langchain_aws.chat_models.bedrock_converse"
+    ):
+        _messages_to_bedrock(messages)
+
+    warnings_logged = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings_logged) == 1
+    assert "foreign_provider_block" in warnings_logged[0].getMessage()
 
 
 def test__messages_to_bedrock_replaces_dropped_only_content() -> None:

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -693,6 +693,35 @@ def test__messages_to_bedrock_ignores_foreign_reasoning_block() -> None:
     ]
 
 
+def test__messages_to_bedrock_preserves_ai_cache_point() -> None:
+    """Preserve cache points when replaying normalized assistant history."""
+    messages = [
+        HumanMessage(content="What is 2 + 2?"),
+        AIMessage(
+            content=[
+                {"type": "text", "text": "4"},
+                {
+                    "type": "non_standard",
+                    "value": {"cachePoint": {"type": "default"}},
+                },
+            ]
+        ),
+    ]
+
+    actual_messages, _ = _messages_to_bedrock(messages)
+
+    assert actual_messages == [
+        {"role": "user", "content": [{"text": "What is 2 + 2?"}]},
+        {
+            "role": "assistant",
+            "content": [
+                {"text": "4"},
+                {"cachePoint": {"type": "default"}},
+            ],
+        },
+    ]
+
+
 def test__messages_to_bedrock_replaces_dropped_only_content() -> None:
     messages = [
         HumanMessage(content="Search for the weather."),

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -893,9 +893,9 @@ def test__messages_to_bedrock_warns_once_per_dropped_block_type(
     warnings_logged = _dropped_block_warnings(caplog)
     assert len(warnings_logged) == 1
     assert "foreign_provider_block" in warnings_logged[0]
-    # The block itself is logged, not just its type, so the loss is diagnosable
-    # from the first occurrence.
-    assert "{'type': 'foreign_provider_block'}" in warnings_logged[0]
+    # Blocks can carry user data, so the warning names the block type only; the
+    # block itself stays at debug level, out of default-level logs.
+    assert "{'type': 'foreign_provider_block'}" not in warnings_logged[0]
 
 
 def test__messages_to_bedrock_warns_per_distinct_non_standard_block(

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -1036,7 +1036,9 @@ def test__messages_to_bedrock_drops_partially_native_ai_block(
     Forwarding one of these would reach Bedrock and fail validation, which is
     the crash this filtering exists to prevent.
     """
-    messages = [AIMessage(content=[{"type": "non_standard", "value": value}])]
+    messages: list[BaseMessage] = [
+        AIMessage(content=[{"type": "non_standard", "value": value}])
+    ]
 
     actual_messages, _ = _messages_to_bedrock(messages)
 
@@ -1050,7 +1052,9 @@ def test__messages_to_bedrock_drops_degenerate_ai_non_standard_value(
     value: Any,
 ) -> None:
     """Malformed payloads are dropped, not forwarded or raised on."""
-    messages = [AIMessage(content=[{"type": "non_standard", "value": value}])]
+    messages: list[BaseMessage] = [
+        AIMessage(content=[{"type": "non_standard", "value": value}])
+    ]
 
     actual_messages, _ = _messages_to_bedrock(messages)
 
@@ -1083,7 +1087,9 @@ def test__messages_to_bedrock_preserves_every_native_block_key(key: str) -> None
     member discards assistant content instead of sending it.
     """
     payload = {"marker": key}
-    messages = [AIMessage(content=[{"type": "non_standard", "value": {key: payload}}])]
+    messages: list[BaseMessage] = [
+        AIMessage(content=[{"type": "non_standard", "value": {key: payload}}])
+    ]
 
     actual_messages, _ = _messages_to_bedrock(messages)
 
@@ -1095,7 +1101,7 @@ def test__messages_to_bedrock_drops_foreign_block_in_tool_results(
     block_type: str,
 ) -> None:
     """Both tool result branches propagate dropping into nested content."""
-    messages = [
+    messages: list[BaseMessage] = [
         AIMessage(
             content=[
                 {
@@ -1128,7 +1134,7 @@ def test__messages_to_bedrock_drops_foreign_block_in_tool_results(
 
 def test__messages_to_bedrock_keeps_tool_calls_when_content_dropped() -> None:
     """Tool calls repopulate the turn, so no placeholder is needed."""
-    messages = [
+    messages: list[BaseMessage] = [
         AIMessage(
             content=[{"type": "foreign_provider_block"}],
             tool_calls=[
@@ -1162,7 +1168,7 @@ def test__messages_to_bedrock_keeps_tool_calls_when_content_dropped() -> None:
 
 def test__messages_to_bedrock_keeps_cache_point_only_tool_result_valid() -> None:
     """Cache points move outside the toolResult, which must not be left empty."""
-    messages = [
+    messages: list[BaseMessage] = [
         ToolMessage(
             content=[{"cachePoint": {"type": "default"}}],
             tool_call_id="call_abc",

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -19,7 +19,9 @@ from typing import (
 )
 from unittest import mock
 
+import botocore.session
 import pytest
+from botocore.model import StructureShape
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import (
     AIMessage,
@@ -61,9 +63,15 @@ from langchain_aws.chat_models.bedrock_converse import (
     _snake_to_camel_keys,
     _split_inline_reasoning,
     _strip_null_anyof,
-    _warned_dropped_block_types,
+    _warn_dropped_block_type,
 )
 from langchain_aws.function_calling import convert_to_anthropic_tool
+
+
+@pytest.fixture(autouse=True)
+def _reset_dropped_block_warnings() -> None:
+    """Isolate the process-wide warn-once state from test ordering."""
+    _warn_dropped_block_type.cache_clear()
 
 
 class TestBedrockStandard(ChatModelUnitTests):
@@ -665,14 +673,6 @@ def test__messages_to_bedrock_ignores_foreign_function_call_block() -> None:
     assert actual_system == []
 
 
-@pytest.fixture(autouse=True)
-def _reset_dropped_block_warnings() -> Iterator[None]:
-    """Isolate the process-wide warn-once state from test ordering."""
-    _warned_dropped_block_types.clear()
-    yield
-    _warned_dropped_block_types.clear()
-
-
 def test__messages_to_bedrock_ignores_foreign_reasoning_block() -> None:
     messages = [
         HumanMessage(content="What is 2 + 2?"),
@@ -795,40 +795,6 @@ def test__messages_to_bedrock_preserves_ai_audio_block() -> None:
     }
 
 
-def test__messages_to_bedrock_drops_foreign_block_nested_in_tool_result() -> None:
-    """Dropping applies inside tool result content, not just at the top level."""
-    messages = [
-        HumanMessage(content="What is the weather in Paris?"),
-        AIMessage(
-            content=[
-                {
-                    "type": "tool_result",
-                    "tool_use_id": "call_abc",
-                    "content": [
-                        {"type": "text", "text": "Sunny"},
-                        {"type": "foreign_provider_block"},
-                    ],
-                }
-            ]
-        ),
-    ]
-
-    actual_messages, _ = _messages_to_bedrock(messages)
-
-    assert actual_messages[1] == {
-        "role": "assistant",
-        "content": [
-            {
-                "toolResult": {
-                    "toolUseId": "call_abc",
-                    "content": [{"text": "Sunny"}],
-                    "status": "success",
-                }
-            }
-        ],
-    }
-
-
 def test__messages_to_bedrock_replaces_dropped_nested_tool_result_content() -> None:
     """Tool results remain valid when all nested content is unsupported."""
     messages = [
@@ -860,17 +826,19 @@ def test__messages_to_bedrock_replaces_dropped_nested_tool_result_content() -> N
     }
 
 
-def _dropped_block_warnings(caplog: pytest.LogCaptureFixture) -> List[str]:
-    """Return warnings about individual dropped blocks.
+def _warnings_matching(
+    caplog: pytest.LogCaptureFixture,
+    substring: str = "Dropping unsupported content block",
+) -> List[str]:
+    """Return warnings whose message contains `substring`.
 
-    Filters out the separate warning about an assistant turn left with no
-    usable content, which is emitted unconditionally.
+    The default separates the per-block drop warning from the warning about an
+    assistant turn left with no usable content, which is unconditional.
     """
     return [
         record.getMessage()
         for record in caplog.records
-        if record.levelno == logging.WARNING
-        and "Dropping unsupported content block" in record.getMessage()
+        if record.levelno == logging.WARNING and substring in record.getMessage()
     ]
 
 
@@ -885,12 +853,10 @@ def test__messages_to_bedrock_warns_once_per_dropped_block_type(
         AIMessage(content=[{"type": "foreign_provider_block"}]),
     ]
 
-    with caplog.at_level(
-        logging.WARNING, logger="langchain_aws.chat_models.bedrock_converse"
-    ):
+    with caplog.at_level(logging.WARNING, logger="langchain_aws"):
         _messages_to_bedrock(messages)
 
-    warnings_logged = _dropped_block_warnings(caplog)
+    warnings_logged = _warnings_matching(caplog)
     assert len(warnings_logged) == 1
     assert "foreign_provider_block" in warnings_logged[0]
     # Blocks can carry user data, so the warning names the block type only; the
@@ -913,12 +879,10 @@ def test__messages_to_bedrock_warns_per_distinct_non_standard_block(
         ),
     ]
 
-    with caplog.at_level(
-        logging.WARNING, logger="langchain_aws.chat_models.bedrock_converse"
-    ):
+    with caplog.at_level(logging.WARNING, logger="langchain_aws"):
         _messages_to_bedrock(messages)
 
-    warnings_logged = _dropped_block_warnings(caplog)
+    warnings_logged = _warnings_matching(caplog)
     assert len(warnings_logged) == 2
     assert "openai_annotation" in warnings_logged[0]
     assert "google_grounding" in warnings_logged[1]
@@ -935,16 +899,10 @@ def test__messages_to_bedrock_warns_when_assistant_turn_is_erased(
         AIMessage(content=[{"type": "foreign_provider_block"}]),
     ]
 
-    with caplog.at_level(
-        logging.WARNING, logger="langchain_aws.chat_models.bedrock_converse"
-    ):
+    with caplog.at_level(logging.WARNING, logger="langchain_aws"):
         _messages_to_bedrock(messages)
 
-    erased = [
-        record.getMessage()
-        for record in caplog.records
-        if "has no content Bedrock can accept" in record.getMessage()
-    ]
+    erased = _warnings_matching(caplog, "has no content Bedrock can accept")
     # Reported for every erased turn, unlike the deduped per-block warning, and
     # naming the message so it can be found in a long replayed history.
     assert len(erased) == 2
@@ -1077,6 +1035,26 @@ def test__messages_to_bedrock_rejects_malformed_ai_block(block: Dict[str, Any]) 
     """Structurally broken blocks keep raising, even where dropping applies."""
     with pytest.raises(ValueError, match="Unsupported content block type"):
         _messages_to_bedrock([AIMessage(content=[block])])
+
+
+def test__bedrock_content_block_keys_match_botocore() -> None:
+    """Catch drift between the hardcoded allowlist and the service model.
+
+    The allowlist is parametrized over itself elsewhere, which only catches
+    someone deleting an entry. This catches the other direction: AWS adding a
+    `ContentBlock` member, which would otherwise be silently dropped from
+    assistant turns until someone noticed missing content.
+    """
+    service_model = botocore.session.get_session().get_service_model("bedrock-runtime")
+    expected = {
+        key
+        for shape_name in ("ContentBlock", "ToolResultContentBlock")
+        # `shape_for` is typed as returning the `Shape` base class; both of
+        # these are structures, which is where `members` lives.
+        for key in cast(StructureShape, service_model.shape_for(shape_name)).members
+    }
+
+    assert set(_BEDROCK_CONTENT_BLOCK_KEYS) == expected
 
 
 @pytest.mark.parametrize("key", sorted(_BEDROCK_CONTENT_BLOCK_KEYS))


### PR DESCRIPTION
Closes #1206

When a thread switches model providers, `AIMessage.content` can retain provider-specific blocks such as OpenAI Responses `function_call` items or Google reasoning. `ChatBedrockConverse` currently tries to serialize those raw blocks and raises before it can send the portable text and tool calls, leaving persisted threads unable to return to Bedrock.

This keeps conversion strict for human, system, and tool content while ignoring unsupported blocks in AI history. Standard tool calls are still reconstructed from `AIMessage.tool_calls`, preserving OpenAI's canonical `call_id` instead of its separate Responses item `id`. If every AI content block is provider-specific, a placeholder keeps the Bedrock assistant message valid.