### PR TITLE
fix(langgraph-checkpoint-aws): preserve delta snapshots when patching messages

### DIFF
--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/agentcore/helpers.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/agentcore/helpers.py
@@ -595,17 +595,19 @@ def patch_orphan_tool_calls(messages: Any) -> Any:
     tool_calls that don't have corresponding ToolMessages. This would cause
     Bedrock to throw a ValidationException. This function patches the state by
     adding placeholder ToolMessages with status="error" for each orphaned tool_call.
+    Delta snapshots are returned unchanged because they are incomplete seeds whose
+    pending writes are replayed later.
 
     Args:
         messages: Messages or delta snapshot from checkpoint channel values.
 
     Returns:
-        The original container type with placeholder `ToolMessage` objects added for
-        orphaned tool calls.
+        The original delta snapshot, or a message list with placeholder `ToolMessage`
+        objects added for orphaned tool calls.
     """
     delta_snapshot_type = getattr(serde_types, "_DeltaSnapshot", None)
     if delta_snapshot_type is not None and isinstance(messages, delta_snapshot_type):
-        return delta_snapshot_type(patch_orphan_tool_calls(messages.value))
+        return messages
 
     if not messages:
         return messages

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/agentcore/helpers.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/agentcore/helpers.py
@@ -11,7 +11,7 @@ import logging
 import time
 import warnings
 from collections import defaultdict
-from typing import Any, cast
+from typing import Any, Protocol, cast, overload
 
 import boto3
 from botocore.config import Config
@@ -24,6 +24,7 @@ from langgraph.checkpoint.base import (
     RunnableConfig,
     SerializerProtocol,
 )
+from langgraph.checkpoint.serde import types as serde_types
 
 from .constants import (
     EMPTY_CHANNEL_VALUE,
@@ -38,6 +39,12 @@ from .models import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+class _DeltaSnapshotProtocol(Protocol):
+    @property
+    def value(self) -> Any: ...
+
 
 # Union type for all events
 EventType = CheckpointEvent | ChannelDataEvent | WritesEvent
@@ -567,7 +574,21 @@ class EventProcessor:
         )
 
 
-def patch_orphan_tool_calls(messages: list[Any]) -> list[Any]:
+@overload
+def patch_orphan_tool_calls(
+    messages: _DeltaSnapshotProtocol,
+) -> _DeltaSnapshotProtocol: ...
+
+
+@overload
+def patch_orphan_tool_calls(messages: list[Any]) -> list[Any]: ...
+
+
+@overload
+def patch_orphan_tool_calls(messages: None) -> None: ...
+
+
+def patch_orphan_tool_calls(messages: Any) -> Any:
     """Add placeholder ToolMessages for orphaned tool_calls in AIMessages.
 
     When a checkpoint is saved mid-tool-execution, there may be AIMessages with
@@ -576,11 +597,16 @@ def patch_orphan_tool_calls(messages: list[Any]) -> list[Any]:
     adding placeholder ToolMessages with status="error" for each orphaned tool_call.
 
     Args:
-        messages: List of messages from checkpoint channel_values
+        messages: Messages or delta snapshot from checkpoint channel values.
 
     Returns:
-        List of messages with placeholder ToolMessages added for orphaned tool_calls
+        The original container type with placeholder `ToolMessage` objects added for
+        orphaned tool calls.
     """
+    delta_snapshot_type = getattr(serde_types, "_DeltaSnapshot", None)
+    if delta_snapshot_type is not None and isinstance(messages, delta_snapshot_type):
+        return delta_snapshot_type(patch_orphan_tool_calls(messages.value))
+
     if not messages:
         return messages
 

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_patch_orphan_tool_calls.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_patch_orphan_tool_calls.py
@@ -3,6 +3,7 @@ Unit tests for patch_orphan_tool_calls function.
 """
 
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langgraph.checkpoint.serde.types import _DeltaSnapshot
 
 from langgraph_checkpoint_aws.checkpoint.agentcore.helpers import (
     patch_orphan_tool_calls,
@@ -17,6 +18,24 @@ class TestPatchOrphanToolCalls:
 
     def test_none_messages_list(self):
         assert patch_orphan_tool_calls(None) is None
+
+    def test_delta_snapshot_preserves_type_and_patches_inner_messages(self):
+        messages = [
+            HumanMessage(content="Hello"),
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {"id": "orphan_123", "name": "get_weather", "args": {}},
+                ],
+            ),
+        ]
+
+        result = patch_orphan_tool_calls(_DeltaSnapshot(messages))
+
+        assert isinstance(result, _DeltaSnapshot)
+        assert result.value[:2] == messages
+        assert isinstance(result.value[2], ToolMessage)
+        assert result.value[2].tool_call_id == "orphan_123"
 
     def test_messages_without_tool_calls(self):
         messages = [

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_patch_orphan_tool_calls.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_patch_orphan_tool_calls.py
@@ -19,7 +19,7 @@ class TestPatchOrphanToolCalls:
     def test_none_messages_list(self):
         assert patch_orphan_tool_calls(None) is None
 
-    def test_delta_snapshot_preserves_type_and_patches_inner_messages(self):
+    def test_delta_snapshot_is_not_patched_before_pending_writes_replay(self):
         messages = [
             HumanMessage(content="Hello"),
             AIMessage(
@@ -30,12 +30,11 @@ class TestPatchOrphanToolCalls:
             ),
         ]
 
-        result = patch_orphan_tool_calls(_DeltaSnapshot(messages))
+        snapshot = _DeltaSnapshot(messages)
+        result = patch_orphan_tool_calls(snapshot)
 
-        assert isinstance(result, _DeltaSnapshot)
-        assert result.value[:2] == messages
-        assert isinstance(result.value[2], ToolMessage)
-        assert result.value[2].tool_call_id == "orphan_123"
+        assert result is snapshot
+        assert result.value == messages
 
     def test_messages_without_tool_calls(self):
         messages = [

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_patch_orphan_tool_calls.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_patch_orphan_tool_calls.py
@@ -2,11 +2,21 @@
 Unit tests for patch_orphan_tool_calls function.
 """
 
+import pytest
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
-from langgraph.checkpoint.serde.types import _DeltaSnapshot
+from langgraph.checkpoint.serde import types as _serde_types
 
 from langgraph_checkpoint_aws.checkpoint.agentcore.helpers import (
     patch_orphan_tool_calls,
+)
+
+# `_DeltaSnapshot` only exists on newer langgraph-checkpoint releases, while the
+# package still supports `langgraph-checkpoint>=3.0.0`. Import it defensively so
+# collection does not fail on versions that predate it.
+_DeltaSnapshot = getattr(_serde_types, "_DeltaSnapshot", None)
+requires_delta_snapshot = pytest.mark.skipif(
+    _DeltaSnapshot is None,
+    reason="requires a langgraph-checkpoint version that ships _DeltaSnapshot",
 )
 
 
@@ -19,6 +29,7 @@ class TestPatchOrphanToolCalls:
     def test_none_messages_list(self):
         assert patch_orphan_tool_calls(None) is None
 
+    @requires_delta_snapshot
     def test_delta_snapshot_is_not_patched_before_pending_writes_replay(self):
         messages = [
             HumanMessage(content="Hello"),

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_saver.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_saver.py
@@ -11,9 +11,11 @@ from unittest.mock import ANY, MagicMock, Mock, call, patch
 
 import pytest
 from botocore.exceptions import ClientError
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langchain_core.runnables import RunnableConfig
 from langgraph.checkpoint.base import Checkpoint, CheckpointMetadata, CheckpointTuple
 from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
+from langgraph.checkpoint.serde.types import _DeltaSnapshot
 from langgraph.constants import TASKS
 
 from langgraph_checkpoint_aws.checkpoint.agentcore.constants import (
@@ -1699,6 +1701,62 @@ class TestEventProcessor:
         assert tuple_result.checkpoint["id"] == "checkpoint_123"
         assert len(tuple_result.pending_writes) == 1
         assert tuple_result.checkpoint["channel_values"]["default"] == "test_value"
+
+    def test_build_checkpoint_tuple_does_not_patch_delta_snapshot_seed(
+        self,
+        processor,
+        sample_checkpoint_event,
+    ):
+        tool_call_id = "tooluse_resolved_by_pending_write"
+        seed = _DeltaSnapshot(
+            [
+                HumanMessage(content="How many libraries?", id="message_1"),
+                AIMessage(
+                    content="",
+                    id="message_2",
+                    tool_calls=[
+                        {"id": tool_call_id, "name": "execute_sql", "args": {}}
+                    ],
+                ),
+            ]
+        )
+        real_tool_result = ToolMessage(
+            content="1234",
+            id="message_3",
+            tool_call_id=tool_call_id,
+        )
+        sample_checkpoint_event.checkpoint_data["channel_versions"]["messages"] = (
+            "messages_v1"
+        )
+        config = CheckpointerConfig(
+            thread_id="test_thread",
+            actor_id="test_actor",
+            checkpoint_ns="test_ns",
+        )
+
+        tuple_result = processor.build_checkpoint_tuple(
+            sample_checkpoint_event,
+            [
+                WriteItem(
+                    task_id="task_1",
+                    channel="messages",
+                    value=real_tool_result,
+                )
+            ],
+            {("messages", "messages_v1"): seed},
+            config,
+        )
+
+        result_seed = tuple_result.checkpoint["channel_values"]["messages"]
+        tool_results = [
+            message for message in result_seed.value if isinstance(message, ToolMessage)
+        ] + [
+            value
+            for _, channel, value in tuple_result.pending_writes
+            if channel == "messages" and isinstance(value, ToolMessage)
+        ]
+        assert result_seed is seed
+        assert [message.tool_call_id for message in tool_results] == [tool_call_id]
 
     def test_build_checkpoint_tuple_with_parent(
         self,

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_saver.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_saver.py
@@ -14,8 +14,8 @@ from botocore.exceptions import ClientError
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langchain_core.runnables import RunnableConfig
 from langgraph.checkpoint.base import Checkpoint, CheckpointMetadata, CheckpointTuple
+from langgraph.checkpoint.serde import types as _serde_types
 from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
-from langgraph.checkpoint.serde.types import _DeltaSnapshot
 from langgraph.constants import TASKS
 
 from langgraph_checkpoint_aws.checkpoint.agentcore.constants import (
@@ -37,6 +37,15 @@ from langgraph_checkpoint_aws.checkpoint.agentcore.models import (
     WritesEvent,
 )
 from langgraph_checkpoint_aws.checkpoint.agentcore.saver import AgentCoreMemorySaver
+
+# `_DeltaSnapshot` only exists on newer langgraph-checkpoint releases, while the
+# package still supports `langgraph-checkpoint>=3.0.0`. Resolve it defensively so
+# collection does not fail on versions that predate it.
+_DeltaSnapshot = getattr(_serde_types, "_DeltaSnapshot", None)
+requires_delta_snapshot = pytest.mark.skipif(
+    _DeltaSnapshot is None,
+    reason="requires a langgraph-checkpoint version that ships _DeltaSnapshot",
+)
 
 # Configure pytest to use anyio for async tests
 pytestmark = pytest.mark.anyio
@@ -1702,6 +1711,7 @@ class TestEventProcessor:
         assert len(tuple_result.pending_writes) == 1
         assert tuple_result.checkpoint["channel_values"]["default"] == "test_value"
 
+    @requires_delta_snapshot
     def test_build_checkpoint_tuple_does_not_patch_delta_snapshot_seed(
         self,
         processor,


### PR DESCRIPTION
Fixes #1231

`AgentCoreMemorySaver` now preserves DeltaChannel snapshots while repairing orphaned tool calls, preventing resumed message state from becoming a nested list or gaining duplicate tool results.

---

`patch_orphan_tool_calls` previously iterated `_DeltaSnapshot` as its single NamedTuple field and returned a plain list. A snapshot is also an incomplete DeltaChannel seed whose pending writes are replayed later, so patching its inner messages can insert a placeholder for a tool result that the pending writes already contain. The helper now preserves delta snapshots unchanged while retaining orphan repair for complete message lists.

Runtime detection keeps the existing `langgraph-checkpoint>=3,<5` compatibility range importable even though `_DeltaSnapshot` is only present in newer checkpoint releases.

<details>
<summary>Test plan</summary>

- Both regressions fail on the previous implementation and pass with the fix: snapshot container preservation, and a seed tool call resolved by a pending `ToolMessage` without a duplicate ID
- Focused helper and seed-replay tests: 11 passed
- AgentCore target files: 91 stable tests passed; 5 pre-existing macOS concurrency timing assertions fail unchanged
- Full unit suite: 1072 passed; 9 pre-existing macOS/Python 3.13 concurrency timing assertions fail unchanged on `origin/main`
- Ruff format/check and mypy: passed
- Import smoke test with `langgraph-checkpoint==3.0.0`: passed

</details>

AI-agent assistance was used to implement and validate this contribution.