### PR TITLE
fix(aws): Normalize cross-provider assistant content before serialization in ChatBedrockConverse

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -2256,19 +2256,33 @@ def _messages_to_bedrock(
 ) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
     """Handle Bedrock converse and Anthropic style content blocks"""
     for idx, message in enumerate(messages):
+        if not isinstance(message, AIMessage):
+            continue
+        model_provider = message.response_metadata.get("model_provider")
         # Translate v1 content
-        if (
-            isinstance(message, AIMessage)
-            and message.response_metadata.get("output_version") == "v1"
-        ):
+        if message.response_metadata.get("output_version") == "v1":
             messages[idx] = message.model_copy(
                 update={
                     "content": _convert_from_v1_to_converse(
                         cast(list[types.ContentBlock], message.content),
-                        message.response_metadata.get("model_provider"),
+                        model_provider,
                     )
                 }
             )
+        elif model_provider not in (None, "bedrock_converse", "bedrock"):
+            try:
+                normalized = message.content_blocks
+            except Exception:
+                logger.debug(
+                    "content_blocks normalization failed for message %d; "
+                    "serializing raw content.",
+                    idx,
+                    exc_info=True,
+                )
+            else:
+                messages[idx] = message.model_copy(
+                    update={"content": cast(list, normalized)}
+                )
 
     bedrock_messages: List[Dict[str, Any]] = []
     bedrock_system: List[Dict[str, Any]] = []
@@ -2900,6 +2914,16 @@ def _lc_content_to_bedrock(
                         "toolUseId": block["id"],
                         "input": tool_input,
                         "name": block["name"],
+                    }
+                }
+            )
+        elif block["type"] == "tool_call":
+            bedrock_content.append(
+                {
+                    "toolUse": {
+                        "toolUseId": block.get("id") or "",
+                        "input": block.get("args") or {},
+                        "name": block.get("name", ""),
                     }
                 }
             )

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -7282,3 +7282,84 @@ def test_format_tools_strips_null_anyof() -> None:
     assert input_schema["properties"]["limit"] == {"type": "integer"}
     assert input_schema["properties"]["offset"] == {"type": "integer"}
     assert input_schema["properties"]["query"] == {"type": "string"}
+
+
+def test__lc_content_to_bedrock_standard_tool_call_block() -> None:
+    content = _lc_content_to_bedrock(
+        [
+            {
+                "type": "tool_call",
+                "name": "get_weather",
+                "args": {"city": "Paris"},
+                "id": "call_1",
+            }
+        ]
+    )
+    assert content == [
+        {
+            "toolUse": {
+                "toolUseId": "call_1",
+                "input": {"city": "Paris"},
+                "name": "get_weather",
+            }
+        }
+    ]
+
+
+def test__messages_to_bedrock_normalizes_foreign_provider_content() -> None:
+    messages = [
+        HumanMessage("hi"),
+        AIMessage(
+            content=[
+                {"type": "thinking", "thinking": "hmm", "signature": "Z29vZ2xl"},
+                {"type": "text", "text": "answer"},
+            ],
+            response_metadata={"model_provider": "google_genai"},
+        ),
+        HumanMessage("go on"),
+    ]
+    bedrock_messages, _ = _messages_to_bedrock(messages)
+    assert bedrock_messages[1]["content"] == [{"text": "answer"}]
+
+
+def test__messages_to_bedrock_native_thinking_not_normalized() -> None:
+    thinking = {"type": "thinking", "thinking": "hmm", "signature": "YW50aA=="}
+    expected = [
+        {
+            "reasoningContent": {
+                "reasoningText": {"text": "hmm", "signature": "YW50aA=="}
+            }
+        },
+        {"text": "answer"},
+    ]
+    for meta in ({"model_provider": "bedrock_converse"}, {}):
+        messages = [
+            HumanMessage("hi"),
+            AIMessage(
+                content=[thinking, {"type": "text", "text": "answer"}],
+                response_metadata=meta,
+            ),
+            HumanMessage("go on"),
+        ]
+        bedrock_messages, _ = _messages_to_bedrock(messages)
+        assert bedrock_messages[1]["content"] == expected, f"meta={meta}"
+
+
+def test__messages_to_bedrock_foreign_tool_call_round_trip() -> None:
+    messages = [
+        HumanMessage("weather?"),
+        AIMessage(
+            content=[
+                {
+                    "type": "tool_call",
+                    "name": "get_weather",
+                    "args": {"city": "Paris"},
+                    "id": "call_1",
+                }
+            ],
+        ),
+        ToolMessage("sunny", tool_call_id="call_1"),
+    ]
+    bedrock_messages, _ = _messages_to_bedrock(messages)
+    assert bedrock_messages[1]["content"][0]["toolUse"]["toolUseId"] == "call_1"
+    assert bedrock_messages[2]["content"][0]["toolResult"]["toolUseId"] == "call_1"


### PR DESCRIPTION
Follow-up to #1218, this covers 2 extra edge cases with processing cross-provider messages:

**1. Signed Gemini thinking blocks**

When `ChatGoogleGenerativeAI` generates thinking blocks from the raw Gemini response, it also includes Gemini's thinking signatures. Unfortunately this happens to be the exact same format as Anthropic's blocks (i.e. `{"type": "thinking", "thinking": "...", "signature": "..."}`), so they get serialized as Anthropic thinking blocks anyway, and Bedrock subsequently throws an error when it doesn't recognize the signature format. 

Fixed this by adding a normalization step for AI messages from other providers, so that they're translated to a standard type and dropped with the other unsupported cross-provider AI blocks by the logic implemented in #1218.

**2. `tool_call` handling**

We don't currently have handling for `tool_call` content type, so these blocks get dropped and sometimes end up orphaning a corresponding `tool_result` block, which Bedrock doesn't allow. 

Fixed by adding another condition to `_messages_to_bedrock` to convert `tool_call` blocks to `toolUse`.

