### PR TITLE
fix(aws): align ChatAnthropicMantle auth precedence with the Anthropic SDK Mantle client

### DIFF
--- a/libs/aws/langchain_aws/chat_models/anthropic.py
+++ b/libs/aws/langchain_aws/chat_models/anthropic.py
@@ -372,7 +372,8 @@ class ChatAnthropicMantle(ChatAnthropic):
     support both authentication modes Mantle accepts:
 
     - **Amazon Bedrock API key** (bearer token), from ``bedrock_api_key`` or the
-      ``AWS_BEARER_TOKEN_BEDROCK`` environment variable.
+      ``AWS_BEARER_TOKEN_BEDROCK`` environment variable. Explicit SigV4
+      credentials take precedence over an environment-sourced API key.
     - **AWS SigV4** with standard AWS credentials — explicit keys, a named
       profile, or the default credential chain (environment, instance profile,
       SSO, etc.). Used automatically whenever no API key is provided.
@@ -416,8 +417,11 @@ class ChatAnthropicMantle(ChatAnthropic):
     """Amazon Bedrock API key used to authenticate to Mantle.
 
     If not provided, read from the ``AWS_BEARER_TOKEN_BEDROCK`` environment
-    variable. When neither is set, the client falls back to AWS SigV4 using
-    the credentials below (or the default AWS credential chain).
+    variable. An explicitly supplied API key takes precedence over SigV4
+    credentials. An environment-sourced API key is ignored when a profile or
+    complete access key pair is explicitly supplied, allowing callers to select
+    SigV4 authentication. Otherwise, the client falls back to the default AWS
+    credential chain when no API key is available.
     """
 
     aws_access_key_id: SecretStr | None = Field(
@@ -485,7 +489,17 @@ class ChatAnthropicMantle(ChatAnthropic):
         }
         if self.anthropic_api_url and "api.anthropic.com" not in self.anthropic_api_url:
             client_params["base_url"] = self.anthropic_api_url
-        if self.bedrock_api_key:
+        explicit_sigv4_credentials = (
+            "credentials_profile_name" in self.model_fields_set
+            and bool(self.credentials_profile_name)
+        ) or (
+            {"aws_access_key_id", "aws_secret_access_key"} <= self.model_fields_set
+            and self.aws_access_key_id is not None
+            and self.aws_secret_access_key is not None
+        )
+        if self.bedrock_api_key and (
+            "bedrock_api_key" in self.model_fields_set or not explicit_sigv4_credentials
+        ):
             client_params["api_key"] = self.bedrock_api_key.get_secret_value()
         if self.aws_access_key_id:
             client_params["aws_access_key"] = self.aws_access_key_id.get_secret_value()

--- a/libs/aws/langchain_aws/chat_models/anthropic.py
+++ b/libs/aws/langchain_aws/chat_models/anthropic.py
@@ -419,9 +419,9 @@ class ChatAnthropicMantle(ChatAnthropic):
     If not provided, read from the ``AWS_BEARER_TOKEN_BEDROCK`` environment
     variable. An explicitly supplied API key takes precedence over SigV4
     credentials. An environment-sourced API key is ignored when a profile or
-    complete access key pair is explicitly supplied, allowing callers to select
-    SigV4 authentication. Otherwise, the client falls back to the default AWS
-    credential chain when no API key is available.
+    either static credential is explicitly supplied and both resolve to values,
+    allowing callers to select SigV4 authentication. Otherwise, the client falls
+    back to the default AWS credential chain when no API key is available.
     """
 
     aws_access_key_id: SecretStr | None = Field(
@@ -493,7 +493,7 @@ class ChatAnthropicMantle(ChatAnthropic):
             "credentials_profile_name" in self.model_fields_set
             and bool(self.credentials_profile_name)
         ) or (
-            {"aws_access_key_id", "aws_secret_access_key"} <= self.model_fields_set
+            bool({"aws_access_key_id", "aws_secret_access_key"} & self.model_fields_set)
             and self.aws_access_key_id is not None
             and self.aws_secret_access_key is not None
         )

--- a/libs/aws/tests/unit_tests/chat_models/test_anthropic_mantle.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_anthropic_mantle.py
@@ -1,6 +1,8 @@
 """ChatAnthropicMantle unit tests."""
 
-from typing import Tuple, Type, cast
+from collections.abc import Mapping
+from typing import Any, Tuple, Type, cast
+from unittest.mock import patch
 
 import pytest
 from langchain_core.language_models import BaseChatModel, ModelProfile
@@ -11,6 +13,23 @@ from pytest import MonkeyPatch
 from langchain_aws import ChatAnthropicMantle
 
 MODEL_NAME = "anthropic.claude-sonnet-5"
+
+
+def _constructed_client_params(
+    model: ChatAnthropicMantle,
+) -> tuple[Mapping[str, Any], Mapping[str, Any]]:
+    with (
+        patch(
+            "langchain_aws.chat_models.anthropic.AnthropicBedrockMantle"
+        ) as sync_client,
+        patch(
+            "langchain_aws.chat_models.anthropic.AsyncAnthropicBedrockMantle"
+        ) as async_client,
+    ):
+        _ = model._client
+        _ = model._async_client
+
+    return sync_client.call_args.kwargs, async_client.call_args.kwargs
 
 
 class TestAnthropicMantleStandard(ChatModelUnitTests):
@@ -126,6 +145,80 @@ def test_credentials_profile_routed_to_client() -> None:
         credentials_profile_name="my-profile",
     )
     assert model._client_params["aws_profile"] == "my-profile"
+
+
+@pytest.mark.parametrize(
+    ("sigv4_params", "expected_client_params"),
+    [
+        (
+            {"credentials_profile_name": "my-profile"},
+            {"aws_profile": "my-profile"},
+        ),
+        (
+            {
+                "aws_access_key_id": SecretStr("AKIA-test"),
+                "aws_secret_access_key": SecretStr("secret-test"),
+                "aws_session_token": SecretStr("token-test"),
+            },
+            {
+                "aws_access_key": "AKIA-test",
+                "aws_secret_key": "secret-test",
+                "aws_session_token": "token-test",
+            },
+        ),
+    ],
+    ids=["profile", "explicit-keys"],
+)
+def test_explicit_sigv4_credentials_outrank_ambient_api_key(
+    sigv4_params: dict[str, Any], expected_client_params: dict[str, str]
+) -> None:
+    """An ambient bearer token does not override explicit SigV4 credentials."""
+    with MonkeyPatch().context() as m:
+        m.setenv("AWS_BEARER_TOKEN_BEDROCK", "ambient-key")
+        model = ChatAnthropicMantle(  # type: ignore[call-arg]
+            model=MODEL_NAME,
+            region_name="us-east-1",
+            **sigv4_params,
+        )
+
+        client_params_by_type = _constructed_client_params(model)
+
+    for client_params in client_params_by_type:
+        assert "api_key" not in client_params
+        for name, value in expected_client_params.items():
+            assert client_params[name] == value
+
+
+def test_explicit_bedrock_api_key_outranks_sigv4_credentials() -> None:
+    """An explicitly passed bearer key keeps precedence over SigV4 signals."""
+    with MonkeyPatch().context() as m:
+        m.setenv("AWS_BEARER_TOKEN_BEDROCK", "ambient-key")
+        model = ChatAnthropicMantle(  # type: ignore[call-arg]
+            model=MODEL_NAME,
+            region_name="us-east-1",
+            bedrock_api_key=SecretStr("explicit-key"),
+            credentials_profile_name="my-profile",
+        )
+
+        client_params_by_type = _constructed_client_params(model)
+
+    for client_params in client_params_by_type:
+        assert client_params["api_key"] == "explicit-key"
+
+
+def test_ambient_api_key_is_forwarded_without_explicit_sigv4_credentials() -> None:
+    """Ambient bearer authentication remains the default without SigV4 signals."""
+    with MonkeyPatch().context() as m:
+        m.setenv("AWS_BEARER_TOKEN_BEDROCK", "ambient-key")
+        model = ChatAnthropicMantle(  # type: ignore[call-arg]
+            model=MODEL_NAME,
+            region_name="us-east-1",
+        )
+
+        client_params_by_type = _constructed_client_params(model)
+
+    for client_params in client_params_by_type:
+        assert client_params["api_key"] == "ambient-key"
 
 
 def test_ls_params_provider() -> None:

--- a/libs/aws/tests/unit_tests/chat_models/test_anthropic_mantle.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_anthropic_mantle.py
@@ -148,13 +148,15 @@ def test_credentials_profile_routed_to_client() -> None:
 
 
 @pytest.mark.parametrize(
-    ("sigv4_params", "expected_client_params"),
+    ("credential_environment", "sigv4_params", "expected_client_params"),
     [
         (
+            {},
             {"credentials_profile_name": "my-profile"},
             {"aws_profile": "my-profile"},
         ),
         (
+            {},
             {
                 "aws_access_key_id": SecretStr("AKIA-test"),
                 "aws_secret_access_key": SecretStr("secret-test"),
@@ -166,15 +168,43 @@ def test_credentials_profile_routed_to_client() -> None:
                 "aws_session_token": "token-test",
             },
         ),
+        (
+            {"AWS_SECRET_ACCESS_KEY": "secret-from-env"},
+            {"aws_access_key_id": SecretStr("AKIA-explicit")},
+            {
+                "aws_access_key": "AKIA-explicit",
+                "aws_secret_key": "secret-from-env",
+            },
+        ),
+        (
+            {"AWS_ACCESS_KEY_ID": "AKIA-from-env"},
+            {"aws_secret_access_key": SecretStr("secret-explicit")},
+            {
+                "aws_access_key": "AKIA-from-env",
+                "aws_secret_key": "secret-explicit",
+            },
+        ),
     ],
-    ids=["profile", "explicit-keys"],
+    ids=[
+        "profile",
+        "explicit-keys",
+        "explicit-access-key",
+        "explicit-secret-key",
+    ],
 )
 def test_explicit_sigv4_credentials_outrank_ambient_api_key(
-    sigv4_params: dict[str, Any], expected_client_params: dict[str, str]
+    credential_environment: dict[str, str],
+    sigv4_params: dict[str, Any],
+    expected_client_params: dict[str, str],
 ) -> None:
     """An ambient bearer token does not override explicit SigV4 credentials."""
     with MonkeyPatch().context() as m:
+        m.delenv("AWS_ACCESS_KEY_ID", raising=False)
+        m.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+        m.delenv("AWS_SESSION_TOKEN", raising=False)
         m.setenv("AWS_BEARER_TOKEN_BEDROCK", "ambient-key")
+        for name, value in credential_environment.items():
+            m.setenv(name, value)
         model = ChatAnthropicMantle(  # type: ignore[call-arg]
             model=MODEL_NAME,
             region_name="us-east-1",
@@ -184,9 +214,9 @@ def test_explicit_sigv4_credentials_outrank_ambient_api_key(
         client_params_by_type = _constructed_client_params(model)
 
     for client_params in client_params_by_type:
-        assert "api_key" not in client_params
         for name, value in expected_client_params.items():
             assert client_params[name] == value
+        assert "api_key" not in client_params
 
 
 def test_explicit_bedrock_api_key_outranks_sigv4_credentials() -> None:


### PR DESCRIPTION
Partially addresses #1217.

## Summary

`ChatAnthropicMantle` currently promotes a Bedrock API key inherited from
`AWS_BEARER_TOKEN_BEDROCK` into the Anthropic SDK's explicit `api_key`
constructor argument. Because explicit API keys have the SDK's highest auth
precedence, that ambient value silently overrides SigV4 credentials supplied by
the caller.

This change omits an environment-derived API key when the caller explicitly
selects a named AWS profile or supplies either half of a complete effective AWS
access-key pair. An explicitly supplied `bedrock_api_key` still wins, and the
existing automatic behavior remains unchanged when the caller provides no
explicit SigV4 signal.

Thanks to @kimnamu for the detailed reproduction and proposed direction in
#1217.

## Changes

**`libs/aws/langchain_aws/chat_models/anthropic.py`**

- Distinguish caller-supplied authentication fields from environment defaults
  with Pydantic's `model_fields_set`.
- Prefer a caller-selected profile or complete effective access-key pair over
  an ambient Bedrock bearer token.
- Preserve explicit `bedrock_api_key` precedence and document the resulting
  authentication order.

**`libs/aws/tests/unit_tests/chat_models/test_anthropic_mantle.py`**

- Cover profiles, fully explicit key pairs, and both mixed explicit/environment
  key-pair directions.
- Verify the shared behavior reaches both synchronous and asynchronous SDK
  constructors.
- Protect explicit bearer-key precedence and the existing ambient-bearer
  default.

## Areas for careful review

- `model_fields_set` is intentionally used to distinguish caller intent from
  values populated by environment-backed default factories.
- This is the narrow precedence fix supported by the current public Anthropic
  SDK constructor. It does not add `auth_mode` or force refreshable default-chain
  SigV4 when an ambient bearer token exists; that broader part of #1217 still
  requires an SDK authentication-selection seam.

## Verification

- `make format` — clean; 147 files unchanged
- `make lint` — Ruff check/format and mypy passed; 145 source files checked
- `make test` — 1,211 passed, 3 skipped, 1 xpassed
- `git diff --check` — passed

The regression tests are hermetic and do not make network calls. A live Mantle
request was not run because no Mantle-enabled AWS credentials were available in
this environment.

## Release note

`ChatAnthropicMantle` now prefers caller-supplied AWS profile or access-key
credentials over a Bedrock API key inherited from
`AWS_BEARER_TOKEN_BEDROCK`. Explicit `bedrock_api_key` values and automatic
authentication behavior otherwise remain unchanged.

---

AI agents assisted with research, test authoring, implementation, and
independent review. I reviewed the final diff and verified the reported checks
before submission.
