### PR TITLE
fix(aws): preserve redacted reasoning content

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -2963,7 +2963,15 @@ def _lc_content_to_bedrock(
             reasoning_content = block.get("reasoningContent") or block.get(
                 "reasoning_content", {}
             )
-            if reasoning_content.get("signature", ""):
+            if "redactedContent" in reasoning_content:
+                bedrock_content.append(
+                    {
+                        "reasoningContent": {
+                            "redactedContent": reasoning_content["redactedContent"]
+                        }
+                    }
+                )
+            elif reasoning_content.get("signature", ""):
                 bedrock_content.append(
                     {
                         "reasoningContent": {
@@ -3194,6 +3202,15 @@ def _bedrock_to_lc(content: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
                 )
             # Streaming block format
             else:
+                if "redacted_content" in reasoning_dict:
+                    lc_content.append(
+                        {
+                            "type": "reasoning_content",
+                            "reasoning_content": {
+                                "redacted_content": reasoning_dict["redacted_content"],
+                            },
+                        }
+                    )
                 if "text" in reasoning_dict:
                     lc_content.append(
                         {

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -1694,6 +1694,25 @@ def test__bedrock_to_lc_anthropic_reasoning() -> None:
     assert expected_lc == actual
 
 
+def test__bedrock_to_lc_redacted_reasoning_round_trip() -> None:
+    redacted_content = b"encrypted-reasoning"
+    expected_lc: List[Union[str, Dict[str, Any]]] = [
+        {
+            "type": "reasoning_content",
+            "reasoning_content": {"redacted_content": redacted_content},
+        }
+    ]
+
+    actual = _bedrock_to_lc(
+        [{"reasoningContent": {"redactedContent": redacted_content}}]
+    )
+
+    assert actual == expected_lc
+    assert _lc_content_to_bedrock(cast(List[Union[str, Dict[str, Any]]], actual)) == [
+        {"reasoningContent": {"redactedContent": redacted_content}}
+    ]
+
+
 def test__bedrock_to_lc_nova_reasoning_content() -> None:
     """Test parsing Nova's reasoningContent format."""
     bedrock_content: List[Dict[str, Any]] = [
@@ -5563,6 +5582,29 @@ def test_content_block_delta_tool_call_chunk_args_type() -> None:
     args = chunk.tool_call_chunks[0]["args"]
     assert isinstance(args, str)
     assert args == '{"city": "Paris"}'
+
+
+def test_content_block_delta_redacted_reasoning() -> None:
+    redacted_content = b"encrypted-reasoning"
+    event = {
+        "contentBlockDelta": {
+            "contentBlockIndex": 2,
+            "delta": {
+                "reasoningContent": {"redactedContent": redacted_content},
+            },
+        }
+    }
+
+    chunk = _parse_stream_event(event)
+
+    assert isinstance(chunk, AIMessageChunk)
+    assert chunk.content == [
+        {
+            "type": "reasoning_content",
+            "reasoning_content": {"redacted_content": redacted_content},
+            "index": 2,
+        }
+    ]
 
 
 def test_streaming_tool_use_round_trip() -> None:


### PR DESCRIPTION
Fixes #1223

Preserve encrypted Bedrock reasoning deltas as `reasoning_content` blocks so streamed reasoning does not crash and the opaque payload can be replayed in later turns.

---

Bedrock ConverseStream may return `reasoningContent.redactedContent` instead of text or a signature. The inbound converter previously dropped that valid union member, leaving `_parse_stream_event` to index an empty result. This maps the payload into the existing reasoning block shape and restores it to Bedrock format on outbound conversion.

The main area to review is the provider-specific `redacted_content` field retained inside the existing `reasoning_content` block.

<details>
<summary>Test plan</summary>

- Added a failing-then-passing regression for parsing and replaying redacted reasoning.
- Added a streamed-delta regression covering the former `IndexError` path.
- Full `test_bedrock_converse.py`: 370 passed, 1 xpassed.
- Ruff check and format passed; mypy passed across 145 source files.

</details>

AI-assisted investigation and implementation; all changes were reviewed and verified locally.