### PR TITLE
fix(aws): Raise error on unsupported guardrail header usage with Mantle

### DIFF
--- a/libs/aws/langchain_aws/chat_models/anthropic.py
+++ b/libs/aws/langchain_aws/chat_models/anthropic.py
@@ -23,7 +23,11 @@ from typing_extensions import Self
 from langchain_aws._version import _add_langchain_aws_version
 from langchain_aws.chat_models._anthropic_utils import _create_bedrock_client_params
 from langchain_aws.data._profiles import _PROFILES
-from langchain_aws.utils import MODEL_ID_GEO_PREFIXES
+from langchain_aws.utils import (
+    _MANTLE_GUARDRAILS_ERR_MSG,
+    MODEL_ID_GEO_PREFIXES,
+    _check_no_mantle_guardrail_headers,
+)
 
 _MODEL_PROFILES = cast("ModelProfileRegistry", _PROFILES)
 
@@ -468,6 +472,32 @@ class ChatAnthropicMantle(ChatAnthropic):
         if isinstance(values, dict) and not values.get("anthropic_api_key"):
             values["anthropic_api_key"] = ""
         return values
+
+    @model_validator(mode="before")
+    @classmethod
+    def _reject_guardrails(cls, values: Any) -> Any:
+        # TODO: remove after Mantle adds guardrails support
+        if isinstance(values, dict):
+            if any(
+                values.get(key) is not None
+                for key in ("guardrail_config", "guardrails")
+            ):
+                raise ValueError(_MANTLE_GUARDRAILS_ERR_MSG)
+            _check_no_mantle_guardrail_headers(values.get("default_headers"))
+        return values
+
+    def _get_request_payload(
+        self,
+        input_: Any,
+        *,
+        stop: list[str] | None = None,
+        **kwargs: Any,
+    ) -> dict:
+        # TODO: remove after Mantle adds guardrails support
+        if kwargs.get("guardrail_config") is not None:
+            raise ValueError(_MANTLE_GUARDRAILS_ERR_MSG)
+        _check_no_mantle_guardrail_headers(kwargs.get("extra_headers"))
+        return super()._get_request_payload(input_, stop=stop, **kwargs)
 
     @property
     def _client_params(self) -> dict[str, Any]:

--- a/libs/aws/langchain_aws/chat_models/openai.py
+++ b/libs/aws/langchain_aws/chat_models/openai.py
@@ -33,7 +33,9 @@ from langchain_aws._version import _add_langchain_aws_version
 from langchain_aws.data._profiles import _PROFILES
 from langchain_aws.utils import (
     _BEDROCK_API_KEY_MAX_TTL_SECONDS,
+    _MANTLE_GUARDRAILS_ERR_MSG,
     _BedrockApiKeyProvider,
+    _check_no_mantle_guardrail_headers,
 )
 
 _MANTLE_BASE_URL_TEMPLATE = "https://bedrock-mantle.{region}.api.aws/v1"
@@ -164,6 +166,32 @@ class ChatOpenAIMantle(BaseChatOpenAI):
     Capped by Bedrock's server-side maximum and by the underlying credential
     lifetime for refreshable credentials (AssumeRole, SSO, IRSA, ...).
     """
+
+    @model_validator(mode="before")
+    @classmethod
+    def _reject_guardrails(cls, values: Any) -> Any:
+        # TODO: remove after Mantle adds guardrails support
+        if isinstance(values, dict):
+            if any(
+                values.get(key) is not None
+                for key in ("guardrail_config", "guardrails")
+            ):
+                raise ValueError(_MANTLE_GUARDRAILS_ERR_MSG)
+            _check_no_mantle_guardrail_headers(values.get("default_headers"))
+        return values
+
+    def _get_request_payload(
+        self,
+        input_: LanguageModelInput,
+        *,
+        stop: list[str] | None = None,
+        **kwargs: Any,
+    ) -> dict:
+        # TODO: remove after Mantle adds guardrails support
+        if kwargs.get("guardrail_config") is not None:
+            raise ValueError(_MANTLE_GUARDRAILS_ERR_MSG)
+        _check_no_mantle_guardrail_headers(kwargs.get("extra_headers"))
+        return super()._get_request_payload(input_, stop=stop, **kwargs)
 
     @model_validator(mode="before")
     @classmethod

--- a/libs/aws/langchain_aws/utils.py
+++ b/libs/aws/langchain_aws/utils.py
@@ -557,6 +557,23 @@ def trim_message_whitespace(messages: List[Any]) -> List[Any]:
     return messages
 
 
+_MANTLE_GUARDRAILS_ERR_MSG = (
+    "Amazon Bedrock Guardrails are not supported on the bedrock-mantle "
+    "endpoint. Please use ``ChatAnthropicBedrock`` or ``ChatBedrockConverse`` "
+    "instead, which support guardrails via the bedrock-runtime endpoint."
+)
+
+
+def _check_no_mantle_guardrail_headers(headers: Optional[Dict[str, Any]]) -> None:
+    """Reject Bedrock guardrail headers, which Mantle silently ignores."""
+    # TODO: remove after Mantle adds guardrails support
+    if not headers:
+        return
+    for key in headers:
+        if key.lower().startswith("x-amzn-bedrock-guardrail"):
+            raise ValueError(_MANTLE_GUARDRAILS_ERR_MSG)
+
+
 class _StaticCredentialProvider:
     """Wraps resolved botocore credentials in the shape ``provide_token`` expects.
 

--- a/libs/aws/tests/unit_tests/chat_models/test_anthropic_mantle.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_anthropic_mantle.py
@@ -1,6 +1,6 @@
 """ChatAnthropicMantle unit tests."""
 
-from typing import Tuple, Type, cast
+from typing import Any, Tuple, Type, cast
 
 import pytest
 from langchain_core.language_models import BaseChatModel, ModelProfile
@@ -218,3 +218,39 @@ def test_inherits_anthropic_features() -> None:
         "_agenerate",
     ):
         assert hasattr(model, attr)
+
+
+def _make_model(**kwargs: Any) -> ChatAnthropicMantle:
+    return ChatAnthropicMantle(  # type: ignore[call-arg]
+        model_name=MODEL_NAME,
+        region_name="us-east-1",
+        bedrock_api_key=SecretStr("test-key"),
+        **kwargs,
+    )
+
+
+def test_guardrail_default_headers_rejected_at_construction() -> None:
+    with pytest.raises(ValueError, match="not supported on the bedrock-mantle"):
+        _make_model(
+            default_headers={
+                "X-Amzn-Bedrock-GuardrailIdentifier": "gr-1",
+                "X-Amzn-Bedrock-GuardrailVersion": "1",
+            },
+        )
+
+
+def test_guardrail_extra_headers_rejected_per_request() -> None:
+    model = _make_model()
+    with pytest.raises(ValueError, match="not supported on the bedrock-mantle"):
+        model._get_request_payload(
+            "hello",
+            extra_headers={"X-Amzn-Bedrock-GuardrailIdentifier": "gr-1"},
+        )
+
+
+def test_non_guardrail_headers_still_allowed() -> None:
+    model = _make_model(default_headers={"X-Custom-Header": "ok"})
+    payload = model._get_request_payload(
+        "hello", extra_headers={"X-Another-Header": "ok"}
+    )
+    assert payload["extra_headers"] == {"X-Another-Header": "ok"}

--- a/libs/aws/tests/unit_tests/chat_models/test_openai.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_openai.py
@@ -330,3 +330,39 @@ def test_installed_provider_mints_token_when_called() -> None:
     provider = cast("_BedrockApiKeyProvider", model.openai_api_key)
     with patch("aws_bedrock_token_generator.provide_token", return_value="tok-xyz"):
         assert provider() == "tok-xyz"
+
+
+def _make_model(**kwargs: object) -> ChatOpenAIMantle:
+    return ChatOpenAIMantle(
+        model=MODEL_NAME,
+        region_name="us-east-1",
+        bedrock_api_key=SecretStr("test-key"),
+        **kwargs,  # type: ignore[arg-type]
+    )
+
+
+def test_guardrail_default_headers_rejected_at_construction() -> None:
+    with pytest.raises(ValueError, match="not supported on the bedrock-mantle"):
+        _make_model(
+            default_headers={
+                "X-Amzn-Bedrock-GuardrailIdentifier": "gr-1",
+                "X-Amzn-Bedrock-GuardrailVersion": "1",
+            },
+        )
+
+
+def test_guardrail_extra_headers_rejected_per_request() -> None:
+    model = _make_model()
+    with pytest.raises(ValueError, match="not supported on the bedrock-mantle"):
+        model._get_request_payload(
+            "hello",
+            extra_headers={"X-Amzn-Bedrock-GuardrailIdentifier": "gr-1"},
+        )
+
+
+def test_non_guardrail_headers() -> None:
+    model = _make_model(default_headers={"X-Custom-Header": "ok"})
+    payload = model._get_request_payload(
+        "hello", extra_headers={"X-Another-Header": "ok"}
+    )
+    assert payload["extra_headers"] == {"X-Another-Header": "ok"}


### PR DESCRIPTION
Fixes #1224:

Updates `AnthropicBedrockMantle` and `ChatOpenAIMantle` to catch and throw an error on user attempts to pass `X-Amzn-Bedrock-Guardrail*` headers, which are currently unsupported on Mantle endpoint.

Marked TODO removal, as this is expected to be a temporary mitigation until Mantle guardrails support is added.