### PR TITLE
perf(langgraph-checkpoint-aws): avoid one get_tuple round trip per ancestor in AgentCoreMemorySaver

### DIFF
--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/agentcore/helpers.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/agentcore/helpers.py
@@ -11,6 +11,7 @@ import logging
 import time
 import warnings
 from collections import defaultdict
+from collections.abc import Iterator
 from typing import Any, cast
 
 import boto3
@@ -440,6 +441,64 @@ class AgentCoreEventClient:
                 break
 
         return all_events
+
+    def iter_event_pages(
+        self,
+        session_id: str,
+        actor_id: str,
+        *,
+        max_results: int | None = 100,
+    ) -> Iterator[list[EventType]]:
+        """Yield parsed events page by page, with no total item cap.
+
+        Unlike `get_events`, this never enforces a global `limit` (and so
+        never emits its "Stopped retrieving events" warning): a caller that
+        only needs a prefix of a thread's history — for example, walking an
+        ancestor chain until every requested channel is seeded — can stop
+        iterating once it has enough, turning what would otherwise be a
+        full-history fetch into a lazily-paged one.
+
+        Args:
+            session_id: The session ID to retrieve events for.
+            actor_id: The actor ID to retrieve events for.
+            max_results: Maximum number of results to retrieve per ListEvents
+                call.
+
+        Yields:
+            The events decoded from each successive page of ListEvents, in
+            the order AgentCore Memory returns them.
+        """
+        next_token: str | None = None
+
+        while True:
+            params: dict[str, Any] = {
+                "memoryId": self.memory_id,
+                "actorId": actor_id,
+                "sessionId": session_id,
+                "maxResults": max_results,
+                "includePayloads": True,
+            }
+            if next_token:
+                params["nextToken"] = next_token
+
+            response = self.client.list_events(**params)
+
+            page_events: list[EventType] = []
+            for event in response.get("events", []):
+                for payload_item in event.get("payload", []):
+                    blob = payload_item.get("blob")
+                    if not blob:
+                        continue
+                    try:
+                        page_events.append(self.serializer.deserialize_event(blob))
+                    except EventDecodingError as e:
+                        logger.warning(f"Failed to decode event: {e}")
+
+            yield page_events
+
+            next_token = response.get("nextToken")
+            if not next_token:
+                break
 
     def delete_events(self, session_id: str, actor_id: str) -> None:
         """Delete all events for a session."""

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/agentcore/saver.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/agentcore/saver.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import asyncio
 import random
 from collections.abc import AsyncIterator, Iterator, Mapping, Sequence
-from typing import Any, TypeAlias, cast
+from typing import TYPE_CHECKING, Any, TypeAlias, cast
 
 from langchain_core.runnables import RunnableConfig, run_in_executor
 from langgraph.checkpoint.base import (
@@ -16,11 +16,22 @@ from langgraph.checkpoint.base import (
     Checkpoint,
     CheckpointMetadata,
     CheckpointTuple,
-    DeltaChannelHistory,
     SerializerProtocol,
     get_checkpoint_id,
     get_checkpoint_metadata,
 )
+
+if TYPE_CHECKING:
+    # `DeltaChannelHistory` was added to `langgraph-checkpoint` alongside
+    # `DeltaChannel`/`get_delta_channel_history` support and does not exist
+    # in `langgraph-checkpoint` 3.0.0, the package's declared floor
+    # (`langgraph-checkpoint>=3.0.0,<5.0.0`). A module-level import would
+    # make importing this whole package fail on 3.0.x. It is only ever used
+    # here as a type annotation, and `from __future__ import annotations`
+    # (above) makes all annotations in this module lazy strings, so a
+    # `TYPE_CHECKING`-only import is sufficient: static type checkers still
+    # resolve it, and nothing evaluates it at runtime.
+    from langgraph.checkpoint.base import DeltaChannelHistory
 
 from langgraph_checkpoint_aws.checkpoint.deferred_saver import PendingWrite
 

--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/agentcore/saver.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/agentcore/saver.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import asyncio
 import random
-from collections.abc import AsyncIterator, Iterator, Sequence
+from collections.abc import AsyncIterator, Iterator, Mapping, Sequence
 from typing import Any, TypeAlias, cast
 
 from langchain_core.runnables import RunnableConfig, run_in_executor
@@ -16,6 +16,7 @@ from langgraph.checkpoint.base import (
     Checkpoint,
     CheckpointMetadata,
     CheckpointTuple,
+    DeltaChannelHistory,
     SerializerProtocol,
     get_checkpoint_id,
     get_checkpoint_metadata,
@@ -34,6 +35,7 @@ from .helpers import (
     AgentCoreEventClient,
     EventProcessor,
     EventSerializer,
+    EventType,
 )
 from .models import (
     ChannelDataEvent,
@@ -190,6 +192,173 @@ class AgentCoreMemorySaver(BaseCheckpointSaver[str]):
             )
 
             count += 1
+
+    def get_delta_channel_history(
+        self, *, config: RunnableConfig, channels: Sequence[str]
+    ) -> Mapping[str, DeltaChannelHistory]:
+        """Walk the parent chain returning per-channel writes and seed.
+
+        !!! warning "Beta"
+
+            `get_delta_channel_history` is part of langgraph's `DeltaChannel`
+            support surface and is marked Beta upstream: the signature,
+            return shape (`DeltaChannelHistory`), and interaction with
+            `_DeltaSnapshot` blobs may change. Re-check this override
+            against `BaseCheckpointSaver.get_delta_channel_history` on any
+            `langgraph-checkpoint` upgrade.
+
+        The base implementation issues one `get_tuple` (one AgentCore
+        `ListEvents` round trip) per ancestor checkpoint, which is O(depth)
+        network calls and dominates resume latency on long-running threads.
+        This override instead pages through the thread's events in bulk via
+        `AgentCoreEventClient.iter_event_pages`, reconstructs checkpoints
+        from them locally, and replays the identical parent-chain walk —
+        stopping as soon as the walk is satisfied rather than always
+        fetching the full thread history.
+
+        Args:
+            config: Configuration identifying the target checkpoint.
+            channels: Channel names to walk for. Empty returns an empty
+                mapping.
+
+        Returns:
+            Per-channel `DeltaChannelHistory` for every name in `channels`.
+        """
+        if not channels:
+            return {}
+
+        checkpoint_config = CheckpointerConfig.from_runnable_config(
+            RunnableConfigDict(config)
+        )
+        target_tuple = self.get_tuple(config)
+
+        tuples_by_id: dict[str, CheckpointTuple] = {}
+        result, complete = self._replay_delta_channel_history(
+            target_tuple, tuples_by_id, channels
+        )
+
+        if not complete:
+            all_events: list[EventType] = []
+            for page in self.checkpoint_event_client.iter_event_pages(
+                checkpoint_config.session_id,
+                checkpoint_config.actor_id,
+                max_results=self.max_results,
+            ):
+                all_events.extend(page)
+                tuples_by_id = self._tuples_by_checkpoint_id(
+                    all_events, checkpoint_config
+                )
+                result, complete = self._replay_delta_channel_history(
+                    target_tuple, tuples_by_id, channels
+                )
+                if complete:
+                    break
+
+        return result
+
+    async def aget_delta_channel_history(
+        self, *, config: RunnableConfig, channels: Sequence[str]
+    ) -> Mapping[str, DeltaChannelHistory]:
+        """Async version of `get_delta_channel_history`.
+
+        !!! warning "Beta"
+
+            See `get_delta_channel_history` for caveats; this method shares
+            the same beta status upstream.
+        """
+        return await run_in_executor(
+            None, self.get_delta_channel_history, config=config, channels=channels
+        )
+
+    def _tuples_by_checkpoint_id(
+        self,
+        events: Sequence[EventType],
+        checkpoint_config: CheckpointerConfig,
+    ) -> dict[str, CheckpointTuple]:
+        """Reconstruct `CheckpointTuple`s keyed by checkpoint id from events.
+
+        Args:
+            events: All events fetched so far for the thread.
+            checkpoint_config: The thread/actor/namespace being walked.
+
+        Returns:
+            Every checkpoint reconstructable from `events`, keyed by its id.
+        """
+        checkpoints, writes_by_checkpoint, channel_data = self.processor.process_events(
+            list(events)
+        )
+        return {
+            checkpoint_id: self.processor.build_checkpoint_tuple(
+                checkpoint_event,
+                writes_by_checkpoint.get(checkpoint_id, []),
+                channel_data,
+                checkpoint_config,
+            )
+            for checkpoint_id, checkpoint_event in checkpoints.items()
+        }
+
+    @staticmethod
+    def _replay_delta_channel_history(
+        target_tuple: CheckpointTuple | None,
+        tuples_by_id: dict[str, CheckpointTuple],
+        channels: Sequence[str],
+    ) -> tuple[dict[str, DeltaChannelHistory], bool]:
+        """Replay the base `get_delta_channel_history` walk against known tuples.
+
+        Mirrors `BaseCheckpointSaver.get_delta_channel_history` exactly:
+        same write ordering (writes are collected newest-to-oldest per
+        ancestor then reversed once at the end, giving oldest-to-newest
+        overall), and the same seed selection at the nearest ancestor whose
+        `channel_values[ch]` is populated. The only difference is that
+        ancestors are looked up in an in-memory `tuples_by_id` map — built
+        from `parent_config` links, never from fetch order — instead of one
+        `get_tuple` call per ancestor.
+
+        Args:
+            target_tuple: The checkpoint tuple identified by the caller's
+                config.
+            tuples_by_id: Checkpoints reconstructed so far, keyed by
+                checkpoint id. Ancestors not yet fetched are simply absent.
+            channels: Channel names to walk for.
+
+        Returns:
+            The per-channel result built from the tuples available so far,
+            and whether the walk is complete (reached the root, or every
+            channel is seeded) as opposed to stalled on an ancestor that
+            has not been fetched yet.
+        """
+        collected_by_ch: dict[str, list[tuple[str, str, Any]]] = {
+            c: [] for c in channels
+        }
+        seed_by_ch: dict[str, Any] = {}
+        remaining: set[str] = set(channels)
+        cursor_config = target_tuple.parent_config if target_tuple else None
+        complete = True
+
+        while cursor_config is not None and remaining:
+            cursor_id = get_checkpoint_id(cursor_config)
+            tup = tuples_by_id.get(cursor_id) if cursor_id is not None else None
+            if tup is None:
+                complete = False
+                break
+            if tup.pending_writes:
+                for write in reversed(tup.pending_writes):
+                    if write[1] in remaining:
+                        collected_by_ch[write[1]].append(write)
+            for ch in list(remaining):
+                if ch in tup.checkpoint["channel_values"]:
+                    seed_by_ch[ch] = tup.checkpoint["channel_values"][ch]
+                    remaining.discard(ch)
+            cursor_config = tup.parent_config
+
+        result: dict[str, DeltaChannelHistory] = {}
+        for ch in channels:
+            entry: DeltaChannelHistory = {"writes": list(reversed(collected_by_ch[ch]))}
+            if ch in seed_by_ch:
+                entry["seed"] = seed_by_ch[ch]
+            result[ch] = entry
+
+        return result, complete
 
     def put(
         self,

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_delta_channel_equivalence.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_delta_channel_equivalence.py
@@ -1,0 +1,428 @@
+"""Equivalence tests: `AgentCoreMemorySaver.get_delta_channel_history` vs.
+`BaseCheckpointSaver.get_delta_channel_history`.
+
+This is the core correctness argument for the `get_delta_channel_history` /
+`aget_delta_channel_history` overrides: they exist purely for performance
+(bulk-paged event fetch instead of one `get_tuple` round trip per ancestor),
+so their output must be *identical* to the base implementation's for the
+same underlying data, in every case the base handles -- a single page, a
+chain split across multiple `ListEvents` pages, a forked/branched thread
+(only on-path ancestors may contribute), and a long thread driven through
+real `DeltaChannel` snapshot/replay machinery.
+
+Each test builds a synthetic event log, then computes the result two ways
+against the *same* saver instance and the *same* fetched data:
+
+  * `saver.get_delta_channel_history(...)` -- the override under test.
+  * `BaseCheckpointSaver.get_delta_channel_history(saver, ...)` -- the
+    upstream reference algorithm, called unbound so it walks ancestors via
+    `saver.get_tuple(...)` (one AgentCore round trip per ancestor) instead
+    of the override's bulk path.
+
+and asserts the two are equal, plus that no message id or `tool_call_id`
+is duplicated in the reconstructed value.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langchain_core.runnables import RunnableConfig
+from langgraph.channels.delta import DeltaChannel
+from langgraph.checkpoint.base import BaseCheckpointSaver
+from langgraph.checkpoint.serde.types import _DeltaSnapshot
+from langgraph.pregel._checkpoint import (
+    create_checkpoint,
+    delta_channels_to_snapshot,
+    empty_checkpoint,
+)
+
+from langgraph_checkpoint_aws.checkpoint.agentcore.models import (
+    ChannelDataEvent,
+    CheckpointEvent,
+    WriteItem,
+    WritesEvent,
+)
+from langgraph_checkpoint_aws.checkpoint.agentcore.saver import AgentCoreMemorySaver
+
+THREAD_ID = "equiv-thread"
+ACTOR_ID = "equiv-actor"
+CHECKPOINT_NS = "equiv-ns"
+
+
+def _checkpoint_data(checkpoint_id, channel_versions=None):
+    return {
+        "v": 1,
+        "id": checkpoint_id,
+        "ts": "2024-01-01T00:00:00Z",
+        "channel_versions": channel_versions or {},
+        "versions_seen": {},
+        "pending_sends": [],
+    }
+
+
+def _list_events_page(saver, events, *, next_token=None):
+    response = {
+        "events": [
+            {
+                "eventId": f"event_{i}",
+                "payload": [{"blob": saver.serializer.serialize_event(event)}],
+            }
+            for i, event in enumerate(events)
+        ]
+    }
+    if next_token:
+        response["nextToken"] = next_token
+    return response
+
+
+def _make_saver(**kwargs):
+    mock_client = MagicMock()
+    with patch("boto3.client") as mock_boto3_client:
+        mock_boto3_client.return_value = mock_client
+        saver = AgentCoreMemorySaver(memory_id="equiv-memory-id", **kwargs)
+    return saver, mock_client
+
+
+def _config(checkpoint_id):
+    return RunnableConfig(
+        configurable={
+            "thread_id": THREAD_ID,
+            "actor_id": ACTOR_ID,
+            "checkpoint_ns": CHECKPOINT_NS,
+            "checkpoint_id": checkpoint_id,
+        }
+    )
+
+
+def _assert_equivalent_and_committed(saver, config, channels):
+    """Call both implementations and assert byte-identical results."""
+    override_result = saver.get_delta_channel_history(config=config, channels=channels)
+    base_result = BaseCheckpointSaver.get_delta_channel_history(
+        saver, config=config, channels=channels
+    )
+    assert override_result == base_result
+    return override_result
+
+
+def _linear_chain(saver, *, num_ancestors, seed_at="root"):
+    """Build a linear chain root -> c1 -> ... -> c{num_ancestors} with a
+    plain (non-`_DeltaSnapshot`) seed at `seed_at` and one write per
+    ancestor after it. Returns (events, target_checkpoint_id)."""
+    events = []
+    events.append(
+        CheckpointEvent(
+            checkpoint_id="root",
+            checkpoint_data=_checkpoint_data("root", {"notes": "v0"}),
+            metadata={"step": 0},
+            thread_id=THREAD_ID,
+            checkpoint_ns=CHECKPOINT_NS,
+        )
+    )
+    events.append(
+        ChannelDataEvent(
+            channel="notes",
+            version="v0",
+            value="root_seed",
+            thread_id=THREAD_ID,
+            checkpoint_ns=CHECKPOINT_NS,
+        )
+    )
+    assert seed_at == "root"  # only supported seed position for this helper
+
+    prev_id = "root"
+    for i in range(1, num_ancestors + 1):
+        cid = f"c{i}"
+        events.append(
+            CheckpointEvent(
+                checkpoint_id=cid,
+                checkpoint_data=_checkpoint_data(cid),
+                metadata={"step": i},
+                parent_checkpoint_id=prev_id,
+                thread_id=THREAD_ID,
+                checkpoint_ns=CHECKPOINT_NS,
+            )
+        )
+        events.append(
+            WritesEvent(
+                checkpoint_id=prev_id,
+                writes=[WriteItem(task_id=f"t{i}", channel="notes", value=f"m{i}")],
+            )
+        )
+        prev_id = cid
+    return events, prev_id
+
+
+class TestDeltaChannelHistoryEquivalenceSyntheticSinglePage:
+    """A linear ancestor chain fetched in a single `ListEvents` page."""
+
+    def test_equivalence_and_no_duplicates(self):
+        saver, mock_client = _make_saver()
+        events, target_id = _linear_chain(saver, num_ancestors=10)
+        mock_client.list_events.return_value = _list_events_page(saver, events)
+
+        result = _assert_equivalent_and_committed(saver, _config(target_id), ["notes"])
+
+        assert result["notes"]["seed"] == "root_seed"
+        values = [result["notes"]["seed"]] + [w[2] for w in result["notes"]["writes"]]
+        assert len(values) == len(set(values))
+
+
+class TestDeltaChannelHistoryEquivalencePaginated:
+    """The same chain, but split across two `ListEvents` pages (newest
+    events first, oldest ancestors requiring a second page -- mirroring
+    real AgentCore Memory pagination)."""
+
+    def test_equivalence_across_page_boundary(self):
+        saver, mock_client = _make_saver()
+        events, target_id = _linear_chain(saver, num_ancestors=10)
+
+        newest_first = list(reversed(events))
+        mid = len(newest_first) // 2
+        page1 = _list_events_page(saver, newest_first[:mid], next_token="tok1")
+        page2 = _list_events_page(saver, newest_first[mid:])
+
+        def _side_effect(**kwargs):
+            return page2 if kwargs.get("nextToken") == "tok1" else page1
+
+        mock_client.list_events.side_effect = _side_effect
+        result = _assert_equivalent_and_committed(saver, _config(target_id), ["notes"])
+        assert result["notes"]["seed"] == "root_seed"
+        assert len(result["notes"]["writes"]) == 10
+
+
+class TestDeltaChannelHistoryEquivalenceForkedThread:
+    """A forked/branched thread: two children (`b1`, `b2`) of the same
+    parent (`a`), each writing to `notes` independently. The target
+    descends only from `b2`. Only on-path ancestors (`a`, `b2`, ...) may
+    contribute writes or a seed -- `b1`'s branch must be invisible, for
+    both the override and the base reference walk."""
+
+    def test_only_on_path_ancestors_contribute(self):
+        saver, mock_client = _make_saver()
+        events = [
+            CheckpointEvent(
+                checkpoint_id="root",
+                checkpoint_data=_checkpoint_data("root", {"notes": "v0"}),
+                metadata={"step": 0},
+                thread_id=THREAD_ID,
+                checkpoint_ns=CHECKPOINT_NS,
+            ),
+            ChannelDataEvent(
+                channel="notes",
+                version="v0",
+                value="root_seed",
+                thread_id=THREAD_ID,
+                checkpoint_ns=CHECKPOINT_NS,
+            ),
+            CheckpointEvent(
+                checkpoint_id="a",
+                checkpoint_data=_checkpoint_data("a"),
+                metadata={"step": 1},
+                parent_checkpoint_id="root",
+                thread_id=THREAD_ID,
+                checkpoint_ns=CHECKPOINT_NS,
+            ),
+            WritesEvent(
+                checkpoint_id="root",
+                writes=[WriteItem(task_id="t_root", channel="notes", value="m_root")],
+            ),
+            # Off-path branch: b1 is a sibling of b2, both children of "a".
+            # b1's write must never appear when walking from a target under b2.
+            CheckpointEvent(
+                checkpoint_id="b1",
+                checkpoint_data=_checkpoint_data("b1"),
+                metadata={"step": 2, "source": "fork"},
+                parent_checkpoint_id="a",
+                thread_id=THREAD_ID,
+                checkpoint_ns=CHECKPOINT_NS,
+            ),
+            WritesEvent(
+                checkpoint_id="b1",
+                writes=[
+                    WriteItem(task_id="t_b1", channel="notes", value="OFF_PATH_m_b1")
+                ],
+            ),
+            # On-path branch: b2, also a child of "a" (a resumed/forked run).
+            CheckpointEvent(
+                checkpoint_id="b2",
+                checkpoint_data=_checkpoint_data("b2"),
+                metadata={"step": 2, "source": "fork"},
+                parent_checkpoint_id="a",
+                thread_id=THREAD_ID,
+                checkpoint_ns=CHECKPOINT_NS,
+            ),
+            WritesEvent(
+                checkpoint_id="a",
+                writes=[WriteItem(task_id="t_a", channel="notes", value="m_a")],
+            ),
+            WritesEvent(
+                checkpoint_id="b2",
+                writes=[WriteItem(task_id="t_b2", channel="notes", value="m_b2")],
+            ),
+            CheckpointEvent(
+                checkpoint_id="target",
+                checkpoint_data=_checkpoint_data("target"),
+                metadata={"step": 3},
+                parent_checkpoint_id="b2",
+                thread_id=THREAD_ID,
+                checkpoint_ns=CHECKPOINT_NS,
+            ),
+        ]
+        mock_client.list_events.return_value = _list_events_page(saver, events)
+
+        result = _assert_equivalent_and_committed(saver, _config("target"), ["notes"])
+
+        write_values = [w[2] for w in result["notes"]["writes"]]
+        assert "OFF_PATH_m_b1" not in write_values
+        assert write_values == ["m_root", "m_a", "m_b2"]
+        assert result["notes"]["seed"] == "root_seed"
+
+
+class TestDeltaChannelHistoryEquivalenceRealDeltaChannel:
+    """A 20-turn thread driven through real `langgraph.channels.delta`
+    machinery (`DeltaChannel.update`/`replay_writes`,
+    `delta_channels_to_snapshot`, `pregel._checkpoint.create_checkpoint`),
+    with `snapshot_frequency=3` (so several `_DeltaSnapshot` boundaries are
+    crossed) and `max_results=5` (so every checkpoint's events are split
+    across several `ListEvents` pages). This exercises the exact real-world
+    shape of the reported regression: a `_DeltaSnapshot` seed with further
+    writes stacked on top, reconstructed from bulk-paged events.
+    """
+
+    @staticmethod
+    def _add_messages(base, writes):
+        return list(base) + list(writes)
+
+    @staticmethod
+    def _get_next_version(current, _channel):
+        if current is None:
+            return "00000000000000000000000000000001"
+        return f"{int(current) + 1:032d}"
+
+    def test_equivalence_across_snapshot_boundaries(self):
+        store: list[dict] = []
+
+        def _fake_create_event(**kwargs):
+            store.append(kwargs)
+            return {"event": {"eventId": f"e{len(store)}"}}
+
+        def _fake_list_events(**kwargs):
+            max_results = kwargs.get("maxResults") or 100
+            next_token = kwargs.get("nextToken")
+            start = int(next_token) if next_token else 0
+            end = start + max_results
+            page = store[start:end]
+            response = {
+                "events": [
+                    {"eventId": f"e{i}", "payload": ev["payload"]}
+                    for i, ev in enumerate(page, start=start)
+                ]
+            }
+            if end < len(store):
+                response["nextToken"] = str(end)
+            return response
+
+        mock_client = MagicMock()
+        mock_client.create_event.side_effect = _fake_create_event
+        mock_client.list_events.side_effect = _fake_list_events
+
+        with patch("boto3.client") as mock_boto3_client:
+            mock_boto3_client.return_value = mock_client
+            saver = AgentCoreMemorySaver(memory_id="equiv-memory-id", max_results=5)
+
+        channel = DeltaChannel(self._add_messages, list, snapshot_frequency=3)
+        channel.value = []
+
+        checkpoint = empty_checkpoint()
+        base_config = RunnableConfig(
+            configurable={
+                "thread_id": THREAD_ID,
+                "actor_id": ACTOR_ID,
+                "checkpoint_ns": CHECKPOINT_NS,
+            }
+        )
+        counters: dict[str, tuple[int, int]] = {}
+        prev_checkpoint_id: str | None = None
+        tool_call_counter = 0
+
+        for step in range(20):
+            if step % 2 == 0:
+                writes = [HumanMessage(content=f"question {step}", id=f"h{step}")]
+            else:
+                tool_call_counter += 1
+                tc_id = f"call_{tool_call_counter}"
+                writes = [
+                    AIMessage(
+                        content="",
+                        tool_calls=[{"name": "search", "args": {}, "id": tc_id}],
+                        id=f"ai{step}",
+                    )
+                ]
+
+            channel.update(writes)
+            updates, supersteps = counters.get("messages", (0, 0))
+            counters["messages"] = (updates + 1, supersteps + 1)
+
+            channels_to_snapshot = delta_channels_to_snapshot(
+                {"messages": channel}, counters
+            )
+            if "messages" in channels_to_snapshot:
+                counters["messages"] = (0, 0)
+
+            prev_version = checkpoint["channel_versions"].get("messages")
+            checkpoint = dict(checkpoint)
+            checkpoint["channel_versions"] = dict(checkpoint["channel_versions"])
+            checkpoint["channel_versions"]["messages"] = self._get_next_version(
+                prev_version, None
+            )
+
+            checkpoint = create_checkpoint(
+                checkpoint,
+                {"messages": channel},
+                step,
+                id=str(uuid.uuid4()),
+                updated_channels={"messages"},
+                get_next_version=self._get_next_version,
+                channels_to_snapshot=channels_to_snapshot,
+            )
+
+            put_config = dict(base_config)
+            put_config["configurable"] = dict(base_config["configurable"])
+            if prev_checkpoint_id:
+                put_config["configurable"]["checkpoint_id"] = prev_checkpoint_id
+
+            metadata = {"source": "loop", "step": step, "writes": {}, "parents": {}}
+            new_versions = {"messages": checkpoint["channel_versions"]["messages"]}
+            result_config = saver.put(put_config, checkpoint, metadata, new_versions)
+            prev_checkpoint_id = result_config["configurable"]["checkpoint_id"]
+
+            if step % 2 == 1:
+                tool_message = ToolMessage(
+                    content="result", tool_call_id=tc_id, id=f"tm{step}"
+                )
+                saver.put_writes(
+                    result_config, [("messages", tool_message)], task_id=f"task{step}"
+                )
+                channel.replay_writes([(f"task{step}", "messages", tool_message)])
+
+        target_config = RunnableConfig(
+            configurable={
+                "thread_id": THREAD_ID,
+                "actor_id": ACTOR_ID,
+                "checkpoint_ns": CHECKPOINT_NS,
+                "checkpoint_id": prev_checkpoint_id,
+            }
+        )
+
+        result = _assert_equivalent_and_committed(saver, target_config, ["messages"])
+
+        seed = result["messages"].get("seed")
+        seed_messages = list(seed.value) if isinstance(seed, _DeltaSnapshot) else []
+        write_values = [w[2] for w in result["messages"]["writes"]]
+        all_messages = seed_messages + write_values
+
+        message_ids = [m.id for m in all_messages]
+        assert len(message_ids) == len(set(message_ids))

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_langgraph_checkpoint_compat.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_langgraph_checkpoint_compat.py
@@ -1,0 +1,68 @@
+"""Import-compatibility regression tests for `langgraph-checkpoint`'s floor.
+
+`langgraph_checkpoint_aws.checkpoint.agentcore.saver` supports
+`langgraph-checkpoint>=3.0.0,<5.0.0` (see `pyproject.toml`). `DeltaChannel`
+support (`DeltaChannelHistory`, `BaseCheckpointSaver.get_delta_channel_history`)
+was added to `langgraph-checkpoint` after 3.0.0, so `DeltaChannelHistory`
+must never be imported at module level from `langgraph.checkpoint.base` --
+doing so breaks importing this whole package on the declared floor version,
+even though the currently installed `langgraph-checkpoint` (see
+`uv.lock`) does have it.
+"""
+
+import importlib
+import sys
+
+import langgraph.checkpoint.base as checkpoint_base
+
+SAVER_MODULE = "langgraph_checkpoint_aws.checkpoint.agentcore.saver"
+
+
+def test_saver_module_imports_without_delta_channel_history(monkeypatch):
+    """Simulate `langgraph-checkpoint` 3.0.0: no `DeltaChannelHistory` on
+    `langgraph.checkpoint.base`. Importing the saver module must still
+    succeed -- it is only ever needed here as a type annotation."""
+    monkeypatch.delattr(checkpoint_base, "DeltaChannelHistory", raising=False)
+    monkeypatch.delitem(sys.modules, SAVER_MODULE, raising=False)
+
+    try:
+        module = importlib.import_module(SAVER_MODULE)
+    except ImportError as exc:  # pragma: no cover - failure path under test
+        raise AssertionError(
+            "AgentCoreMemorySaver module failed to import without "
+            f"DeltaChannelHistory (langgraph-checkpoint 3.0.0 floor): {exc}"
+        ) from None
+
+    # Defining `get_delta_channel_history`/`aget_delta_channel_history` must
+    # not require the base class to already define them -- on a langgraph
+    # version without DeltaChannel support they are simply unused methods.
+    assert hasattr(module.AgentCoreMemorySaver, "get_delta_channel_history")
+    assert hasattr(module.AgentCoreMemorySaver, "aget_delta_channel_history")
+
+
+def test_delta_channel_history_import_is_type_checking_only():
+    """Static guard: `DeltaChannelHistory` must be imported only inside an
+    `if TYPE_CHECKING:` block in `saver.py`, never at module level, so a
+    reviewer re-adding a top-level import trips this before it ships."""
+    import ast
+    from pathlib import Path
+
+    saver_path = Path(
+        importlib.import_module(SAVER_MODULE).__file__  # type: ignore[arg-type]
+    )
+    tree = ast.parse(saver_path.read_text())
+
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.ImportFrom)
+            and node.module == "langgraph.checkpoint.base"
+        ):
+            names = {alias.name for alias in node.names}
+            if "DeltaChannelHistory" in names:
+                # This import is only acceptable directly under `if
+                # TYPE_CHECKING:` at module level, never mixed into the
+                # unconditional top-level import block.
+                assert getattr(node, "col_offset", 0) > 0, (
+                    "DeltaChannelHistory must be imported only inside an "
+                    "`if TYPE_CHECKING:` block, not at module level"
+                )

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_saver.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_saver.py
@@ -45,6 +45,34 @@ MOCK_SLEEP_DURATION = 0.05
 TOTAL_EXPECTED_TIME = (N_ASYNC_CALLS * MOCK_SLEEP_DURATION) / 2
 
 
+def _checkpoint_data(checkpoint_id, channel_versions=None):
+    """Minimal `Checkpoint`-shaped dict for building `CheckpointEvent`s."""
+    return {
+        "v": 1,
+        "id": checkpoint_id,
+        "ts": "2024-01-01T00:00:00Z",
+        "channel_versions": channel_versions or {},
+        "versions_seen": {},
+        "pending_sends": [],
+    }
+
+
+def _list_events_page(saver, events, *, next_token=None):
+    """Build a ListEvents-shaped response dict from domain events."""
+    response = {
+        "events": [
+            {
+                "eventId": f"event_{i}",
+                "payload": [{"blob": saver.serializer.serialize_event(event)}],
+            }
+            for i, event in enumerate(events)
+        ]
+    }
+    if next_token:
+        response["nextToken"] = next_token
+    return response
+
+
 @pytest.fixture
 def sample_checkpoint_tuple():
     return CheckpointTuple(
@@ -512,6 +540,296 @@ class TestAgentCoreMemorySaver:
 
         assert len(results) == 0
 
+    def test_get_delta_channel_history_empty_channels(
+        self, saver, mock_boto_client, runnable_config
+    ):
+        result = saver.get_delta_channel_history(config=runnable_config, channels=[])
+
+        assert result == {}
+        mock_boto_client.list_events.assert_not_called()
+
+    def test_get_delta_channel_history_no_ancestors(
+        self, saver, mock_boto_client, runnable_config
+    ):
+        """A checkpoint with no parent yields an unseeded, empty-writes entry."""
+        runnable_config["configurable"]["checkpoint_id"] = "root"
+        root_event = CheckpointEvent(
+            checkpoint_id="root",
+            checkpoint_data=_checkpoint_data("root"),
+            metadata={"step": 0},
+            thread_id="test_thread_id",
+            checkpoint_ns="test_namespace",
+        )
+        mock_boto_client.list_events.return_value = _list_events_page(
+            saver, [root_event]
+        )
+
+        result = saver.get_delta_channel_history(
+            config=runnable_config, channels=["notes"]
+        )
+
+        assert result == {"notes": {"writes": []}}
+
+    def test_get_delta_channel_history_seed_found_at_ancestor(
+        self, saver, mock_boto_client, runnable_config
+    ):
+        runnable_config["configurable"]["checkpoint_id"] = "c2"
+
+        c2_event = CheckpointEvent(
+            checkpoint_id="c2",
+            checkpoint_data=_checkpoint_data("c2"),
+            metadata={"step": 1},
+            parent_checkpoint_id="c1",
+            thread_id="test_thread_id",
+            checkpoint_ns="test_namespace",
+        )
+        c1_event = CheckpointEvent(
+            checkpoint_id="c1",
+            checkpoint_data=_checkpoint_data("c1", {"notes": "v1"}),
+            metadata={"step": 0},
+            thread_id="test_thread_id",
+            checkpoint_ns="test_namespace",
+        )
+        notes_at_c1 = ChannelDataEvent(
+            channel="notes",
+            version="v1",
+            value="seed_value",
+            thread_id="test_thread_id",
+            checkpoint_ns="test_namespace",
+        )
+        mock_boto_client.list_events.return_value = _list_events_page(
+            saver, [c2_event, c1_event, notes_at_c1]
+        )
+
+        result = saver.get_delta_channel_history(
+            config=runnable_config, channels=["notes"]
+        )
+
+        assert result == {"notes": {"writes": [], "seed": "seed_value"}}
+
+    def test_get_delta_channel_history_writes_collected_in_order(
+        self, saver, mock_boto_client, runnable_config
+    ):
+        """Writes accumulate oldest-ancestor-first, and within one ancestor's
+        batch of writes, their original storage order is preserved."""
+        runnable_config["configurable"]["checkpoint_id"] = "c3"
+
+        c3_event = CheckpointEvent(
+            checkpoint_id="c3",
+            checkpoint_data=_checkpoint_data("c3"),
+            metadata={"step": 3},
+            parent_checkpoint_id="c2",
+            thread_id="test_thread_id",
+            checkpoint_ns="test_namespace",
+        )
+        c2_event = CheckpointEvent(
+            checkpoint_id="c2",
+            checkpoint_data=_checkpoint_data("c2"),
+            metadata={"step": 2},
+            parent_checkpoint_id="c1",
+            thread_id="test_thread_id",
+            checkpoint_ns="test_namespace",
+        )
+        c1_event = CheckpointEvent(
+            checkpoint_id="c1",
+            checkpoint_data=_checkpoint_data("c1"),
+            metadata={"step": 1},
+            parent_checkpoint_id="root",
+            thread_id="test_thread_id",
+            checkpoint_ns="test_namespace",
+        )
+        root_event = CheckpointEvent(
+            checkpoint_id="root",
+            checkpoint_data=_checkpoint_data("root", {"notes": "v0"}),
+            metadata={"step": 0},
+            thread_id="test_thread_id",
+            checkpoint_ns="test_namespace",
+        )
+        notes_at_root = ChannelDataEvent(
+            channel="notes",
+            version="v0",
+            value="root_seed",
+            thread_id="test_thread_id",
+            checkpoint_ns="test_namespace",
+        )
+        writes_c2 = WritesEvent(
+            checkpoint_id="c2",
+            writes=[WriteItem(task_id="t_c2", channel="notes", value="w_c2")],
+        )
+        writes_c1 = WritesEvent(
+            checkpoint_id="c1",
+            writes=[
+                WriteItem(task_id="t_c1a", channel="notes", value="w_c1a"),
+                WriteItem(task_id="t_c1b", channel="notes", value="w_c1b"),
+            ],
+        )
+
+        mock_boto_client.list_events.return_value = _list_events_page(
+            saver,
+            [
+                c3_event,
+                c2_event,
+                c1_event,
+                root_event,
+                notes_at_root,
+                writes_c2,
+                writes_c1,
+            ],
+        )
+
+        result = saver.get_delta_channel_history(
+            config=runnable_config, channels=["notes"]
+        )
+
+        assert result == {
+            "notes": {
+                "writes": [
+                    ("t_c1a", "notes", "w_c1a"),
+                    ("t_c1b", "notes", "w_c1b"),
+                    ("t_c2", "notes", "w_c2"),
+                ],
+                "seed": "root_seed",
+            }
+        }
+
+    def test_get_delta_channel_history_stops_paging_once_satisfied(
+        self, saver, mock_boto_client, runnable_config
+    ):
+        """Once every channel is seeded, no further pages should be fetched
+        for the ancestor walk, even if more pages remain available."""
+        runnable_config["configurable"]["checkpoint_id"] = "c2"
+
+        c2_event = CheckpointEvent(
+            checkpoint_id="c2",
+            checkpoint_data=_checkpoint_data("c2"),
+            metadata={"step": 1},
+            parent_checkpoint_id="c1",
+            thread_id="test_thread_id",
+            checkpoint_ns="test_namespace",
+        )
+        c1_event = CheckpointEvent(
+            checkpoint_id="c1",
+            checkpoint_data=_checkpoint_data("c1", {"notes": "v1"}),
+            metadata={"step": 0},
+            parent_checkpoint_id="root",
+            thread_id="test_thread_id",
+            checkpoint_ns="test_namespace",
+        )
+        notes_at_c1 = ChannelDataEvent(
+            channel="notes",
+            version="v1",
+            value="seed_c1",
+            thread_id="test_thread_id",
+            checkpoint_ns="test_namespace",
+        )
+        root_event = CheckpointEvent(
+            checkpoint_id="root",
+            checkpoint_data=_checkpoint_data("root"),
+            metadata={"step": -1},
+            thread_id="test_thread_id",
+            checkpoint_ns="test_namespace",
+        )
+
+        page1 = _list_events_page(
+            saver, [c2_event, c1_event, notes_at_c1], next_token="tok1"
+        )
+        page2 = _list_events_page(saver, [root_event])
+
+        def _side_effect(**kwargs):
+            return page2 if kwargs.get("nextToken") == "tok1" else page1
+
+        mock_boto_client.list_events.side_effect = _side_effect
+
+        result = saver.get_delta_channel_history(
+            config=runnable_config, channels=["notes"]
+        )
+
+        assert result == {"notes": {"writes": [], "seed": "seed_c1"}}
+        # get_tuple's own full scan makes 2 calls (page1, then page2 to
+        # exhaust pagination); the ancestor walk should stop after page1
+        # since "notes" is already seeded there, for 3 calls total.
+        assert mock_boto_client.list_events.call_count == 3
+
+    def test_get_delta_channel_history_chain_spans_multiple_pages(
+        self, saver, mock_boto_client, runnable_config
+    ):
+        """The ancestor walk must not silently truncate when the seed (or
+        writes) only appear on a later page."""
+        runnable_config["configurable"]["checkpoint_id"] = "c3"
+
+        c3_event = CheckpointEvent(
+            checkpoint_id="c3",
+            checkpoint_data=_checkpoint_data("c3"),
+            metadata={"step": 2},
+            parent_checkpoint_id="c2",
+            thread_id="test_thread_id",
+            checkpoint_ns="test_namespace",
+        )
+        c2_event = CheckpointEvent(
+            checkpoint_id="c2",
+            checkpoint_data=_checkpoint_data("c2"),
+            metadata={"step": 1},
+            parent_checkpoint_id="c1",
+            thread_id="test_thread_id",
+            checkpoint_ns="test_namespace",
+        )
+        writes_c2 = WritesEvent(
+            checkpoint_id="c2",
+            writes=[WriteItem(task_id="t_c2", channel="notes", value="w_c2")],
+        )
+        c1_event = CheckpointEvent(
+            checkpoint_id="c1",
+            checkpoint_data=_checkpoint_data("c1"),
+            metadata={"step": 0},
+            parent_checkpoint_id="root",
+            thread_id="test_thread_id",
+            checkpoint_ns="test_namespace",
+        )
+        writes_c1 = WritesEvent(
+            checkpoint_id="c1",
+            writes=[WriteItem(task_id="t_c1", channel="notes", value="w_c1")],
+        )
+        root_event = CheckpointEvent(
+            checkpoint_id="root",
+            checkpoint_data=_checkpoint_data("root", {"notes": "v0"}),
+            metadata={"step": -1},
+            thread_id="test_thread_id",
+            checkpoint_ns="test_namespace",
+        )
+        notes_at_root = ChannelDataEvent(
+            channel="notes",
+            version="v0",
+            value="root_seed",
+            thread_id="test_thread_id",
+            checkpoint_ns="test_namespace",
+        )
+
+        page1 = _list_events_page(
+            saver, [c3_event, c2_event, writes_c2], next_token="tok1"
+        )
+        page2 = _list_events_page(
+            saver, [c1_event, writes_c1, root_event, notes_at_root]
+        )
+
+        def _side_effect(**kwargs):
+            return page2 if kwargs.get("nextToken") == "tok1" else page1
+
+        mock_boto_client.list_events.side_effect = _side_effect
+
+        result = saver.get_delta_channel_history(
+            config=runnable_config, channels=["notes"]
+        )
+
+        assert result == {
+            "notes": {
+                "writes": [
+                    ("t_c1", "notes", "w_c1"),
+                    ("t_c2", "notes", "w_c2"),
+                ],
+                "seed": "root_seed",
+            }
+        }
+
     def test_put_success(
         self,
         saver,
@@ -822,6 +1140,20 @@ class TestAgentCoreMemorySaver:
             mock_get.assert_called_once_with(runnable_config)
 
             assert result is not None
+
+    async def test_aget_delta_channel_history_calls_sync_method_with_correct_args(
+        self, saver, runnable_config
+    ):
+        expected = {"notes": {"writes": []}}
+        with patch.object(
+            saver, "get_delta_channel_history", return_value=expected
+        ) as mock_get:
+            result = await saver.aget_delta_channel_history(
+                config=runnable_config, channels=["notes"]
+            )
+
+            mock_get.assert_called_once_with(config=runnable_config, channels=["notes"])
+            assert result == expected
 
     async def test_alist_calls_sync_method_with_correct_args(
         self, saver, runnable_config, mock_slow_list


### PR DESCRIPTION
BaseCheckpointSaver.get_delta_channel_history`'s default implementation issues one get_tuple call (one AgentCore ListEvents round trip) per ancestor checkpoint it walks. Chain depth grows every turn of a conversation, so this is O(depth) network round trips, and it runs on every resume of a DeltaChannel-backed thread. On a real 43-ancestor thread that walk costs ~30x a single checkpoint load, paid again on every resume — measured below.

AgentCoreMemorySaver.list() already reconstructs checkpoint tuples from a bulk event fetch far more cheaply, because it processes one batch of ListEvents pages into all the checkpoints/writes/channel-data it needs at once, instead of one API round trip per checkpoint. This PR gives `get_delta_channel_history` the same treatment.

Measured directly against live AgentCore Memory, on the same 43-ancestor thread, in the same process, back to back — the override versus the base implementation reached via BaseCheckpointSaver.get_delta_channel_history(saver, ...):

```
single get_tuple            :  2.81s
override (this PR)          :  2.00s
base implementation         : 61.84s     -> 30.9x
writes: 22 == 22   seed: identical (equal=True)
```
Deliberately reporting the isolated operation rather than an end-to-end figure. End-to-end agent latency on this workload is dominated by model thinking time and varied 23.9s-80.3s across runs of identical code, so it cannot support a claim about a checkpointer change. The A/B above changes only the code path.

**What changed**
Added get_delta_channel_history / aget_delta_channel_history overrides to AgentCoreMemorySaver, reproducing the base walk's contract exactly (same double-reversed() write ordering, same seed selection at the nearest ancestor with the channel populated inline, same early stop once every channel is seeded) but sourcing ancestors from bulk-paged events instead of repeated get_tuple calls. aget_delta_channel_history delegates to the sync override via run_in_executor, matching this saver's existing async pattern.

Two correctness traps this specifically guards against:

- **Ancestry vs. fetch/event order.** Raw event order is not ancestor
  order for forked/branched threads — a thread can have multiple
  checkpoint chains sharing a `thread_id` (e.g. after a time-travel
  resume). `_replay_delta_channel_history` walks `parent_config` links
  through an in-memory map built from fetched events, looked up strictly
  by checkpoint id, never by position in the event stream. If a needed
  ancestor id isn't in the map yet, the walk reports itself incomplete
  (mirroring the base's `if get_tuple(cursor) is None: break`) rather than
  guessing from what's available.
- **Paging that can't silently truncate.** `AgentCoreEventClient.get_events(limit=N)`
  counts *events*, not checkpoints, and silently returns a short chain with
  only a `UserWarning` if the limit is hit. This PR adds `iter_event_pages`,
  a pagination primitive with no total-item cap; the override pages
  through it lazily, re-running the walk after every page and stopping
  the instant it's satisfied.

**Also fixed in this branch:** the override's module-level import of
`DeltaChannelHistory` from `langgraph.checkpoint.base` does not exist in
`langgraph-checkpoint` 3.0.0, the package's own declared floor
(`langgraph-checkpoint>=3.0.0,<5.0.0`) — it would break `import
langgraph_checkpoint_aws` entirely on that version, for every user, not
just `DeltaChannel` users. `DeltaChannelHistory` is only ever used as a
type annotation here, and the module already has `from __future__ import
annotations`, so it's now imported under `TYPE_CHECKING` only. The
override methods themselves degrade safely on old `langgraph-checkpoint`:
defining a method on a subclass never requires the base class to declare
it first, so on a runtime without `DeltaChannel` support these are simply
unused methods.

`get_delta_channel_history` is marked **Beta** upstream in `langgraph`
(`BaseCheckpointSaver`) — signature, return shape, and interaction with
`_DeltaSnapshot` blobs may change. Flagged with a `!!! warning "Beta"`
MkDocs admonition on the override docstring.

<details>
<summary>Test plan</summary>

- **Stubbed unit tests** (`tests/unit_tests/agentcore/test_saver.py`, no
  network): 7 focused tests for `get_delta_channel_history` /
  `aget_delta_channel_history` — empty `channels` → `{}` with zero calls;
  a checkpoint with no parent; seed found at an immediate ancestor; writes
  collected in the correct order across a 3-ancestor chain (asserts the
  exact tuple sequence); early stop verified via `list_events.call_count`
  when a further page exists but shouldn't be needed; a chain whose
  seed/writes are split across two `ListEvents` pages, proving no
  truncation at a page boundary; and the async delegation test.
  **7/7 passed.**

- **Equivalence tests against the reference implementation**
  (`tests/unit_tests/agentcore/test_delta_channel_equivalence.py`, newly
  added and committed — not left as scratch scripts). This is the core
  correctness argument for a `perf` PR: the override's output is compared
  directly against `BaseCheckpointSaver.get_delta_channel_history` (called
  unbound, so it walks via `saver.get_tuple` per ancestor — the exact
  thing this PR replaces) on identical underlying data, and asserted
  byte-identical, across four scenarios:
  - a single-page synthetic ancestor chain
  - the same chain split across two `ListEvents` pages
  - a **forked/branched thread** (two children of the same parent; the
    target descends from only one branch) — asserts the off-path
    sibling's writes never leak in
  - a **20-turn thread driven through real `langgraph` machinery** —
    `langgraph.channels.delta.DeltaChannel.update`/`.replay_writes`,
    `langgraph.pregel._checkpoint.create_checkpoint`,
    `delta_channels_to_snapshot`, with `snapshot_frequency=3` (crossing
    several real `_DeltaSnapshot` boundaries) and `max_results=5` (forcing
    every checkpoint's events across several `ListEvents` pages) — the
    only one of the four not backed by hand-built stub events.

  All four **pass** (4/4) and additionally assert no duplicate message id
  or `tool_call_id` in the reconstructed value. Honesty note: the first
  three (synthetic, paginated, forked) are stub-based — hand-constructed
  `CheckpointEvent`/`WritesEvent`/`ChannelDataEvent` objects served through
  a mocked `boto3` client, not a running `Pregel` graph. Only the fourth
  exercises real `DeltaChannel`/`create_checkpoint` machinery end to end.

- **`langgraph-checkpoint` 3.0.0 import smoke test.** Built an isolated
  scratch venv (not the package's own `.venv`/lockfile) with `pip install
  "langgraph-checkpoint==3.0.0" langgraph`, confirmed the resolved
  environment (`langgraph-checkpoint` 3.0.0 + `langgraph` 1.1.10) genuinely
  lacks `DeltaChannelHistory` and `BaseCheckpointSaver.get_delta_channel_history`,
  then `pip install --no-deps -e .` the local package into it and ran
  `import langgraph_checkpoint_aws` +
  `AgentCoreMemorySaver(memory_id=..., region_name=...)`.
  - **Before the import fix:** `ImportError: cannot import name
    'DeltaChannelHistory' from 'langgraph.checkpoint.base'` — package
    fails to import at all.
  - **After the import fix:** import and construction both succeed.
  - Also added a committed regression test
    (`tests/unit_tests/agentcore/test_langgraph_checkpoint_compat.py`,
    2 tests) that reproduces this failure mode *inside the package's own
    test venv* by monkeypatching `DeltaChannelHistory` off
    `langgraph.checkpoint.base` and re-importing the saver module — no
    second environment needed in CI. Plus a static AST check that
    `DeltaChannelHistory` is never imported outside `TYPE_CHECKING`. Both
    fail against the pre-fix code and pass after.

- **Full suite:** `make test` → **1092 passed** (1086 baseline for this
  branch + 6 new: 2 import-compat + 4 equivalence). 29 pre-existing
  warnings, all `RuntimeWarning: coroutine ... was never awaited` from
  `tests/unit_tests/store/valkey/*` async mock fixtures — unrelated
  subsystem (Valkey store, not the AgentCore checkpoint saver), pre-existing
  on this branch before either of this PR's commits, not touched by this
  change.

- **Lint/types:** `make lint` (`ruff check`, `ruff format --diff`, `mypy`)
  and `uv run --group lint mypy .` — clean, no errors, no new warnings
  attributable to this change.

</details>

### Areas that need careful review

- **The ancestor-chain reconstruction from `parent_config` links.** This is
  the crux of the PR's safety — `_replay_delta_channel_history` /
  `_tuples_by_checkpoint_id` in `saver.py` assert that walking an in-memory
  map keyed by checkpoint id, built from bulk-fetched events, is exactly
  equivalent to the base's per-ancestor `get_tuple` walk. The equivalence
  test suite added in this PR exercises single-page, paginated, forked, and
  real-`DeltaChannel` scenarios and found them identical in all cases
  tried, but it is still synthetic/small-scale (largest case: 20 turns).
  Please look hard at those two functions for any place fetch order could
  leak into the result on a much longer or more heavily forked real thread.
- **Paging termination.** The override pages through `iter_event_pages`
  lazily and stops "the instant the walk is satisfied" (root reached, or
  every requested channel seeded). Worth double-checking there's no path
  where a channel's `pending_writes` are still split across an
  as-yet-unfetched page at the moment its *seed* is found — the walk
  currently only checks that an ancestor's `CheckpointEvent` has been
  seen, not that every `WritesEvent` attributable to it has arrived.
- **The Beta status of the upstream method being overridden.**
  `get_delta_channel_history` is explicitly marked Beta in
  `langgraph-checkpoint`'s `BaseCheckpointSaver` — its signature, return
  shape, and interaction with `_DeltaSnapshot` are called out upstream as
  subject to change. This override needs to be re-checked against the
  base implementation on every `langgraph-checkpoint` upgrade; the
  `!!! warning "Beta"` admonition on the override docstring is meant to
  make that easy to find, but it's a manual process, not enforced by
  anything automated.

>NOTE Part of this contribution was developed with the help of an AI coding assistant (agentic implementation from a fully root-caused, pre-measured performance issue, plus a live-testing follow-up pass that verified the optimization's correctness and caught a langgraph-checkpoint 3.x import compatibility break before it shipped). All tests and the final diff were reviewed manually before submission.