### PR TITLE
fix(aws): preserve zero temperature in ChatBedrock tracing

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -994,7 +994,7 @@ class ChatBedrock(BaseChatModel, BedrockBase):
             ls_model_name=params.get("model") or self.model_id,
             ls_model_type="chat",
         )
-        if ls_temperature := params.get("temperature", self.temperature):
+        if (ls_temperature := params.get("temperature", self.temperature)) is not None:
             ls_params["ls_temperature"] = ls_temperature
         if ls_max_tokens := params.get("max_tokens", self.max_tokens):
             ls_params["ls_max_tokens"] = ls_max_tokens

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock.py
@@ -881,6 +881,16 @@ def test_standard_tracing_params() -> None:
         "ls_temperature": 0.1,
     }
 
+    llm = ChatBedrock(model_id="foo", temperature=0, region_name="us-west-2")  # type: ignore[call-arg]
+    assert llm._get_ls_params() == {**expected, "ls_temperature": 0}
+
+    llm = ChatBedrock(model_id="foo", temperature=None, region_name="us-west-2")  # type: ignore[call-arg]
+    assert llm._get_ls_params() == expected
+
+    llm = ChatBedrock(model_id="foo", temperature=0.1, region_name="us-west-2")  # type: ignore[call-arg]
+    assert llm._get_ls_params(temperature=0) == {**expected, "ls_temperature": 0}
+    assert llm._get_ls_params(temperature=None) == expected
+
 
 def test_invocation_params_includes_model() -> None:
     llm = ChatBedrock(model="us.anthropic.claude-sonnet-5", region="us-west-2")


### PR DESCRIPTION
## Summary

- Preserve an explicit `temperature=0` in ChatBedrock tracing metadata.
- Continue omitting `ls_temperature` when the resolved temperature is `None`.
- Add regression coverage for constructor values and per-call precedence.

## Why

ChatBedrock used a truthiness check when constructing tracing metadata, which discarded the valid value `0`. Checking specifically for `None` preserves zero while retaining the existing omission and runtime-override behavior.

## Validation

- Targeted ChatBedrock tracing regression test
- Ruff check and format check
- mypy
- Import and compile checks
- `git diff --check`
