### PR TITLE
fix(aws): honor zero MemoryDB distance threshold

### DIFF
--- a/libs/aws/langchain_aws/vectorstores/inmemorydb/base.py
+++ b/libs/aws/langchain_aws/vectorstores/inmemorydb/base.py
@@ -1029,7 +1029,7 @@ class InMemoryVectorStore(VectorStore):
         if with_metadata:
             return_fields.extend(self._schema.metadata_keys)
 
-        if distance_threshold:
+        if distance_threshold is not None:
             params_dict["distance_threshold"] = distance_threshold
             return (
                 self._prepare_range_query(

--- a/libs/aws/tests/unit_tests/vectorstores/test_inmemorydb.py
+++ b/libs/aws/tests/unit_tests/vectorstores/test_inmemorydb.py
@@ -1,0 +1,50 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+from langchain_aws.vectorstores.inmemorydb.base import InMemoryVectorStore
+
+
+@pytest.mark.parametrize(
+    ("distance_threshold", "uses_range_query"),
+    [(0.0, True), (0.5, True), (None, False)],
+)
+def test_prepare_query_selects_query_type_by_distance_threshold(
+    distance_threshold: float | None, uses_range_query: bool
+) -> None:
+    store = object.__new__(InMemoryVectorStore)
+    store._schema = Mock(
+        content_key="content",
+        metadata_keys=[],
+        vector_dtype="float32",
+    )
+    range_query = Mock()
+    vector_query = Mock()
+
+    with (
+        patch(
+            "langchain_aws.vectorstores.inmemorydb.base._array_to_buffer",
+            return_value=b"encoded-query",
+        ),
+        patch.object(store, "_prepare_range_query", return_value=range_query) as range,
+        patch.object(store, "_prepare_vector_query", return_value=vector_query) as knn,
+    ):
+        query, params = store._prepare_query(
+            [0.1, 0.2],
+            k=3,
+            distance_threshold=distance_threshold,
+            with_metadata=False,
+        )
+
+    expected_params: dict[str, bytes | float] = {"vector": b"encoded-query"}
+    if uses_range_query:
+        assert distance_threshold is not None
+        expected_params["distance_threshold"] = distance_threshold
+        assert query is range_query
+        range.assert_called_once_with(3, filter=None, return_fields=["content"])
+        knn.assert_not_called()
+    else:
+        assert query is vector_query
+        range.assert_not_called()
+        knn.assert_called_once_with(3, filter=None, return_fields=["content"])
+    assert params == expected_params


### PR DESCRIPTION
## Summary

Treat `distance_threshold=0.0` as an explicitly configured threshold when building MemoryDB vector queries.

- Use `VECTOR_RANGE` for every non-`None` threshold and bind the exact value.
- Use KNN only when the threshold is `None`.
- Preserve positive-threshold behavior.
- Add unit coverage for zero, positive, and absent thresholds.

## Testing

- Focused unit tests: 3 passed
- Ruff check and format check
- Mypy on the changed source and test files
- Syntax, import, and diff hygiene checks