### PR TITLE
feat(langgraph-checkpoint-aws): add flush_writes option to DeferredCheckpointSaver

### DIFF
--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/deferred_saver.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/checkpoint/deferred_saver.py
@@ -99,10 +99,61 @@ class DeferredCheckpointSaver(BaseCheckpointSaver):
             ``SyncBatchFlushable`` or ``AsyncBatchFlushable``, flush uses
             a single ``put_with_writes`` call instead of 1 + N sequential
             calls.  Defaults to ``False`` for backward compatibility.
+            ``AgentCoreMemorySaver`` implements both protocols, so this is
+            the preferred way to reach one API call per flush.
+        flush_writes: When ``False``, flush persists only the checkpoint and
+            discards buffered writes, reducing flush to a single ``put()``
+            call.  Buffered writes are still served to the graph from memory
+            during execution, so a run that reaches the end persists complete
+            state — the final ``put()`` already has every task output applied.
+            See the warning below for what a partially completed run loses.
+            Prefer *batch_writes* when the underlying saver supports it: it
+            reaches the same single call while keeping the write records.
+            Reach for this only with a saver that does not implement the
+            batch protocols.
 
     Raises:
         ValueError: If *saver* is itself a ``DeferredCheckpointSaver``
-            (nesting is not supported).
+            (nesting is not supported), or if *batch_writes* and
+            ``flush_writes=False`` are combined.
+
+    !!! warning "One in-flight run per instance"
+
+        The buffer holds a single checkpoint slot, so a ``put()`` for one
+        ``thread_id`` discards whatever was buffered for another.  Sharing
+        one instance across concurrent runs — a module-level saver serving
+        concurrent requests, for example — silently loses turns.  Create one
+        instance per in-flight run, or per request.
+
+        Sequential reuse is fine: ``flush()`` and ``clear()`` both empty the
+        buffer, so the next run starts clean.  Subgraphs are also fine —
+        they share the parent's ``thread_id`` and only vary
+        ``checkpoint_ns``.
+
+    !!! warning "`flush_writes=False` makes node execution at-least-once"
+
+        LangGraph writes a per-task record when a node finishes.  Those
+        records are not only debug metadata — they are the receipts the
+        runtime uses on resume to tell which tasks in the current superstep
+        already ran.  Dropping them means a resumed superstep re-executes
+        tasks that had already completed.
+
+        This affects any run that does not reach the end: a node raising
+        (``flush_on_exit`` still flushes, from its ``finally`` block), or an
+        ``interrupt()``.  Resuming such a thread succeeds and converges to
+        the same channel values, but every already-completed sibling task in
+        the unfinished superstep runs a second time.  If your nodes have
+        side effects — tool calls, API writes, payments — those side effects
+        repeat.
+
+        Two further consequences: ``state.interrupts`` comes back empty
+        after a flush, so a restarted process can see *that* a thread is
+        paused but not what it asked the human; and time travel plus
+        ``get_state_history()`` inspection of pending tasks no longer work.
+
+        Set this to ``False`` only when nodes are idempotent (or the run is
+        never resumed) and the persisted checkpoint alone is enough to
+        restore your application state.
 
     Example::
 
@@ -111,10 +162,23 @@ class DeferredCheckpointSaver(BaseCheckpointSaver):
 
         with deferred.flush_on_exit():
             graph.invoke(input, config)
+
+    Example: one API call per invocation without the batch protocols, for
+    idempotent nodes only::
+
+        deferred = DeferredCheckpointSaver(my_saver, flush_writes=False)
+        graph = workflow.compile(checkpointer=deferred)
+
+        with deferred.flush_on_exit():
+            graph.invoke(input, config)
     """
 
     def __init__(
-        self, saver: BaseCheckpointSaver, *, batch_writes: bool = False
+        self,
+        saver: BaseCheckpointSaver,
+        *,
+        batch_writes: bool = False,
+        flush_writes: bool = True,
     ) -> None:
         if isinstance(saver, DeferredCheckpointSaver):
             msg = (
@@ -122,9 +186,22 @@ class DeferredCheckpointSaver(BaseCheckpointSaver):
                 "Pass the underlying saver directly."
             )
             raise ValueError(msg)
+        if batch_writes and not flush_writes:
+            # Anyone setting both wanted fewer API calls and did not realize
+            # batch_writes alone gets there.  Say so rather than silently
+            # picking the option that also drops the write records.
+            msg = (
+                "batch_writes=True and flush_writes=False are contradictory. "
+                "batch_writes=True already reduces flush to a single call and "
+                "keeps the per-task write records that make node execution "
+                "once-per-superstep; flush_writes=False drops them. Remove "
+                "flush_writes=False."
+            )
+            raise ValueError(msg)
         super().__init__()
         self._saver = saver
         self._batch_writes = batch_writes
+        self._flush_writes = flush_writes
         self._lock = threading.Lock()
         self._pending_checkpoint: _PendingCheckpoint | None = None
         self._pending_writes: list[_PendingWrite] = []
@@ -165,6 +242,9 @@ class DeferredCheckpointSaver(BaseCheckpointSaver):
         Each call overwrites the previously buffered checkpoint — only the
         latest one is kept.  This is the core optimization: for a 6-node
         workflow LangGraph calls ``put()`` 6 times, but we only persist once.
+
+        Overwriting is only safe within a single run — see the class-level
+        note on one in-flight run per instance.
 
         Args:
             config: The runnable config associated with this checkpoint.
@@ -436,7 +516,9 @@ class DeferredCheckpointSaver(BaseCheckpointSaver):
     def flush(self) -> RunnableConfig | None:
         """Persist all buffered data to the underlying saver.
 
-        When ``batch_writes=True`` and the saver implements
+        When ``flush_writes=False``, only the checkpoint is persisted and
+        buffered writes are discarded (single ``put()`` call).  Otherwise,
+        when ``batch_writes=True`` and the saver implements
         ``SyncBatchFlushable``, the checkpoint and all writes are persisted
         in a single ``put_with_writes()`` call (fast path).  Otherwise the
         checkpoint is flushed first, then writes are drained one at a time
@@ -455,12 +537,45 @@ class DeferredCheckpointSaver(BaseCheckpointSaver):
             Exception: Any exception raised by the underlying saver during
                 persistence is propagated after restoring unflushed data.
         """
+        # --- Checkpoint-only path: writes are dropped, not persisted ---
+        if not self._flush_writes:
+            return self._flush_checkpoint_only()
+
         # --- Fast path: saver supports sync batching ---
         if self._batch_writes and isinstance(self._saver, SyncBatchFlushable):
             return self._flush_batched()
 
         # --- Fallback path: existing 1 + N behavior ---
         return self._flush_sequential()
+
+    def _flush_checkpoint_only(self) -> RunnableConfig | None:
+        """Persist the checkpoint and discard buffered writes.
+
+        Writes are dropped before the network call: they are never persisted
+        under ``flush_writes=False``, so there is nothing to retry on failure
+        and nothing to restore.  The checkpoint itself is restored on failure
+        unless a newer ``put()`` raced in while we were blocked on I/O.
+        """
+        with self._lock:
+            pending_cp = self._pending_checkpoint
+            self._pending_checkpoint = None
+            self._pending_writes.clear()
+
+        if pending_cp is None:
+            return None
+
+        try:
+            return self._saver.put(
+                pending_cp.config,
+                pending_cp.checkpoint,
+                pending_cp.metadata,
+                pending_cp.new_versions,
+            )
+        except Exception:
+            with self._lock:
+                if self._pending_checkpoint is None:
+                    self._pending_checkpoint = pending_cp
+            raise
 
     def _flush_batched(self) -> RunnableConfig | None:
         """Fast path: persist checkpoint + writes in one call."""
@@ -569,9 +684,11 @@ class DeferredCheckpointSaver(BaseCheckpointSaver):
     async def aflush(self) -> RunnableConfig | None:
         """Async version of :meth:`flush`.
 
-        When ``batch_writes=True`` and the saver implements
-        ``AsyncBatchFlushable``, uses ``aput_with_writes()`` (fast path).
-        Otherwise falls back to sequential ``aput()`` + N ``aput_writes()``.
+        When ``flush_writes=False``, persists only the checkpoint with a
+        single ``aput()`` call and discards buffered writes.  Otherwise, when
+        ``batch_writes=True`` and the saver implements ``AsyncBatchFlushable``,
+        uses ``aput_with_writes()`` (fast path).  Otherwise falls back to
+        sequential ``aput()`` + N ``aput_writes()``.
 
         Returns:
             The config returned by the underlying saver, or ``None`` if no
@@ -581,12 +698,39 @@ class DeferredCheckpointSaver(BaseCheckpointSaver):
             Exception: Any exception raised by the underlying saver during
                 persistence is propagated after restoring unflushed data.
         """
+        # --- Checkpoint-only path: writes are dropped, not persisted ---
+        if not self._flush_writes:
+            return await self._aflush_checkpoint_only()
+
         # --- Fast path: saver supports async batching ---
         if self._batch_writes and isinstance(self._saver, AsyncBatchFlushable):
             return await self._aflush_batched()
 
         # --- Fallback path: existing 1 + N behavior ---
         return await self._aflush_sequential()
+
+    async def _aflush_checkpoint_only(self) -> RunnableConfig | None:
+        """Async version of :meth:`_flush_checkpoint_only`."""
+        with self._lock:
+            pending_cp = self._pending_checkpoint
+            self._pending_checkpoint = None
+            self._pending_writes.clear()
+
+        if pending_cp is None:
+            return None
+
+        try:
+            return await self._saver.aput(
+                pending_cp.config,
+                pending_cp.checkpoint,
+                pending_cp.metadata,
+                pending_cp.new_versions,
+            )
+        except Exception:
+            with self._lock:
+                if self._pending_checkpoint is None:
+                    self._pending_checkpoint = pending_cp
+            raise
 
     async def _aflush_batched(self) -> RunnableConfig | None:
         """Async fast path: persist checkpoint + writes in one call."""
@@ -685,7 +829,9 @@ class DeferredCheckpointSaver(BaseCheckpointSaver):
         """Context manager that flushes buffered data on exit.
 
         Flushes in the ``finally`` block so data is persisted even when the
-        graph raises an exception.
+        graph raises an exception.  Note that under ``flush_writes=False``
+        that exception path is exactly the case where completed tasks lose
+        their receipts and re-run on resume — see the class-level warning.
 
         Yields:
             This ``DeferredCheckpointSaver`` instance.
@@ -703,6 +849,9 @@ class DeferredCheckpointSaver(BaseCheckpointSaver):
     @contextlib.asynccontextmanager
     async def aflush_on_exit(self) -> AsyncIterator[DeferredCheckpointSaver]:
         """Async context manager that flushes buffered data on exit.
+
+        Carries the same ``flush_writes=False`` caveat as
+        :meth:`flush_on_exit`.
 
         Yields:
             This ``DeferredCheckpointSaver`` instance.

--- a/libs/langgraph-checkpoint-aws/tests/integration_tests/test_deferred_saver.py
+++ b/libs/langgraph-checkpoint-aws/tests/integration_tests/test_deferred_saver.py
@@ -411,6 +411,52 @@ class TestDeferredCheckpointSaver:
         finally:
             cleanup(thread_id, actor_id)
 
+    def test_flush_writes_disabled_persists_checkpoint_only(
+        self, saver_and_cleanup: _SaverAndCleanup
+    ) -> None:
+        """flush_writes=False persists the checkpoint and drops the writes."""
+        saver, cleanup, thread_id, actor_id = self._unpack(saver_and_cleanup)
+        deferred = DeferredCheckpointSaver(saver, flush_writes=False)
+        checkpoint = _make_checkpoint()
+
+        config: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "actor_id": actor_id,
+                "checkpoint_ns": "",
+            }
+        }
+        write_config: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "actor_id": actor_id,
+                "checkpoint_ns": "",
+                "checkpoint_id": checkpoint["id"],
+            }
+        }
+
+        try:
+            deferred.put(
+                config,
+                checkpoint,
+                {"source": "input", "step": 1},
+                {"messages": "v1"},
+            )
+            deferred.put_writes(write_config, [("messages", "hello")], "task-1")
+
+            deferred.flush()
+            assert deferred.is_empty
+
+            # Checkpoint state survived...
+            result = saver.get_tuple(write_config)
+            assert result is not None
+            assert result.checkpoint["id"] == checkpoint["id"]
+            assert result.checkpoint["channel_values"]["messages"] == ["test message"]
+            # ...but no per-task write records were written.
+            assert not result.pending_writes
+        finally:
+            cleanup(thread_id, actor_id)
+
     def test_multi_session_isolation(self, saver_and_cleanup: _SaverAndCleanup) -> None:
         """Two flush_on_exit blocks with different threads stay isolated."""
         saver, cleanup, thread_id_1, actor_id = self._unpack(saver_and_cleanup)

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/test_deferred_saver.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/test_deferred_saver.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import operator
 import threading
-from typing import Any
+from typing import Annotated, Any, TypedDict
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -13,6 +14,8 @@ from langgraph.checkpoint.base import (
     CheckpointMetadata,
 )
 from langgraph.checkpoint.memory import MemorySaver
+from langgraph.graph import END, START, StateGraph
+from langgraph.types import Command, interrupt
 
 from langgraph_checkpoint_aws.checkpoint.deferred_saver import DeferredCheckpointSaver
 
@@ -1107,3 +1110,588 @@ class TestAsyncFlushCheckpointRace:
         result = deferred.get_tuple(_make_config(thread_id="t1"))
         assert result is not None
         assert result.checkpoint["id"] == "ckpt-new"
+
+
+class _BatchFlushableSaver(MemorySaver):
+    """MemorySaver that also satisfies the batch flush protocols."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.put_with_writes_calls = 0
+        self.aput_with_writes_calls = 0
+
+    def put_with_writes(
+        self,
+        config: RunnableConfig,
+        checkpoint: Checkpoint,
+        metadata: CheckpointMetadata,
+        new_versions: Any,
+        pending_writes: Any,
+    ) -> RunnableConfig:
+        self.put_with_writes_calls += 1
+        return self.put(config, checkpoint, metadata, new_versions)
+
+    async def aput_with_writes(
+        self,
+        config: RunnableConfig,
+        checkpoint: Checkpoint,
+        metadata: CheckpointMetadata,
+        new_versions: Any,
+        pending_writes: Any,
+    ) -> RunnableConfig:
+        self.aput_with_writes_calls += 1
+        return await self.aput(config, checkpoint, metadata, new_versions)
+
+
+class TestFlushWritesDisabled:
+    """flush_writes=False persists the checkpoint only."""
+
+    def test_default_persists_writes(self, memory_saver: MemorySaver) -> None:
+        """Default stays backward compatible: writes reach the saver."""
+        deferred = DeferredCheckpointSaver(memory_saver)
+        config = _make_config(thread_id="t1")
+        deferred.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), {})
+        deferred.put_writes(
+            _make_config(thread_id="t1", checkpoint_id="ckpt-1"),
+            [("ch1", "v1")],
+            "task-1",
+        )
+
+        with patch.object(memory_saver, "put_writes") as mock_pw:
+            deferred.flush()
+            mock_pw.assert_called_once()
+
+    def test_flush_does_not_call_put_writes(self, memory_saver: MemorySaver) -> None:
+        deferred = DeferredCheckpointSaver(memory_saver, flush_writes=False)
+        config = _make_config(thread_id="t1")
+        deferred.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), {})
+        write_config = _make_config(thread_id="t1", checkpoint_id="ckpt-1")
+        deferred.put_writes(write_config, [("ch1", "v1")], "task-1")
+        deferred.put_writes(write_config, [("ch2", "v2")], "task-2")
+
+        with (
+            patch.object(memory_saver, "put_writes") as mock_pw,
+            patch.object(memory_saver, "put", wraps=memory_saver.put) as mock_put,
+        ):
+            result = deferred.flush()
+
+        # Exactly one API call: the checkpoint. Zero write calls.
+        mock_put.assert_called_once()
+        mock_pw.assert_not_called()
+        assert result is not None
+        assert result["configurable"]["checkpoint_id"] == "ckpt-1"
+
+    def test_flush_discards_buffered_writes(self, memory_saver: MemorySaver) -> None:
+        deferred = DeferredCheckpointSaver(memory_saver, flush_writes=False)
+        config = _make_config(thread_id="t1")
+        deferred.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), {})
+        deferred.put_writes(
+            _make_config(thread_id="t1", checkpoint_id="ckpt-1"),
+            [("ch1", "v1")],
+            "task-1",
+        )
+
+        deferred.flush()
+
+        assert deferred.is_empty
+        assert not deferred.has_buffered_writes
+        # Nothing landed in the backend either.
+        persisted = memory_saver.get_tuple(_make_config(thread_id="t1"))
+        assert persisted is not None
+        assert not persisted.pending_writes
+
+    def test_checkpoint_state_is_preserved(self, memory_saver: MemorySaver) -> None:
+        """Skipping writes must not affect the persisted conversation state."""
+        deferred = DeferredCheckpointSaver(memory_saver, flush_writes=False)
+        config = _make_config(thread_id="t1")
+        deferred.put(
+            config, _make_checkpoint("ckpt-1"), _make_metadata(), {"messages": "v1"}
+        )
+        deferred.put_writes(
+            _make_config(thread_id="t1", checkpoint_id="ckpt-1"),
+            [("messages", "dropped")],
+            "task-1",
+        )
+
+        deferred.flush()
+
+        persisted = memory_saver.get_tuple(_make_config(thread_id="t1"))
+        assert persisted is not None
+        assert persisted.checkpoint["id"] == "ckpt-1"
+        assert persisted.checkpoint["channel_values"] == {"messages": ["hello"]}
+
+    def test_writes_still_visible_before_flush(self, memory_saver: MemorySaver) -> None:
+        """Buffered writes are still served to the running graph."""
+        deferred = DeferredCheckpointSaver(memory_saver, flush_writes=False)
+        config = _make_config(thread_id="t1")
+        deferred.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), {})
+        deferred.put_writes(
+            _make_config(thread_id="t1", checkpoint_id="ckpt-1"),
+            [("ch1", "v1")],
+            "task-1",
+        )
+
+        result = deferred.get_tuple(_make_config(thread_id="t1"))
+
+        assert result is not None
+        assert result.pending_writes == [("task-1", "ch1", "v1")]
+
+    def test_flush_returns_none_when_only_writes_buffered(
+        self, memory_saver: MemorySaver
+    ) -> None:
+        deferred = DeferredCheckpointSaver(memory_saver, flush_writes=False)
+        deferred.put_writes(
+            _make_config(thread_id="t1", checkpoint_id="ckpt-1"),
+            [("ch1", "v1")],
+            "task-1",
+        )
+
+        with patch.object(memory_saver, "put_writes") as mock_pw:
+            result = deferred.flush()
+
+        assert result is None
+        assert deferred.is_empty
+        mock_pw.assert_not_called()
+
+    def test_flush_returns_none_when_empty(self, memory_saver: MemorySaver) -> None:
+        deferred = DeferredCheckpointSaver(memory_saver, flush_writes=False)
+        assert deferred.flush() is None
+
+    def test_flush_failure_restores_checkpoint_and_drops_writes(
+        self, memory_saver: MemorySaver
+    ) -> None:
+        deferred = DeferredCheckpointSaver(memory_saver, flush_writes=False)
+        config = _make_config(thread_id="t1")
+        deferred.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), {})
+        deferred.put_writes(
+            _make_config(thread_id="t1", checkpoint_id="ckpt-1"),
+            [("ch1", "v1")],
+            "task-1",
+        )
+
+        with patch.object(
+            memory_saver, "put", side_effect=RuntimeError("network error")
+        ):
+            with pytest.raises(RuntimeError, match="network error"):
+                deferred.flush()
+
+        # The checkpoint is retryable; the writes were never persistable.
+        assert deferred.has_buffered_checkpoint
+        assert not deferred.has_buffered_writes
+
+    def test_flush_failure_does_not_clobber_new_checkpoint(
+        self, memory_saver: MemorySaver
+    ) -> None:
+        deferred = DeferredCheckpointSaver(memory_saver, flush_writes=False)
+        config = _make_config(thread_id="t1")
+        deferred.put(config, _make_checkpoint("ckpt-old"), _make_metadata(), {})
+
+        def failing_put_that_races(*args: Any, **kwargs: Any) -> None:
+            deferred.put(config, _make_checkpoint("ckpt-new"), _make_metadata(1), {})
+            msg = "network error"
+            raise RuntimeError(msg)
+
+        with patch.object(memory_saver, "put", side_effect=failing_put_that_races):
+            with pytest.raises(RuntimeError, match="network error"):
+                deferred.flush()
+
+        result = deferred.get_tuple(_make_config(thread_id="t1"))
+        assert result is not None
+        assert result.checkpoint["id"] == "ckpt-new"
+
+    def test_flush_on_exit_persists_checkpoint_only(
+        self, memory_saver: MemorySaver
+    ) -> None:
+        deferred = DeferredCheckpointSaver(memory_saver, flush_writes=False)
+        config = _make_config(thread_id="t1")
+
+        with patch.object(memory_saver, "put_writes") as mock_pw:
+            with deferred.flush_on_exit():
+                deferred.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), {})
+                deferred.put_writes(
+                    _make_config(thread_id="t1", checkpoint_id="ckpt-1"),
+                    [("ch1", "v1")],
+                    "task-1",
+                )
+
+        assert deferred.is_empty
+        mock_pw.assert_not_called()
+        assert memory_saver.get_tuple(_make_config(thread_id="t1")) is not None
+
+    def test_combining_with_batch_writes_raises(self) -> None:
+        """Both flags together is a contradiction, not a precedence question.
+
+        ``batch_writes=True`` already reaches one API call while keeping the
+        write records, so silently honoring ``flush_writes=False`` would trade
+        away durability the caller did not need to give up.
+        """
+        with pytest.raises(ValueError, match="contradictory"):
+            DeferredCheckpointSaver(
+                _BatchFlushableSaver(), batch_writes=True, flush_writes=False
+            )
+
+    def test_batch_writes_alone_still_batches(self) -> None:
+        """The recommended alternative keeps the single call and the writes."""
+        saver = _BatchFlushableSaver()
+        deferred = DeferredCheckpointSaver(saver, batch_writes=True)
+        config = _make_config(thread_id="t1")
+        deferred.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), {})
+        deferred.put_writes(
+            _make_config(thread_id="t1", checkpoint_id="ckpt-1"),
+            [("ch1", "v1")],
+            "task-1",
+        )
+
+        result = deferred.flush()
+
+        assert result is not None
+        assert saver.put_with_writes_calls == 1
+        assert deferred.is_empty
+
+    @pytest.mark.asyncio
+    async def test_aflush_does_not_call_aput_writes(
+        self, memory_saver: MemorySaver
+    ) -> None:
+        deferred = DeferredCheckpointSaver(memory_saver, flush_writes=False)
+        config = _make_config(thread_id="t1")
+        await deferred.aput(config, _make_checkpoint("ckpt-1"), _make_metadata(), {})
+        await deferred.aput_writes(
+            _make_config(thread_id="t1", checkpoint_id="ckpt-1"),
+            [("ch1", "v1")],
+            "task-1",
+        )
+
+        with patch.object(
+            memory_saver, "aput_writes", new_callable=AsyncMock
+        ) as mock_apw:
+            result = await deferred.aflush()
+
+        mock_apw.assert_not_called()
+        assert result is not None
+        assert deferred.is_empty
+        persisted = await memory_saver.aget_tuple(_make_config(thread_id="t1"))
+        assert persisted is not None
+        assert persisted.checkpoint["id"] == "ckpt-1"
+        assert not persisted.pending_writes
+
+    @pytest.mark.asyncio
+    async def test_aflush_failure_restores_checkpoint_and_drops_writes(
+        self, memory_saver: MemorySaver
+    ) -> None:
+        deferred = DeferredCheckpointSaver(memory_saver, flush_writes=False)
+        config = _make_config(thread_id="t1")
+        deferred.put(config, _make_checkpoint("ckpt-1"), _make_metadata(), {})
+        deferred.put_writes(
+            _make_config(thread_id="t1", checkpoint_id="ckpt-1"),
+            [("ch1", "v1")],
+            "task-1",
+        )
+
+        with patch.object(
+            memory_saver,
+            "aput",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("async fail"),
+        ):
+            with pytest.raises(RuntimeError, match="async fail"):
+                await deferred.aflush()
+
+        assert deferred.has_buffered_checkpoint
+        assert not deferred.has_buffered_writes
+
+    @pytest.mark.asyncio
+    async def test_aflush_on_exit_persists_checkpoint_only(
+        self, memory_saver: MemorySaver
+    ) -> None:
+        deferred = DeferredCheckpointSaver(memory_saver, flush_writes=False)
+        config = _make_config(thread_id="t1")
+
+        with patch.object(
+            memory_saver, "aput_writes", new_callable=AsyncMock
+        ) as mock_apw:
+            async with deferred.aflush_on_exit():
+                await deferred.aput(
+                    config, _make_checkpoint("ckpt-1"), _make_metadata(), {}
+                )
+                await deferred.aput_writes(
+                    _make_config(thread_id="t1", checkpoint_id="ckpt-1"),
+                    [("ch1", "v1")],
+                    "task-1",
+                )
+
+        assert deferred.is_empty
+        mock_apw.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_abatch_writes_alone_still_batches(self) -> None:
+        """Async twin of :meth:`test_batch_writes_alone_still_batches`."""
+        saver = _BatchFlushableSaver()
+        deferred = DeferredCheckpointSaver(saver, batch_writes=True)
+        config = _make_config(thread_id="t1")
+        await deferred.aput(config, _make_checkpoint("ckpt-1"), _make_metadata(), {})
+        await deferred.aput_writes(
+            _make_config(thread_id="t1", checkpoint_id="ckpt-1"),
+            [("ch1", "v1")],
+            "task-1",
+        )
+
+        result = await deferred.aflush()
+
+        assert result is not None
+        assert saver.aput_with_writes_calls == 1
+        assert deferred.is_empty
+
+
+class _ConversationState(TypedDict):
+    messages: Annotated[list[str], operator.add]
+
+
+def _build_multi_node_graph(checkpointer: DeferredCheckpointSaver) -> Any:
+    """Compile a three-node graph so each turn produces several writes."""
+
+    def node_a(state: _ConversationState) -> _ConversationState:
+        return {"messages": ["a"]}
+
+    def node_b(state: _ConversationState) -> _ConversationState:
+        return {"messages": ["b"]}
+
+    def node_c(state: _ConversationState) -> _ConversationState:
+        return {"messages": ["c"]}
+
+    builder = StateGraph(_ConversationState)
+    builder.add_node("a", node_a)
+    builder.add_node("b", node_b)
+    builder.add_node("c", node_c)
+    builder.add_edge(START, "a")
+    builder.add_edge("a", "b")
+    builder.add_edge("b", "c")
+    builder.add_edge("c", END)
+    return builder.compile(checkpointer=checkpointer)
+
+
+class TestFlushWritesDisabledGraphRun:
+    """End-to-end graph runs with flush_writes=False."""
+
+    def test_multi_turn_conversation_state_is_preserved(
+        self, memory_saver: MemorySaver
+    ) -> None:
+        """Conversation state accumulates across turns without write records."""
+        deferred = DeferredCheckpointSaver(memory_saver, flush_writes=False)
+        graph = _build_multi_node_graph(deferred)
+        config = _make_config(thread_id="conversation-1")
+
+        with patch.object(
+            memory_saver, "put_writes", wraps=memory_saver.put_writes
+        ) as mock_pw:
+            for turn in range(3):
+                with deferred.flush_on_exit():
+                    graph.invoke({"messages": [f"turn-{turn}"]}, config)
+
+        # No per-task write records were persisted for any turn.
+        mock_pw.assert_not_called()
+
+        # Every message from every turn survived in the persisted checkpoint.
+        state = graph.get_state(config)
+        assert state.values["messages"] == [
+            "turn-0",
+            "a",
+            "b",
+            "c",
+            "turn-1",
+            "a",
+            "b",
+            "c",
+            "turn-2",
+            "a",
+            "b",
+            "c",
+        ]
+
+    def test_graph_run_persists_single_checkpoint_per_turn(
+        self, memory_saver: MemorySaver
+    ) -> None:
+        """A three-node turn costs exactly one put() at flush time."""
+        deferred = DeferredCheckpointSaver(memory_saver, flush_writes=False)
+        graph = _build_multi_node_graph(deferred)
+        config = _make_config(thread_id="conversation-2")
+
+        with patch.object(memory_saver, "put", wraps=memory_saver.put) as mock_put:
+            with deferred.flush_on_exit():
+                graph.invoke({"messages": ["hello"]}, config)
+
+        assert mock_put.call_count == 1
+        assert deferred.is_empty
+
+    @pytest.mark.asyncio
+    async def test_async_multi_turn_conversation_state_is_preserved(
+        self, memory_saver: MemorySaver
+    ) -> None:
+        deferred = DeferredCheckpointSaver(memory_saver, flush_writes=False)
+        graph = _build_multi_node_graph(deferred)
+        config = _make_config(thread_id="conversation-3")
+
+        with patch.object(
+            memory_saver, "aput_writes", new_callable=AsyncMock
+        ) as mock_apw:
+            for turn in range(2):
+                async with deferred.aflush_on_exit():
+                    await graph.ainvoke({"messages": [f"turn-{turn}"]}, config)
+
+        mock_apw.assert_not_called()
+
+        state = await graph.aget_state(config)
+        assert state.values["messages"] == [
+            "turn-0",
+            "a",
+            "b",
+            "c",
+            "turn-1",
+            "a",
+            "b",
+            "c",
+        ]
+
+
+def _build_fanout_graph(checkpointer: DeferredCheckpointSaver, calls: list[str]) -> Any:
+    """Fan out to two nodes, one of which pauses on ``interrupt()``."""
+
+    def completes(state: _ConversationState) -> _ConversationState:
+        calls.append("completes")
+        return {"messages": ["completes"]}
+
+    def pauses(state: _ConversationState) -> _ConversationState:
+        answer = interrupt("need input")
+        return {"messages": [f"human:{answer}"]}
+
+    def join(state: _ConversationState) -> _ConversationState:
+        return {"messages": ["join"]}
+
+    builder = StateGraph(_ConversationState)
+    builder.add_node("completes", completes)
+    builder.add_node("pauses", pauses)
+    builder.add_node("join", join)
+    builder.add_edge(START, "completes")
+    builder.add_edge(START, "pauses")
+    builder.add_edge("completes", "join")
+    builder.add_edge("pauses", "join")
+    builder.add_edge("join", END)
+    return builder.compile(checkpointer=checkpointer)
+
+
+def _build_flaky_fanout_graph(
+    checkpointer: DeferredCheckpointSaver, calls: list[str], *, fail: bool
+) -> Any:
+    """Fan out to two nodes, one of which raises when *fail* is set."""
+
+    def healthy(state: _ConversationState) -> _ConversationState:
+        calls.append("healthy")
+        return {"messages": ["healthy"]}
+
+    def flaky(state: _ConversationState) -> _ConversationState:
+        calls.append("flaky")
+        if fail:
+            msg = "transient boom"
+            raise RuntimeError(msg)
+        return {"messages": ["flaky"]}
+
+    def join(state: _ConversationState) -> _ConversationState:
+        return {"messages": ["join"]}
+
+    builder = StateGraph(_ConversationState)
+    builder.add_node("healthy", healthy)
+    builder.add_node("flaky", flaky)
+    builder.add_node("join", join)
+    builder.add_edge(START, "healthy")
+    builder.add_edge(START, "flaky")
+    builder.add_edge("healthy", "join")
+    builder.add_edge("flaky", "join")
+    builder.add_edge("join", END)
+    return builder.compile(checkpointer=checkpointer)
+
+
+class TestFlushWritesDisabledResumeSemantics:
+    """Lock in what a partially completed superstep loses.
+
+    Per-task write records are the receipts LangGraph uses on resume to tell
+    which tasks of the current superstep already ran.  Dropping them makes
+    node execution at-least-once instead of once.  These tests pin that
+    documented trade-off from both sides so a refactor cannot change it
+    silently.
+    """
+
+    @pytest.mark.parametrize(
+        ("flush_writes", "expect_requeued", "expect_reruns"),
+        [(True, False, 1), (False, True, 2)],
+    )
+    def test_interrupted_superstep_requeues_completed_task(
+        self,
+        memory_saver: MemorySaver,
+        flush_writes: bool,
+        expect_requeued: bool,
+        expect_reruns: int,
+    ) -> None:
+        """A completed sibling of an interrupted task re-runs when writes drop."""
+        calls: list[str] = []
+        deferred = DeferredCheckpointSaver(memory_saver, flush_writes=flush_writes)
+        graph = _build_fanout_graph(deferred, calls)
+        config = _make_config(thread_id="interrupted-1")
+
+        with deferred.flush_on_exit():
+            graph.invoke({"messages": ["start"]}, config)
+
+        assert calls.count("completes") == 1
+
+        # What the backend still knows about the paused superstep.
+        state = graph.get_state(config)
+        assert "pauses" in state.next
+        assert ("completes" in state.next) is expect_requeued
+        # Without the write records the interrupt payload is gone, so a
+        # restarted process cannot tell what it asked the human.
+        assert bool(state.interrupts) is not expect_requeued
+
+        # Resuming succeeds either way — but re-runs the completed sibling.
+        resumed = DeferredCheckpointSaver(memory_saver, flush_writes=flush_writes)
+        graph = _build_fanout_graph(resumed, calls)
+        with resumed.flush_on_exit():
+            result = graph.invoke(Command(resume="yes"), config)
+
+        assert calls.count("completes") == expect_reruns
+        assert result["messages"].count("human:yes") == 1
+
+    @pytest.mark.parametrize(
+        ("flush_writes", "expect_reruns"),
+        [(True, 1), (False, 2)],
+    )
+    def test_failed_superstep_reruns_completed_task_on_retry(
+        self,
+        memory_saver: MemorySaver,
+        flush_writes: bool,
+        expect_reruns: int,
+    ) -> None:
+        """Retrying after a node raises re-runs siblings that had succeeded.
+
+        ``flush_on_exit`` flushes from its ``finally`` block, so this is the
+        exception path it advertises — and the one most likely to repeat a
+        node's side effects under ``flush_writes=False``.
+        """
+        calls: list[str] = []
+        config = _make_config(thread_id="failed-1")
+
+        deferred = DeferredCheckpointSaver(memory_saver, flush_writes=flush_writes)
+        graph = _build_flaky_fanout_graph(deferred, calls, fail=True)
+        with pytest.raises(RuntimeError, match="transient boom"):
+            with deferred.flush_on_exit():
+                graph.invoke({"messages": ["start"]}, config)
+
+        assert calls.count("healthy") == 1
+
+        # Retry the same thread with a healthy graph, as a restart would.
+        retried = DeferredCheckpointSaver(memory_saver, flush_writes=flush_writes)
+        graph = _build_flaky_fanout_graph(retried, calls, fail=False)
+        with retried.flush_on_exit():
+            result = graph.invoke(None, config)
+
+        assert calls.count("flaky") == 2
+        assert calls.count("healthy") == expect_reruns
+        # Channel values still converge; only the execution count differs.
+        assert result["messages"].count("healthy") == 1


### PR DESCRIPTION
Closes #1015.

## Why

For savers without `SyncBatchFlushable`/`AsyncBatchFlushable` (DynamoDB, Valkey, bedrock_sessions), `flush()` still costs 1 + N sequential calls. `flush_writes=False` reduces that to a single `put()`.

The trade-off is sharper than the issue anticipated. The per-task write records aren't only debug metadata — they're the receipts LangGraph uses on resume to tell which tasks of the current superstep already ran. Dropping them makes node execution **at-least-once**: a run ending in an exception or `interrupt()` re-executes already-completed siblings on resume. Runs that reach the end are unaffected, since the final `put()` already has every output applied. Documented in a `!!! warning` on the class, with regression tests pinning both directions.

`AgentCoreMemorySaver` *does* implement the batch protocols, so `batch_writes=True` already reaches one API call per flush while keeping the receipts. Combining the two flags is therefore contradictory and raises `ValueError` naming the better option, instead of silently trading away durability.

## Please review carefully

- **`_flush_checkpoint_only` failure semantics** — writes are dropped before the network call, so there is nothing to restore; the checkpoint is restored only if no newer `put()` raced in. Same guard as the existing paths.
- **The `ValueError` is a judgment call.** It rejects a combination nobody can be passing yet (`flush_writes` is new), on the grounds that anyone setting both wanted speed and did not realize `batch_writes` alone suffices. A warning is the alternative.
- **Docstring scope.** The "one in-flight run per instance" note documents a pre-existing limitation (the single `_pending_checkpoint` slot), not something this change introduces. Enforcement is deliberately left out — it would touch the default path.

## Known limitations, not addressed here

- The single-slot buffer still means concurrent runs on a shared instance clobber each other. Fixing it means keying by `thread_id`/`checkpoint_ns`, which redefines `flush()`'s return value and `has_buffered_checkpoint` — its own change.
- `_last_config` is written and never read (pre-existing).
