### PR TITLE
test(aws): Extra ChatAnthropicMantle auth priority tests + docstrings

### DIFF
--- a/libs/aws/langchain_aws/chat_models/anthropic.py
+++ b/libs/aws/langchain_aws/chat_models/anthropic.py
@@ -376,11 +376,19 @@ class ChatAnthropicMantle(ChatAnthropic):
     support both authentication modes Mantle accepts:
 
     - **Amazon Bedrock API key** (bearer token), from ``bedrock_api_key`` or the
-      ``AWS_BEARER_TOKEN_BEDROCK`` environment variable. Explicit SigV4
-      credentials take precedence over an environment-sourced API key.
+      ``AWS_BEARER_TOKEN_BEDROCK`` environment variable.
     - **AWS SigV4** with standard AWS credentials — explicit keys, a named
       profile, or the default credential chain (environment, instance profile,
-      SSO, etc.). Used automatically whenever no API key is provided.
+      SSO, etc.).
+
+    Note that if multiple credential sources are provided/available, the
+    ``AnthropicBedrockMantle`` client resolves priority as follows:
+
+    1. Explicit ``bedrock_api_key``
+    2. Explicit ``aws_access_key_id``/``aws_secret_access_key``
+    3. Explicit ``credentials_profile_name``
+    4. ``AWS_BEARER_TOKEN_BEDROCK`` env variable
+    5. Default AWS credential chain (SigV4)
 
     See the [Claude Platform docs](https://platform.claude.com/docs/en/about-claude/models/overview)
     for the latest models, their capabilities, and pricing.
@@ -421,11 +429,9 @@ class ChatAnthropicMantle(ChatAnthropic):
     """Amazon Bedrock API key used to authenticate to Mantle.
 
     If not provided, read from the ``AWS_BEARER_TOKEN_BEDROCK`` environment
-    variable. An explicitly supplied API key takes precedence over SigV4
-    credentials. An environment-sourced API key is ignored when a profile or
-    either static credential is explicitly supplied and both resolve to values,
-    allowing callers to select SigV4 authentication. Otherwise, the client falls
-    back to the default AWS credential chain when no API key is available.
+    variable. An explicitly passed key always selects bearer authentication;
+    an environment-sourced key is outranked by explicitly passed SigV4
+    credentials. See the class docstring for the full selection order.
     """
 
     aws_access_key_id: SecretStr | None = Field(

--- a/libs/aws/tests/unit_tests/chat_models/test_anthropic_mantle.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_anthropic_mantle.py
@@ -377,3 +377,32 @@ def test_non_guardrail_headers_still_allowed() -> None:
         "hello", extra_headers={"X-Another-Header": "ok"}
     )
     assert payload["extra_headers"] == {"X-Another-Header": "ok"}
+
+
+def test_explicit_sigv4_credentials_select_sigv4_at_sdk_level() -> None:
+    with MonkeyPatch().context() as m:
+        m.setenv("AWS_BEARER_TOKEN_BEDROCK", "api-key")
+        model = ChatAnthropicMantle(  # type: ignore[call-arg]
+            model_name=MODEL_NAME,
+            region_name="us-east-1",
+            aws_access_key_id=SecretStr("key-id"),
+            aws_secret_access_key=SecretStr("sec-key"),
+        )
+        client = model._client
+        assert client._use_sigv4 is True
+        assert client.api_key is None
+
+
+def test_env_sigv4_credentials_do_not_outrank_ambient_api_key() -> None:
+    with MonkeyPatch().context() as m:
+        m.setenv("AWS_BEARER_TOKEN_BEDROCK", "api-key")
+        m.setenv("AWS_ACCESS_KEY_ID", "key-id")
+        m.setenv("AWS_SECRET_ACCESS_KEY", "sec-key")
+        model = ChatAnthropicMantle(  # type: ignore[call-arg]
+            model_name=MODEL_NAME, region_name="us-east-1"
+        )
+
+        client_params_by_type = _constructed_client_params(model)
+
+    for client_params in client_params_by_type:
+        assert client_params["api_key"] == "api-key"


### PR DESCRIPTION
Couple follow-ups to the ChatAnthropicMantle auth behavior updates in #1230:
- 2 extra tests to check that 1) the `_use_sigv4` private flag is actually flipped inside AnthropicBedrockMantle client, and 2) the API key env variable is still priority 1 over anything else
- Added the full `AnthropicBedrockMantle` auth priority list that we now follow to the top-level docstring