### PR TITLE
fix(aws): Forced tool use support on xAI models

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -1146,6 +1146,8 @@ class ChatBedrockConverse(BaseChatModel):
                     self.supports_tool_choice_values = ("auto",)
                 else:
                     self.supports_tool_choice_values = ("auto", "any", "tool")
+            elif "grok" in base_model:
+                self.supports_tool_choice_values = ("auto", "any", "tool")
             elif "llama4" in base_model:
                 self.supports_tool_choice_values = ("auto",)
             elif "llama3" in base_model:

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -357,6 +357,13 @@ def test_deepseek_supports_tool_choice_values(
     assert chat_model.supports_tool_choice_values == expected_values
 
 
+def test_xai_supports_tool_choice_values() -> None:
+    chat_model = ChatBedrockConverse(
+        model="global.xai.grok-4.6", region_name="us-east-1"
+    )
+    assert chat_model.supports_tool_choice_values == ("auto", "any", "tool")
+
+
 def test_deepseek_r1_no_tool_choice_support() -> None:
     chat_model = ChatBedrockConverse(model="deepseek.r1-v1:0", region_name="us-east-1")  # type: ignore[call-arg]
 


### PR DESCRIPTION
In `ChatBedrockConverse`, added the set of supported `ToolChoice` values for xAI models (based on Grok 4.6, will assume this stays the same for future models)