### PR TITLE
fix(aws): Enable Converse streaming for xAI Grok models

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -924,6 +924,9 @@ class ChatBedrockConverse(BaseChatModel):
             or
             # Kimi models
             (provider in ("moonshot", "moonshotai") and "kimi" in model_id_lower)
+            or
+            # xAI Grok models
+            (provider == "xai" and "grok" in model_id_lower)
         ):
             return True
         elif (

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -1415,6 +1415,7 @@ def test_invocation_params_model_prefers_base_model_id() -> None:
         ("qwen.qwen3-32b-v1:0", False),
         ("moonshotai.kimi-k2.5", False),
         ("moonshot.kimi-k2-thinking", False),
+        ("xai.grok-4.6", False),
     ],
 )
 def test_set_disable_streaming(
@@ -3099,6 +3100,12 @@ def test__get_base_model() -> None:
             "arn:aws:bedrock:us-west-2:123456789012:application-inference-profile/my-profile",
             "anthropic.claude-fable-5",
             "anthropic",
+            False,
+        ),
+        (
+            "arn:aws:bedrock:us-west-2:123456789012:application-inference-profile/my-profile",
+            "xai.grok-4.6",
+            "xai",
             False,
         ),
         (

--- a/libs/aws/tests/unit_tests/test_utils.py
+++ b/libs/aws/tests/unit_tests/test_utils.py
@@ -463,6 +463,7 @@ def test_trim_message_whitespace_with_empty_messages() -> None:
         ("us.anthropic.claude-3-sonnet-20240229-v1:0", False),
         ("us.meta.llama4-scout-17b-instruct-v1:0", False),
         ("us.amazon.nova-pro-v1:0", False),
+        ("xai.grok-4.6", False),
     ],
 )
 def test_count_tokens_api_supported_for_model(


### PR DESCRIPTION
Closes out #1223.

Per Bedrock's Grok 4.6 feature support page: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-xai-grok-4-6.html, also will apply to any future Grok models released on `bedrock-runtime`.