### PR TITLE
test(aws): Remove Cohere standard integration tests

### DIFF
--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
@@ -224,44 +224,6 @@ class TestBedrockNovaStandard(ChatModelIntegrationTests):
         super().test_tool_message_histories_list_content(model, my_adder_tool)
 
 
-class TestBedrockCohereStandard(ChatModelIntegrationTests):
-    @property
-    def chat_model_class(self) -> Type[BaseChatModel]:
-        return ChatBedrockConverse
-
-    @property
-    def chat_model_params(self) -> dict:
-        return {"model": "cohere.command-r-plus-v1:0"}
-
-    @property
-    def standard_chat_model_params(self) -> dict:
-        return {"temperature": 0, "max_tokens": 100, "stop": []}
-
-    @property
-    def has_tool_choice(self) -> bool:
-        return False
-
-    @pytest.mark.xfail(reason="Cohere models don't support tool_choice.")
-    def test_structured_few_shot_examples(
-        self, model: BaseChatModel, my_adder_tool: BaseTool
-    ) -> None:
-        pass
-
-    @pytest.mark.xfail(reason="Cohere models don't support tool_choice.")
-    def test_unicode_tool_call_integration(
-        self,
-        model: BaseChatModel,
-        *,
-        tool_choice: Optional[str] = None,
-        force_tool_call: bool = False,
-    ) -> None:
-        pass
-
-    @pytest.mark.xfail(reason="Generates invalid tool call.")
-    def test_tool_calling_with_no_arguments(self, model: BaseChatModel) -> None:
-        pass
-
-
 class TestBedrockXaiStandard(ChatModelIntegrationTests):
     @property
     def chat_model_class(self) -> Type[BaseChatModel]:


### PR DESCRIPTION
Seen in latest integration workflow runs:
```
FAILED tests/integration_tests/chat_models/test_bedrock_converse.py::TestBedrockCohereStandard::test_invoke - botocore.errorfactory.ResourceNotFoundException: An error occurred (ResourceNotFoundException) when calling the Converse operation: This model version has reached the end of its life. Please refer to the AWS documentation for more details.
```
Bedrock officially deactivated access to Cohere Command R+ this week: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-cohere-command-r-plus.html

There is no suitable Cohere LLM remaining on Bedrock (only their Embed/Rerank models), so will be removing the standard ChatBedrockConverse test suite for the provider.
