### PR TITLE
fix(aws): parametrize reasoning block construction by model id

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -2788,6 +2788,9 @@ def _bedrock_reasoning_block(
     )
 
     model_id_lower = (model_id or "").lower()
+    # TODO: `_get_base_model()` returns the raw ARN when `model_id` is an ARN and
+    # `base_model_id` is unset, so this misses Nova v1. Strip the ARN there, then
+    # simplify this to use the resolved provider.
     provider = model_id_lower.partition(".")[0]
 
     if any(

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -2770,7 +2770,7 @@ def _empty_content_fallback(
 
 
 def _bedrock_reasoning_block(
-    text: str, signature: str, model_id: Optional[str]
+    reasoning: Dict[str, Any], model_id: Optional[str]
 ) -> Optional[Dict[str, Any]]:
     """Build a Converse `reasoningContent` block, or `None` if `model_id` rejects it."""
     # Models that reject reasoning content in prior assistant turns entirely, whether
@@ -2796,6 +2796,12 @@ def _bedrock_reasoning_block(
         logger.debug("Dropping reasoning block; %s rejects reasoning content", model_id)
         return None
 
+    # Encrypted reasoning is opaque, so there is no text or signature to gate on.
+    if redacted := reasoning.get("redactedContent"):
+        return {"reasoningContent": {"redactedContent": redacted}}
+
+    text = reasoning.get("text", "")
+    signature = reasoning.get("signature", "")
     if not signature and (
         not text
         or not any(model in model_id_lower for model in _unsigned_reasoning_models)
@@ -3002,7 +3008,11 @@ def _lc_content_to_bedrock(
             bedrock_content.append({"guardContent": {"text": {"text": block["text"]}}})
         elif block["type"] == "thinking":
             reasoning_block = _bedrock_reasoning_block(
-                block.get("thinking", ""), block.get("signature", ""), model_id
+                {
+                    "text": block.get("thinking", ""),
+                    "signature": block.get("signature", ""),
+                },
+                model_id,
             )
             if reasoning_block:
                 bedrock_content.append(reasoning_block)
@@ -3010,11 +3020,7 @@ def _lc_content_to_bedrock(
             reasoning_content = block.get("reasoningContent") or block.get(
                 "reasoning_content", {}
             )
-            reasoning_block = _bedrock_reasoning_block(
-                reasoning_content.get("text", ""),
-                reasoning_content.get("signature", ""),
-                model_id,
-            )
+            reasoning_block = _bedrock_reasoning_block(reasoning_content, model_id)
             if reasoning_block:
                 bedrock_content.append(reasoning_block)
         elif block["type"] == "non_standard" and "value" in block:
@@ -3237,6 +3243,15 @@ def _bedrock_to_lc(content: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
                 )
             # Streaming block format
             else:
+                if "redacted_content" in reasoning_dict:
+                    lc_content.append(
+                        {
+                            "type": "reasoning_content",
+                            "reasoning_content": {
+                                "redacted_content": reasoning_dict["redacted_content"],
+                            },
+                        }
+                    )
                 if "text" in reasoning_dict:
                     lc_content.append(
                         {

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -1330,7 +1330,9 @@ class ChatBedrockConverse(BaseChatModel):
             logger.debug(f"Using raw blocks: {self.raw_blocks}")
             bedrock_messages, system = self.raw_blocks, []
         else:
-            bedrock_messages, system = _messages_to_bedrock(messages, self.system)
+            bedrock_messages, system = _messages_to_bedrock(
+                messages, self.system, model_id=self._get_base_model()
+            )
             if self.guard_last_turn_only:
                 logger.debug("Applying selective guardrail to only the last turn")
                 self._apply_guard_last_turn_only(bedrock_messages)
@@ -1406,7 +1408,9 @@ class ChatBedrockConverse(BaseChatModel):
             logger.debug(f"Using raw blocks: {self.raw_blocks}")
             bedrock_messages, system = self.raw_blocks, []
         else:
-            bedrock_messages, system = _messages_to_bedrock(messages, self.system)
+            bedrock_messages, system = _messages_to_bedrock(
+                messages, self.system, model_id=self._get_base_model()
+            )
             if self.guard_last_turn_only:
                 logger.debug("Applying selective guardrail to only the last turn")
                 self._apply_guard_last_turn_only(bedrock_messages)
@@ -2116,7 +2120,9 @@ class ChatBedrockConverse(BaseChatModel):
             bedrock_messages, system = (
                 (self.raw_blocks, [])
                 if self.raw_blocks
-                else _messages_to_bedrock(messages, self.system)
+                else _messages_to_bedrock(
+                    messages, self.system, model_id=self._get_base_model()
+                )
             )
 
             input_data = {"converse": {"messages": bedrock_messages}}
@@ -2253,6 +2259,8 @@ def _handle_bedrock_error(error: ClientError) -> None:
 def _messages_to_bedrock(
     messages: List[BaseMessage],
     system: Optional[List[Union[str, Dict[str, Any]]]] = None,
+    *,
+    model_id: Optional[str] = None,
 ) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
     """Handle Bedrock converse and Anthropic style content blocks"""
     for idx, message in enumerate(messages):
@@ -2305,7 +2313,9 @@ def _messages_to_bedrock(
         # raising, so a block this module simply does not handle yet stays a
         # loud bug rather than silently vanishing from the prompt.
         content = _lc_content_to_bedrock(
-            msg.content, drop_unsupported=isinstance(msg, AIMessage)
+            msg.content,
+            drop_unsupported=isinstance(msg, AIMessage),
+            model_id=model_id,
         )
         if isinstance(msg, HumanMessage):
             # If there's a human, tool, human message sequence, the
@@ -2451,9 +2461,9 @@ def _split_inline_reasoning(
 ) -> List[Dict[str, Any]]:
     """Split text into ordered text / reasoning_content blocks on complete tag pairs.
 
-    Each ``open_tag ... close_tag`` pair becomes a ``reasoning_content`` block (no
-    ``signature``, so ``_lc_content_to_bedrock`` drops it on round-trips); surrounding
-    text stays as ``text`` blocks.
+    Each ``open_tag ... close_tag`` pair becomes a ``reasoning_content`` block (which
+    ``_bedrock_reasoning_block`` drops on round-trips, since these models reject
+    reasoning content); surrounding text stays as ``text`` blocks.
     """
     if open_tag not in text:
         return [{"type": "text", "text": text}]
@@ -2759,10 +2769,41 @@ def _empty_content_fallback(
     return blocks or [{"text": EMPTY_CONTENT}]
 
 
+def _bedrock_reasoning_block(
+    text: str, signature: str, model_id: Optional[str]
+) -> Optional[Dict[str, Any]]:
+    """Build a Converse `reasoningContent` block, or `None` if `model_id` rejects it."""
+    # Models that reject reasoning content in prior assistant turns entirely, whether
+    # or not it carries a signature. Models that emit inline reasoning (see
+    # `_inline_reasoning_tags`) reject it too, and are detected rather than listed.
+    _reasoning_unsupported_models = ("deepseek.r1",)
+
+    model_id_lower = (model_id or "").lower()
+    provider = model_id_lower.partition(".")[0]
+
+    if any(
+        model in model_id_lower for model in _reasoning_unsupported_models
+    ) or _inline_reasoning_tags(provider, model_id_lower):
+        logger.debug("Dropping reasoning block; %s rejects reasoning content", model_id)
+        return None
+
+    if not signature and (
+        not model_id_lower or "anthropic" in model_id_lower or not text
+    ):
+        logger.debug("Dropping unsigned reasoning block for model %s", model_id)
+        return None
+
+    reasoning_text: Dict[str, Any] = {"text": text}
+    if signature:
+        reasoning_text["signature"] = signature
+    return {"reasoningContent": {"reasoningText": reasoning_text}}
+
+
 def _lc_content_to_bedrock(
     content: Union[str, List[Union[str, Dict[str, Any]]]],
     *,
     drop_unsupported: bool = False,
+    model_id: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     if isinstance(content, str):
         if not content or content.isspace():
@@ -2935,7 +2976,9 @@ def _lc_content_to_bedrock(
                         "toolUseId": block["toolUseId"],
                         "content": _empty_content_fallback(
                             _lc_content_to_bedrock(
-                                block["content"], drop_unsupported=drop_unsupported
+                                block["content"],
+                                drop_unsupported=drop_unsupported,
+                                model_id=model_id,
                             )
                         ),
                         "status": "error" if block.get("isError") else "success",
@@ -2948,32 +2991,22 @@ def _lc_content_to_bedrock(
         elif block["type"] == "guard_content":
             bedrock_content.append({"guardContent": {"text": {"text": block["text"]}}})
         elif block["type"] == "thinking":
-            if block.get("signature", ""):
-                bedrock_content.append(
-                    {
-                        "reasoningContent": {
-                            "reasoningText": {
-                                "text": block.get("thinking", ""),
-                                "signature": block.get("signature", ""),
-                            }
-                        }
-                    }
-                )
+            reasoning_block = _bedrock_reasoning_block(
+                block.get("thinking", ""), block.get("signature", ""), model_id
+            )
+            if reasoning_block:
+                bedrock_content.append(reasoning_block)
         elif block["type"] == "reasoning_content":
             reasoning_content = block.get("reasoningContent") or block.get(
                 "reasoning_content", {}
             )
-            if reasoning_content.get("signature", ""):
-                bedrock_content.append(
-                    {
-                        "reasoningContent": {
-                            "reasoningText": {
-                                "text": reasoning_content.get("text", ""),
-                                "signature": reasoning_content.get("signature", ""),
-                            }
-                        }
-                    }
-                )
+            reasoning_block = _bedrock_reasoning_block(
+                reasoning_content.get("text", ""),
+                reasoning_content.get("signature", ""),
+                model_id,
+            )
+            if reasoning_block:
+                bedrock_content.append(reasoning_block)
         elif block["type"] == "non_standard" and "value" in block:
             # langchain-core's content_blocks property wraps provider-specific
             # blocks (e.g. cachePoint, guardContent) that lack a recognized

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -2777,6 +2777,15 @@ def _bedrock_reasoning_block(
     # or not it carries a signature. Models that emit inline reasoning (see
     # `_inline_reasoning_tags`) reject it too, and are detected rather than listed.
     _reasoning_unsupported_models = ("deepseek.r1",)
+    # Models verified to accept reasoning content carrying no signature. Anything not
+    # listed keeps its reasoning only when signed.
+    _unsigned_reasoning_models = (
+        "openai.gpt-oss",
+        "amazon.nova-2",
+        "deepseek.v3",
+        "minimax",
+        "kimi",
+    )
 
     model_id_lower = (model_id or "").lower()
     provider = model_id_lower.partition(".")[0]
@@ -2788,7 +2797,8 @@ def _bedrock_reasoning_block(
         return None
 
     if not signature and (
-        not model_id_lower or "anthropic" in model_id_lower or not text
+        not text
+        or not any(model in model_id_lower for model in _unsigned_reasoning_models)
     ):
         logger.debug("Dropping unsigned reasoning block for model %s", model_id)
         return None

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -7378,6 +7378,12 @@ _ANSWER_BLOCK = {"text": "Answer."}
         # Models that accept unsigned reasoning have it forwarded.
         ("openai.gpt-oss-120b-1:0", "", [_REASONING_BLOCK, _ANSWER_BLOCK]),
         ("deepseek.v3.2", "", [_REASONING_BLOCK, _ANSWER_BLOCK]),
+        ("minimax.minimax-m2.5", "", [_REASONING_BLOCK, _ANSWER_BLOCK]),
+        ("moonshotai.kimi-k2.5", "", [_REASONING_BLOCK, _ANSWER_BLOCK]),
+        # Models that emit unsigned reasoning but reject it on the way back are
+        # absent from the allowlist, so their reasoning is still dropped.
+        ("openai.gpt-5.6-luna", "", [_ANSWER_BLOCK]),
+        ("xai.grok-4.6", "", [_ANSWER_BLOCK]),
         # DeepSeek R1 rejects reasoning content whether or not it is signed.
         ("deepseek.r1-v1:0", "", [_ANSWER_BLOCK]),
         ("deepseek.r1-v1:0", "sig", [_ANSWER_BLOCK]),
@@ -7393,7 +7399,14 @@ _ANSWER_BLOCK = {"text": "Answer."}
         ("amazon.nova-pro-v1:0", "", [_ANSWER_BLOCK]),
         ("amazon.nova-pro-v1:0", "sig", [_ANSWER_BLOCK]),
         ("amazon.nova-2-lite-v1:0", "", [_REASONING_BLOCK, _ANSWER_BLOCK]),
-        # An unknown model falls back to requiring a signature.
+        # A model not vetted for unsigned reasoning falls back to requiring a
+        # signature, as does an unknown model.
+        ("cohere.command-r-plus-v1:0", "", [_ANSWER_BLOCK]),
+        (
+            "cohere.command-r-plus-v1:0",
+            "sig",
+            [_SIGNED_REASONING_BLOCK, _ANSWER_BLOCK],
+        ),
         (None, "", [_ANSWER_BLOCK]),
         (None, "sig", [_SIGNED_REASONING_BLOCK, _ANSWER_BLOCK]),
     ],

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -7451,3 +7451,61 @@ def test__messages_to_bedrock_reasoning_only_content() -> None:
     actual_messages, _ = _messages_to_bedrock(messages, model_id="deepseek.v3.2")
 
     assert actual_messages[1] == {"role": "assistant", "content": [_REASONING_BLOCK]}
+
+
+def test__bedrock_to_lc_redacted_reasoning_delta() -> None:
+    """A streamed delta carrying only redacted reasoning should not be dropped."""
+    assert _bedrock_to_lc([{"reasoningContent": {"redactedContent": b"abc"}}]) == [
+        {
+            "type": "reasoning_content",
+            "reasoning_content": {"redacted_content": b"abc"},
+        }
+    ]
+
+
+def test__messages_to_bedrock_redacted_reasoning_round_trip() -> None:
+    """Redacted reasoning survives a round trip without a signature."""
+    messages: List[BaseMessage] = [
+        HumanMessage(content="Question?"),
+        AIMessage(
+            content=[
+                {
+                    "type": "reasoning_content",
+                    "reasoning_content": {"redacted_content": b"abc"},
+                },
+                {"type": "text", "text": "Answer."},
+            ]
+        ),
+        HumanMessage(content="Follow-up?"),
+    ]
+
+    actual_messages, _ = _messages_to_bedrock(messages, model_id="xai.grok-4.6")
+
+    assert actual_messages[1] == {
+        "role": "assistant",
+        "content": [
+            {"reasoningContent": {"redactedContent": b"abc"}},
+            _ANSWER_BLOCK,
+        ],
+    }
+
+
+def test__messages_to_bedrock_redacted_reasoning_dropped_when_rejected() -> None:
+    """A model that rejects reasoning outright also rejects the encrypted form."""
+    messages: List[BaseMessage] = [
+        HumanMessage(content="Question?"),
+        AIMessage(
+            content=[
+                {
+                    "type": "reasoning_content",
+                    "reasoning_content": {"redacted_content": b"abc"},
+                },
+                {"type": "text", "text": "Answer."},
+            ]
+        ),
+        HumanMessage(content="Follow-up?"),
+    ]
+
+    actual_messages, _ = _messages_to_bedrock(messages, model_id="deepseek.r1-v1:0")
+
+    assert actual_messages[1] == {"role": "assistant", "content": [_ANSWER_BLOCK]}

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -7363,3 +7363,78 @@ def test__messages_to_bedrock_foreign_tool_call_round_trip() -> None:
     bedrock_messages, _ = _messages_to_bedrock(messages)
     assert bedrock_messages[1]["content"][0]["toolUse"]["toolUseId"] == "call_1"
     assert bedrock_messages[2]["content"][0]["toolResult"]["toolUseId"] == "call_1"
+
+
+_REASONING_BLOCK = {"reasoningContent": {"reasoningText": {"text": "Thinking."}}}
+_SIGNED_REASONING_BLOCK = {
+    "reasoningContent": {"reasoningText": {"text": "Thinking.", "signature": "sig"}}
+}
+_ANSWER_BLOCK = {"text": "Answer."}
+
+
+@pytest.mark.parametrize(
+    ("model_id", "signature", "expected_content"),
+    [
+        # Models that accept unsigned reasoning have it forwarded.
+        ("openai.gpt-oss-120b-1:0", "", [_REASONING_BLOCK, _ANSWER_BLOCK]),
+        ("deepseek.v3.2", "", [_REASONING_BLOCK, _ANSWER_BLOCK]),
+        # DeepSeek R1 rejects reasoning content whether or not it is signed.
+        ("deepseek.r1-v1:0", "", [_ANSWER_BLOCK]),
+        ("deepseek.r1-v1:0", "sig", [_ANSWER_BLOCK]),
+        # Anthropic models require a signature.
+        ("anthropic.claude-sonnet-4-5-20250929-v1:0", "", [_ANSWER_BLOCK]),
+        (
+            "anthropic.claude-sonnet-4-5-20250929-v1:0",
+            "sig",
+            [_SIGNED_REASONING_BLOCK, _ANSWER_BLOCK],
+        ),
+        # Nova v1 emits inline reasoning and rejects it on the way back; Nova 2
+        # uses native reasoning and accepts it.
+        ("amazon.nova-pro-v1:0", "", [_ANSWER_BLOCK]),
+        ("amazon.nova-pro-v1:0", "sig", [_ANSWER_BLOCK]),
+        ("amazon.nova-2-lite-v1:0", "", [_REASONING_BLOCK, _ANSWER_BLOCK]),
+        # An unknown model falls back to requiring a signature.
+        (None, "", [_ANSWER_BLOCK]),
+        (None, "sig", [_SIGNED_REASONING_BLOCK, _ANSWER_BLOCK]),
+    ],
+)
+def test__messages_to_bedrock_reasoning_by_model(
+    model_id: Optional[str], signature: str, expected_content: List[dict]
+) -> None:
+    messages: List[BaseMessage] = [
+        HumanMessage(content="Question?"),
+        AIMessage(
+            content=[
+                {
+                    "type": "reasoning_content",
+                    "reasoning_content": {"text": "Thinking.", "signature": signature},
+                },
+                {"type": "text", "text": "Answer."},
+            ]
+        ),
+        HumanMessage(content="Follow-up?"),
+    ]
+
+    actual_messages, _ = _messages_to_bedrock(messages, model_id=model_id)
+
+    assert actual_messages[1] == {"role": "assistant", "content": expected_content}
+
+
+def test__messages_to_bedrock_reasoning_only_content() -> None:
+    """An unsigned reasoning block should survive as the sole content block."""
+    messages: List[BaseMessage] = [
+        HumanMessage(content="Question?"),
+        AIMessage(
+            content=[
+                {
+                    "type": "reasoning_content",
+                    "reasoning_content": {"text": "Thinking.", "signature": ""},
+                }
+            ]
+        ),
+        HumanMessage(content="Follow-up?"),
+    ]
+
+    actual_messages, _ = _messages_to_bedrock(messages, model_id="deepseek.v3.2")
+
+    assert actual_messages[1] == {"role": "assistant", "content": [_REASONING_BLOCK]}


### PR DESCRIPTION
Within Converse, different models accept different forms of reasoning blocks. See below for example:
```python
import boto3

model = "openai.gpt-oss-120b-1:0"  # runs
# model = "deepseek.v3.2"          # runs
# model = "us.deepseek.r1-v1:0"    # ValidationException (reasoning content not allowed)
# model = "us.anthropic.claude-sonnet-4-5-20250929-v1:0"  # ValidationException (signature required)

payload =  {
"modelId": f"{model}",
"messages": [
    {"role": "user", "content": [{"text": "What is 2+2?"}]},
    {"role": "assistant", "content": [
        {"reasoningContent": {"reasoningText": {
            "text": "The user is asking for the sum of 2 and 2. 2+2=4."
        }}},
        {"text": "2 + 2 = 4."},
    ]},
    {"role": "user", "content": [{"text": "Now multiply that by 10."}]},
],
"system": [],
"inferenceConfig": {},
}

client = boto3.client("bedrock-runtime", region_name="us-east-1")
print(client.converse(**payload)["output"]["message"]["content"])
```

https://github.com/langchain-ai/langchain-aws/pull/408 gated reasoning blocks on the presence of a signature. This is correct for Anthropic models, and at the time also handled DeepSeek R1, which (a) doesn't return signatures, and (b) doesn't accept reasoning blocks passed back in. Now, there are models like DeepSeek 3.2 and GPT-OSS that do accept signature-less reasoning blocks.

Here we make the reasoning block construction depend on the model ID: we let unsigned reasoning be passed back to the model on subsequent turns via an allow-list.