### PR TITLE
test(aws): Update for Anthropic SDK v1

### DIFF
--- a/libs/aws/tests/unit_tests/chat_models/test_anthropic.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_anthropic.py
@@ -168,7 +168,10 @@ def test_chat_anthropic_bedrock_get_request_payload() -> None:
         [HumanMessage(content="Hello")],  # type: ignore[misc]
     )
     assert payload["model"] == BEDROCK_MODEL_NAME
-    assert payload["temperature"] == 0.7
+    temperature = payload.get(
+        "temperature", payload.get("extra_body", {}).get("temperature")
+    )
+    assert temperature == 0.7
     assert payload["max_tokens"] == 1000
     assert "messages" in payload
 

--- a/libs/aws/tests/unit_tests/chat_models/test_anthropic_mantle.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_anthropic_mantle.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any, Literal, Tuple, Type, cast
 from unittest.mock import patch
 
+import anthropic
 import pytest
 from langchain_core.language_models import BaseChatModel, ModelProfile
 from langchain_tests.unit_tests import ChatModelUnitTests
@@ -580,6 +581,10 @@ def test_auth_mode_api_key_with_explicit_profile() -> None:
         assert client.api_key == "api-key"
 
 
+@pytest.mark.skipif(
+    int(anthropic.__version__.partition(".")[0]) < 1,
+    reason="mock transport targets the httpx2 HTTP layer used by anthropic>=1",
+)
 @pytest.mark.parametrize(
     "auth_mode,expected_scheme",
     [("sigv4", "AWS4-HMAC-SHA256"), ("api_key", "Bearer")],
@@ -592,7 +597,7 @@ def test_auth_mode_authorization_scheme_on_the_wire(
     import asyncio
 
     import boto3.session
-    import httpx
+    import httpx2  # anthropic>=1 builds its HTTP layer on httpx2, not httpx
 
     creds_file = tmp_path / "credentials"
     creds_file.write_text(
@@ -621,12 +626,12 @@ def test_auth_mode_authorization_scheme_on_the_wire(
 
         captured: dict[str, str] = {}
 
-        def handler(request: httpx.Request) -> httpx.Response:
+        def handler(request: httpx2.Request) -> httpx2.Response:
             captured["auth"] = request.headers.get("Authorization", "")
-            return httpx.Response(500, json={"error": "captured"})
+            return httpx2.Response(500, json={"error": "captured"})
 
         client = model._client
-        client._client = httpx.Client(transport=httpx.MockTransport(handler))
+        client._client = httpx2.Client(transport=httpx2.MockTransport(handler))
         with pytest.raises(Exception):
             client.messages.create(
                 model=MODEL_NAME,
@@ -639,7 +644,9 @@ def test_auth_mode_authorization_scheme_on_the_wire(
 
         captured.clear()
         async_client = model._async_client
-        async_client._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        async_client._client = httpx2.AsyncClient(
+            transport=httpx2.MockTransport(handler)
+        )
 
         async def _call() -> None:
             await async_client.messages.create(


### PR DESCRIPTION
Updating the `ChatAnthropicBedrock` and `ChatAnthropicMantle` unit tests for the following changes in Anthropic's v1 major release of their Python SDK:
- Removal of the `temperature` param (fixed using `langchain-anthropic` v1.7.0's [compensatory routing](https://github.com/langchain-ai/langchain/pull/39938/changes#diff-7637ab57d9246ec29058238b1d75c93a54efa286df55923a6e8fb6a312396883R83) solution)
- Migration from `httpx` -> `httpx2`.