### PR TITLE
feat(aws): Add ChatOpenAIBedrock for bedrock-runtime OpenAI endpoint

### DIFF
--- a/libs/aws/langchain_aws/__init__.py
+++ b/libs/aws/langchain_aws/__init__.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
         ChatAnthropicBedrock,
         ChatAnthropicMantle,
         ChatBedrockNovaSonic,
+        ChatOpenAIBedrock,
         ChatOpenAIMantle,
     )
     from langchain_aws.document_compressors.rerank import BedrockRerank
@@ -94,6 +95,7 @@ __all__ = [
     "ChatBedrock",
     "ChatBedrockConverse",
     "ChatBedrockNovaSonic",
+    "ChatOpenAIBedrock",
     "ChatOpenAIMantle",
     "SagemakerEndpoint",
     "AmazonKendraRetriever",
@@ -136,6 +138,10 @@ def __getattr__(name: str) -> Any:
         "ChatBedrockNovaSonic": (
             "langchain_aws.chat_models",
             'pip install "langchain-aws[nova-sonic]"',
+        ),
+        "ChatOpenAIBedrock": (
+            "langchain_aws.chat_models",
+            'pip install "langchain-aws[openai]"',
         ),
         "ChatOpenAIMantle": (
             "langchain_aws.chat_models",

--- a/libs/aws/langchain_aws/chat_models/__init__.py
+++ b/libs/aws/langchain_aws/chat_models/__init__.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
         ChatAnthropicMantle,
     )
     from langchain_aws.chat_models.bedrock_nova_sonic import ChatBedrockNovaSonic
-    from langchain_aws.chat_models.openai import ChatOpenAIMantle
+    from langchain_aws.chat_models.openai import ChatOpenAIBedrock, ChatOpenAIMantle
 
 __all__ = [
     "ChatAnthropicBedrock",
@@ -17,6 +17,7 @@ __all__ = [
     "ChatBedrock",
     "ChatBedrockConverse",
     "ChatBedrockNovaSonic",
+    "ChatOpenAIBedrock",
     "ChatOpenAIMantle",
 ]
 
@@ -35,6 +36,10 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "ChatBedrockNovaSonic": (
         "langchain_aws.chat_models.bedrock_nova_sonic",
         'pip install "langchain-aws[nova-sonic]"',
+    ),
+    "ChatOpenAIBedrock": (
+        "langchain_aws.chat_models.openai",
+        'pip install "langchain-aws[openai]"',
     ),
     "ChatOpenAIMantle": (
         "langchain_aws.chat_models.openai",

--- a/libs/aws/langchain_aws/chat_models/anthropic.py
+++ b/libs/aws/langchain_aws/chat_models/anthropic.py
@@ -25,8 +25,9 @@ from langchain_aws.chat_models._anthropic_utils import _create_bedrock_client_pa
 from langchain_aws.data._profiles import _PROFILES
 from langchain_aws.utils import (
     _MANTLE_GUARDRAILS_ERR_MSG,
-    MODEL_ID_GEO_PREFIXES,
-    _check_no_mantle_guardrail_headers,
+    _reject_guardrail_config_values,
+    _reject_guardrail_request_kwargs,
+    _strip_cross_region_prefix,
 )
 
 _MODEL_PROFILES = cast("ModelProfileRegistry", _PROFILES)
@@ -36,9 +37,7 @@ def _get_default_model_profile(model_name: str) -> ModelProfile:
     """Look up the default profile for a model ID."""
     default = _MODEL_PROFILES.get(model_name)
     if default is None:
-        prefix, _, rest = model_name.partition(".")
-        if rest and prefix.lower() in MODEL_ID_GEO_PREFIXES:
-            default = _MODEL_PROFILES.get(rest)
+        default = _MODEL_PROFILES.get(_strip_cross_region_prefix(model_name))
     return (default or {}).copy()
 
 
@@ -506,14 +505,7 @@ class ChatAnthropicMantle(ChatAnthropic):
     @model_validator(mode="before")
     @classmethod
     def _reject_guardrails(cls, values: Any) -> Any:
-        # TODO: remove after Mantle adds guardrails support
-        if isinstance(values, dict):
-            if any(
-                values.get(key) is not None
-                for key in ("guardrail_config", "guardrails")
-            ):
-                raise ValueError(_MANTLE_GUARDRAILS_ERR_MSG)
-            _check_no_mantle_guardrail_headers(values.get("default_headers"))
+        _reject_guardrail_config_values(values, _MANTLE_GUARDRAILS_ERR_MSG)
         return values
 
     def _get_request_payload(
@@ -523,10 +515,7 @@ class ChatAnthropicMantle(ChatAnthropic):
         stop: list[str] | None = None,
         **kwargs: Any,
     ) -> dict:
-        # TODO: remove after Mantle adds guardrails support
-        if kwargs.get("guardrail_config") is not None:
-            raise ValueError(_MANTLE_GUARDRAILS_ERR_MSG)
-        _check_no_mantle_guardrail_headers(kwargs.get("extra_headers"))
+        _reject_guardrail_request_kwargs(kwargs, _MANTLE_GUARDRAILS_ERR_MSG)
         return super()._get_request_payload(input_, stop=stop, **kwargs)
 
     @model_validator(mode="after")

--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -77,6 +77,7 @@ from langchain_aws.data._profiles import _PROFILES
 from langchain_aws.function_calling import ToolsOutputParser
 from langchain_aws.tools.nova_tools import NovaSystemTool
 from langchain_aws.utils import (
+    _strip_cross_region_prefix,
     count_tokens_api_supported_for_model,
     create_aws_client,
     parse_model_provider,
@@ -1229,13 +1230,8 @@ class ChatBedrockConverse(BaseChatModel):
             return self.base_model_id
 
         # For regional model IDs (e.g., us.anthropic.claude-haiku-4-5-20251001-v1:0),
-        # get the base model ID by removing the regional prefix
-        if self.model_id.startswith(
-            ("eu.", "us.", "us-gov.", "apac.", "sa.", "amer.", "global.", "jp.", "au.")
-        ):
-            return self.model_id.partition(".")[2]
-
-        return self.model_id
+        # get the base model ID by removing the cross-Region inference prefix.
+        return _strip_cross_region_prefix(self.model_id)
 
     def _inline_reasoning_tags_for_model(self) -> Optional[Tuple[str, str]]:
         """Inline-reasoning ``(open_tag, close_tag)`` for this model, or ``None``."""

--- a/libs/aws/langchain_aws/chat_models/openai.py
+++ b/libs/aws/langchain_aws/chat_models/openai.py
@@ -1,16 +1,25 @@
-"""OpenAI-compatible chat model for the Amazon Bedrock Mantle endpoint.
+"""OpenAI-compatible chat models for Amazon Bedrock endpoints.
 
 Amazon Bedrock exposes OpenAI-compatible Chat Completions and Responses APIs on
-the ``bedrock-mantle`` endpoint (``bedrock-mantle.{region}.api.aws``). Because the
-wire format matches OpenAI, this integration is a thin subclass of
-``BaseChatOpenAI`` (mirroring the ``AzureChatOpenAI`` pattern) that only resolves
-the Bedrock Mantle base URL and authentication; all chat behaviour (tool calling,
-structured output, streaming, tracing, multimodal) is inherited unchanged.
+two endpoints:
+
+* ``bedrock-mantle`` (``bedrock-mantle.{region}.api.aws``) — served by
+  :class:`ChatOpenAIMantle`, which defaults to the ``/v1`` route. Mantle also
+  serves some models under ``/openai/v1``; override ``base_url`` for those.
+* ``bedrock-runtime`` (``bedrock-runtime.{region}.amazonaws.com/openai/v1``) —
+  served by :class:`ChatOpenAIBedrock`.
+
+Because the wire format matches OpenAI, both integrations are thin subclasses of
+``BaseChatOpenAI`` (mirroring the ``AzureChatOpenAI`` pattern) that only resolve
+the endpoint base URL and authentication; all chat behavior (tool calling,
+structured output, streaming, tracing, multimodal) is inherited unchanged. The
+shared logic lives in :class:`_BaseChatBedrockOpenAI`; each public class only
+sets a handful of endpoint-specific class attributes.
 """
 
 import os
 from collections.abc import AsyncIterator, Iterator
-from typing import Any, Literal, cast
+from typing import Any, ClassVar, Literal, cast
 
 from langchain_core.language_models import (
     LanguageModelInput,
@@ -35,18 +44,40 @@ from langchain_aws.utils import (
     _BEDROCK_API_KEY_MAX_TTL_SECONDS,
     _MANTLE_GUARDRAILS_ERR_MSG,
     _BedrockApiKeyProvider,
-    _check_no_mantle_guardrail_headers,
+    _reject_guardrail_config_values,
+    _reject_guardrail_request_kwargs,
+    _strip_cross_region_prefix,
 )
 
 _MANTLE_BASE_URL_TEMPLATE = "https://bedrock-mantle.{region}.api.aws/v1"
+_BEDROCK_RUNTIME_BASE_URL_TEMPLATE = (
+    "https://bedrock-runtime.{region}.amazonaws.com/openai/v1"
+)
+
+# Guardrails are not accepted by the OpenAI models currently served on the
+# bedrock-runtime OpenAI-compatible endpoint; used only by ChatOpenAIBedrock.
+_BEDROCK_RUNTIME_OAI_GUARDRAILS_ERR_MSG = (
+    "Amazon Bedrock Guardrails are not supported by the current OpenAI models "
+    "on the bedrock-runtime OpenAI-compatible endpoint. Please use "
+    "``ChatAnthropicBedrock`` or ``ChatBedrockConverse`` instead, which support "
+    "guardrails via the bedrock-runtime endpoint."
+)
 
 _MODEL_PROFILES = cast("ModelProfileRegistry", _PROFILES)
 
 
 def _get_default_model_profile(model_name: str) -> ModelProfile:
-    """Return the static capability profile for a Mantle model, or an empty one."""
-    default = _MODEL_PROFILES.get(model_name) or {}
-    return default.copy()
+    """Return the static capability profile for a model, or an empty one.
+
+    Tries the exact model id first (so an explicitly-registered profile such as
+    ``global.openai.gpt-5.6-sol`` is used verbatim), then retries with any
+    geographic/global prefix stripped (so ``us.openai.gpt-5.6-sol`` inherits the
+    base ``openai.gpt-5.6-sol`` profile).
+    """
+    default = _MODEL_PROFILES.get(model_name)
+    if default is None:
+        default = _MODEL_PROFILES.get(_strip_cross_region_prefix(model_name))
+    return (default or {}).copy()
 
 
 def _plain_secret(value: Any) -> str | None:
@@ -58,60 +89,41 @@ def _plain_secret(value: Any) -> str | None:
     return str(value)
 
 
-class ChatOpenAIMantle(BaseChatOpenAI):
-    """OpenAI-compatible GPT/open-weight models via the Amazon Bedrock Mantle endpoint.
+class _BaseChatBedrockOpenAI(BaseChatOpenAI):
+    """Shared implementation for Bedrock OpenAI-compatible chat models.
 
-    Talks to the ``bedrock-mantle`` OpenAI-compatible endpoint
-    (``bedrock-mantle.{region}.api.aws``) using the OpenAI Python SDK.
-    Authentication uses an Amazon Bedrock API key (bearer token) rather than
-    AWS SigV4. Provide it directly (``bedrock_api_key`` /
-    ``AWS_BEARER_TOKEN_BEDROCK``), or omit it and let short-term keys be derived
-    from your AWS credentials and refreshed transparently.
-
-    See the [LangChain docs for `ChatOpenAI`](https://docs.langchain.com/oss/python/integrations/chat/openai)
-    for tutorials and feature walkthroughs — the same features apply here.
-
-    Example (static bearer token):
-        ```python
-        # pip install "langchain-aws[openai]"
-        # export AWS_BEARER_TOKEN_BEDROCK="your-bedrock-api-key"
-        # export AWS_REGION="us-east-1"
-
-        from langchain_aws import ChatOpenAIMantle
-
-        model = ChatOpenAIMantle(
-            model="openai.gpt-oss-120b",
-            region_name="us-east-1",
-        )
-        model.invoke("What is 2 + 2?")
-        ```
-
-    Example (derive short-term keys from AWS credentials):
-        ```python
-        # pip install "langchain-aws[openai]"
-        # Uses the standard boto3 credential chain (env, profile, role, IRSA).
-
-        from langchain_aws import ChatOpenAIMantle
-
-        model = ChatOpenAIMantle(
-            model="openai.gpt-oss-120b",
-            region_name="us-east-1",
-            # optionally: credentials_profile_name="my-profile"
-        )
-        model.invoke("What is 2 + 2?")
-        ```
-
-    Note:
-        This targets the ``bedrock-mantle`` endpoint, which serves only the
-        OpenAI-compatible model catalog (a different, non-superset set of models
-        from ``bedrock-runtime``). For Anthropic Claude on Bedrock, use
-        ``ChatAnthropicBedrock``.
+    Not intended for direct use. Concrete subclasses set the endpoint-specific
+    class attributes below (``_base_url_template``, ``_endpoint_label``,
+    ``_ls_provider_name``, ``_lc_namespace``, ``_llm_type_name``,
+    ``_guardrails_err_msg``); everything else — region/base-URL resolution,
+    Bedrock API-key auth (static bearer token or short-term keys derived from
+    AWS credentials), guardrail rejection, profile resolution, tracing, and the
+    Chat Completions/Responses routing — is shared here.
     """
+
+    # --- Endpoint-specific configuration (set by subclasses) ---------------
+    _base_url_template: ClassVar[str]
+    """``str.format(region=...)`` template for the default endpoint base URL."""
+
+    _endpoint_label: ClassVar[str]
+    """Human-readable endpoint name used in error messages."""
+
+    _ls_provider_name: ClassVar[str]
+    """Value reported as ``ls_provider`` in tracing metadata."""
+
+    _lc_namespace: ClassVar[list[str]]
+    """LangChain serialization namespace for this class."""
+
+    _llm_type_name: ClassVar[str]
+    """Value returned by ``_llm_type``."""
+
+    _guardrails_err_msg: ClassVar[str]
+    """Error raised when guardrails are configured on an unsupported endpoint."""
 
     model_config = ConfigDict(populate_by_name=True)
 
     region_name: str | None = None
-    """AWS region for the Bedrock Mantle endpoint, e.g. ``us-east-1``.
+    """AWS region for the Bedrock endpoint, e.g. ``us-east-1``.
 
     Falls back to the ``AWS_REGION`` or ``AWS_DEFAULT_REGION`` environment
     variable when not provided. Used to build the default ``base_url``.
@@ -120,7 +132,7 @@ class ChatOpenAIMantle(BaseChatOpenAI):
     bedrock_api_key: SecretStr | None = Field(
         default_factory=secret_from_env("AWS_BEARER_TOKEN_BEDROCK", default=None)
     )
-    """Amazon Bedrock API key (bearer token) used to authenticate to Mantle.
+    """Amazon Bedrock API key (bearer token) used to authenticate.
 
     If not provided, read from the ``AWS_BEARER_TOKEN_BEDROCK`` environment
     variable. Sent as the OpenAI ``api_key``.
@@ -167,17 +179,27 @@ class ChatOpenAIMantle(BaseChatOpenAI):
     lifetime for refreshable credentials (AssumeRole, SSO, IRSA, ...).
     """
 
+    @classmethod
+    def _ensure_concrete(cls) -> None:
+        """Guard against instantiating the abstract base directly.
+
+        The endpoint-specific ``ClassVar``s are only set on concrete subclasses,
+        so constructing ``_BaseChatBedrockOpenAI`` itself would otherwise fail
+        with an opaque ``AttributeError`` deep inside a validator.
+        """
+        if cls is _BaseChatBedrockOpenAI:
+            msg = (
+                "_BaseChatBedrockOpenAI is an internal base class and cannot be "
+                "instantiated directly. Use ChatOpenAIMantle (bedrock-mantle) or "
+                "ChatOpenAIBedrock (bedrock-runtime)."
+            )
+            raise TypeError(msg)
+
     @model_validator(mode="before")
     @classmethod
     def _reject_guardrails(cls, values: Any) -> Any:
-        # TODO: remove after Mantle adds guardrails support
-        if isinstance(values, dict):
-            if any(
-                values.get(key) is not None
-                for key in ("guardrail_config", "guardrails")
-            ):
-                raise ValueError(_MANTLE_GUARDRAILS_ERR_MSG)
-            _check_no_mantle_guardrail_headers(values.get("default_headers"))
+        cls._ensure_concrete()
+        _reject_guardrail_config_values(values, cls._guardrails_err_msg)
         return values
 
     def _get_request_payload(
@@ -187,21 +209,19 @@ class ChatOpenAIMantle(BaseChatOpenAI):
         stop: list[str] | None = None,
         **kwargs: Any,
     ) -> dict:
-        # TODO: remove after Mantle adds guardrails support
-        if kwargs.get("guardrail_config") is not None:
-            raise ValueError(_MANTLE_GUARDRAILS_ERR_MSG)
-        _check_no_mantle_guardrail_headers(kwargs.get("extra_headers"))
+        _reject_guardrail_request_kwargs(kwargs, self._guardrails_err_msg)
         return super()._get_request_payload(input_, stop=stop, **kwargs)
 
     @model_validator(mode="before")
     @classmethod
-    def _set_mantle_defaults(cls, values: Any) -> Any:
-        """Resolve the Mantle base URL and bearer key before the client is built.
+    def _set_endpoint_defaults(cls, values: Any) -> Any:
+        """Resolve the endpoint base URL and bearer key before the client is built.
 
         Runs before ``BaseChatOpenAI``'s client-construction validator so the
-        OpenAI client is created pointing at the Bedrock Mantle endpoint with the
+        OpenAI client is created pointing at the Bedrock endpoint with the
         Bedrock API key.
         """
+        cls._ensure_concrete()
         if not isinstance(values, dict):
             return values
 
@@ -211,7 +231,7 @@ class ChatOpenAIMantle(BaseChatOpenAI):
             or os.getenv("AWS_DEFAULT_REGION")
         )
 
-        # Default the base URL to the region's Mantle endpoint unless the caller
+        # Default the base URL to the region's endpoint unless the caller
         # supplied one explicitly (either alias form). If no base URL is given and
         # no region can be resolved, fail here rather than let ``BaseChatOpenAI``
         # fall back to the default OpenAI host — otherwise the Bedrock bearer token
@@ -222,14 +242,15 @@ class ChatOpenAIMantle(BaseChatOpenAI):
         if not has_explicit_base_url:
             if not region:
                 msg = (
-                    "ChatOpenAIMantle could not resolve an AWS region for the "
-                    "Bedrock Mantle endpoint. Set `region_name`, the `AWS_REGION` "
-                    "or `AWS_DEFAULT_REGION` environment variable, or pass an "
-                    "explicit `base_url`. Refusing to default to the OpenAI host "
-                    "so the Bedrock API key is never sent to api.openai.com."
+                    f"{cls.__name__} could not resolve an AWS region for the "
+                    f"{cls._endpoint_label} endpoint. Set `region_name`, the "
+                    "`AWS_REGION` or `AWS_DEFAULT_REGION` environment variable, "
+                    "or pass an explicit `base_url`. Refusing to default to the "
+                    "OpenAI host so the Bedrock API key is never sent to "
+                    "api.openai.com."
                 )
                 raise ValueError(msg)
-            values["base_url"] = _MANTLE_BASE_URL_TEMPLATE.format(region=region)
+            values["base_url"] = cls._base_url_template.format(region=region)
 
         # Route the Bedrock API key into the OpenAI ``api_key`` slot unless the
         # caller already set one explicitly. Precedence:
@@ -280,7 +301,7 @@ class ChatOpenAIMantle(BaseChatOpenAI):
     @property
     def _llm_type(self) -> str:
         """Return type of chat model."""
-        return "openai-mantle-chat"
+        return self._llm_type_name
 
     @property
     def lc_secrets(self) -> dict[str, str]:
@@ -290,14 +311,14 @@ class ChatOpenAIMantle(BaseChatOpenAI):
     @classmethod
     def get_lc_namespace(cls) -> list[str]:
         """Get the namespace of the LangChain object."""
-        return ["langchain", "chat_models", "openai_mantle"]
+        return list(cls._lc_namespace)
 
     def _get_ls_params(
         self, stop: list[str] | None = None, **kwargs: Any
     ) -> LangSmithParams:
         """Get standard params for tracing."""
         params = super()._get_ls_params(stop=stop, **kwargs)
-        params["ls_provider"] = "openai-mantle"
+        params["ls_provider"] = self._ls_provider_name
         return params
 
     def _stream(self, *args: Any, **kwargs: Any) -> Iterator[ChatGenerationChunk]:
@@ -340,3 +361,132 @@ class ChatOpenAIMantle(BaseChatOpenAI):
             tools=tools,
             **kwargs,
         )
+
+
+class ChatOpenAIMantle(_BaseChatBedrockOpenAI):
+    """OpenAI-compatible GPT/open-weight models via the Amazon Bedrock Mantle endpoint.
+
+    Talks to the ``bedrock-mantle`` OpenAI-compatible endpoint
+    (``bedrock-mantle.{region}.api.aws``) using the OpenAI Python SDK.
+    Authentication uses an Amazon Bedrock API key (bearer token) rather than
+    AWS SigV4. Provide it directly (``bedrock_api_key`` /
+    ``AWS_BEARER_TOKEN_BEDROCK``), or omit it and let short-term keys be derived
+    from your AWS credentials and refreshed transparently.
+
+    See the [LangChain docs for `ChatOpenAI`](https://docs.langchain.com/oss/python/integrations/chat/openai)
+    for tutorials and feature walkthroughs — the same features apply here.
+
+    Example (static bearer token):
+        ```python
+        # pip install "langchain-aws[openai]"
+        # export AWS_BEARER_TOKEN_BEDROCK="your-bedrock-api-key"
+        # export AWS_REGION="us-east-1"
+
+        from langchain_aws import ChatOpenAIMantle
+
+        model = ChatOpenAIMantle(
+            model="openai.gpt-oss-120b",
+            region_name="us-east-1",
+        )
+        model.invoke("What is 2 + 2?")
+        ```
+
+    Example (derive short-term keys from AWS credentials):
+        ```python
+        # pip install "langchain-aws[openai]"
+        # Uses the standard boto3 credential chain (env, profile, role, IRSA).
+
+        from langchain_aws import ChatOpenAIMantle
+
+        model = ChatOpenAIMantle(
+            model="openai.gpt-oss-120b",
+            region_name="us-east-1",
+            # optionally: credentials_profile_name="my-profile"
+        )
+        model.invoke("What is 2 + 2?")
+        ```
+
+    Note:
+        This targets the ``bedrock-mantle`` endpoint, which serves only the
+        OpenAI-compatible model catalog (a different, non-superset set of models
+        from ``bedrock-runtime``). For the ``bedrock-runtime`` OpenAI-compatible
+        endpoint (e.g. GPT-5.x via cross-Region inference profiles), use
+        ``ChatOpenAIBedrock``. For Anthropic Claude on Bedrock, use
+        ``ChatAnthropicBedrock``.
+
+        The default ``base_url`` uses Mantle's ``/v1`` route (used by
+        open-weight models such as gpt-oss). Some Mantle models are served
+        under ``/openai/v1`` instead; pass an explicit ``base_url`` for those.
+
+        As on ``bedrock-runtime``, tool calling with the GPT-5.x reasoning
+        models is rejected on the Chat Completions path while reasoning is
+        active; use ``use_responses_api=True`` or ``reasoning_effort="none"``
+        to bind tools. Open-weight models such as gpt-oss are unaffected.
+    """
+
+    _base_url_template = _MANTLE_BASE_URL_TEMPLATE
+    _endpoint_label = "Bedrock Mantle"
+    _ls_provider_name = "openai-mantle"
+    _lc_namespace = ["langchain", "chat_models", "openai_mantle"]
+    _llm_type_name = "openai-mantle-chat"
+    _guardrails_err_msg = _MANTLE_GUARDRAILS_ERR_MSG
+
+
+class ChatOpenAIBedrock(_BaseChatBedrockOpenAI):
+    """OpenAI-compatible models via the Amazon Bedrock ``bedrock-runtime`` endpoint.
+
+    Talks to the ``bedrock-runtime`` OpenAI-compatible endpoint
+    (``bedrock-runtime.{region}.amazonaws.com/openai/v1``) using the OpenAI
+    Python SDK. This is the recommended endpoint for OpenAI models (e.g. the
+    GPT-5.x family) on Amazon Bedrock, and it supports both the Chat Completions
+    and Responses APIs plus cross-Region inference.
+
+    Authentication uses an Amazon Bedrock API key (bearer token). Provide it
+    directly (``bedrock_api_key`` / ``AWS_BEARER_TOKEN_BEDROCK``), or omit it and
+    let short-term keys be derived from your AWS credentials and refreshed
+    transparently.
+
+    See the [LangChain docs for `ChatOpenAI`](https://docs.langchain.com/oss/python/integrations/chat/openai)
+    for tutorials and feature walkthroughs — the same features apply here.
+
+    Example:
+        ```python
+        # pip install "langchain-aws[openai]"
+        # export AWS_REGION="us-west-2"
+
+        from langchain_aws import ChatOpenAIBedrock
+
+        # bedrock-runtime requires a cross-Region inference profile id
+        # (e.g. "us." or "global." prefix), not a bare model id.
+        model = ChatOpenAIBedrock(
+            model="us.openai.gpt-5.6-sol",
+            region_name="us-west-2",
+        )
+        model.invoke("What is 2 + 2?")
+        ```
+
+    Note:
+        Cross-Region inference is selected purely via the ``model`` id — use a
+        geographic (``us.``, ``eu.``, ...) or ``global.`` inference-profile id.
+        Bare foundation-model ids are rejected by this endpoint. For the
+        ``bedrock-mantle`` endpoint (open-weight catalog, server-side tools) use
+        ``ChatOpenAIMantle``. For Anthropic Claude on Bedrock, use
+        ``ChatAnthropicBedrock``.
+
+        Amazon Bedrock Guardrails are not currently accepted by the OpenAI models
+        on this endpoint; configuring them raises an error. Use
+        ``ChatAnthropicBedrock`` or ``ChatBedrockConverse`` for guardrails.
+
+        Tool calling with the GPT-5.x reasoning models is rejected on the Chat
+        Completions path when reasoning is active. To bind tools (e.g. in a
+        LangGraph agent), either use the Responses API
+        (``ChatOpenAIBedrock(..., use_responses_api=True)``) or set
+        ``reasoning_effort="none"``.
+    """
+
+    _base_url_template = _BEDROCK_RUNTIME_BASE_URL_TEMPLATE
+    _endpoint_label = "Bedrock Runtime"
+    _ls_provider_name = "openai-bedrock"
+    _lc_namespace = ["langchain", "chat_models", "openai_bedrock"]
+    _llm_type_name = "openai-bedrock-chat"
+    _guardrails_err_msg = _BEDROCK_RUNTIME_OAI_GUARDRAILS_ERR_MSG

--- a/libs/aws/langchain_aws/utils.py
+++ b/libs/aws/langchain_aws/utils.py
@@ -557,6 +557,21 @@ def trim_message_whitespace(messages: List[Any]) -> List[Any]:
     return messages
 
 
+def _strip_cross_region_prefix(model_id: str) -> str:
+    """Return the base model id with any cross-Region prefix removed.
+
+    Regional/global inference-profile ids (e.g. ``us.anthropic.claude-...`` or
+    ``global.openai.gpt-5.6-sol``) embed the base model id after a
+    geographic/global prefix; ids without a recognized prefix are returned
+    unchanged. Uses the same ``MODEL_ID_GEO_PREFIXES`` set as
+    ``parse_model_provider``.
+    """
+    prefix, _, rest = model_id.partition(".")
+    if rest and prefix.lower() in MODEL_ID_GEO_PREFIXES:
+        return rest
+    return model_id
+
+
 _MANTLE_GUARDRAILS_ERR_MSG = (
     "Amazon Bedrock Guardrails are not supported on the bedrock-mantle "
     "endpoint. Please use ``ChatAnthropicBedrock`` or ``ChatBedrockConverse`` "
@@ -564,14 +579,50 @@ _MANTLE_GUARDRAILS_ERR_MSG = (
 )
 
 
-def _check_no_mantle_guardrail_headers(headers: Optional[Dict[str, Any]]) -> None:
-    """Reject Bedrock guardrail headers, which Mantle silently ignores."""
-    # TODO: remove after Mantle adds guardrails support
+def _check_no_guardrail_headers(
+    headers: Optional[Dict[str, Any]], err_msg: str
+) -> None:
+    """Raise ``err_msg`` if any ``X-Amzn-Bedrock-Guardrail*`` header is present.
+
+    Used by endpoints that silently ignore guardrail headers, so a
+    misconfiguration fails loudly instead of passing content unguarded.
+    """
     if not headers:
         return
     for key in headers:
         if key.lower().startswith("x-amzn-bedrock-guardrail"):
-            raise ValueError(_MANTLE_GUARDRAILS_ERR_MSG)
+            raise ValueError(err_msg)
+
+
+def _reject_guardrail_config_values(values: Any, err_msg: str) -> None:
+    """Raise ``err_msg`` if guardrails are configured at construction time.
+
+    Checks the ``guardrail_config`` / ``guardrails`` fields and any guardrail
+    request headers in ``default_headers``. Shared by the chat models whose
+    endpoint does not honor Bedrock Guardrails on its OpenAI/Anthropic-
+    compatible path (bedrock-mantle, and OpenAI models on bedrock-runtime), so
+    a misconfiguration fails loudly instead of silently passing content
+    unguarded.
+    """
+    # TODO: remove for an endpoint once it supports guardrails on this path.
+    if not isinstance(values, dict):
+        return
+    if any(values.get(key) is not None for key in ("guardrail_config", "guardrails")):
+        raise ValueError(err_msg)
+    _check_no_guardrail_headers(values.get("default_headers"), err_msg)
+
+
+def _reject_guardrail_request_kwargs(kwargs: Dict[str, Any], err_msg: str) -> None:
+    """Raise ``err_msg`` if guardrails are set on a per-request invocation.
+
+    The per-request counterpart to ``_reject_guardrail_config_values``: checks
+    the per-request ``guardrail_config`` kwarg and any guardrail request headers
+    in ``extra_headers``.
+    """
+    # TODO: remove for an endpoint once it supports guardrails on this path.
+    if kwargs.get("guardrail_config") is not None:
+        raise ValueError(err_msg)
+    _check_no_guardrail_headers(kwargs.get("extra_headers"), err_msg)
 
 
 class _StaticCredentialProvider:
@@ -609,8 +660,8 @@ class _BedrockApiKeyProvider:
     for use with async clients.
 
     This is the shared building block behind bearer-token authentication for
-    the Bedrock Mantle chat models (``ChatOpenAIMantle`` /
-    ``ChatAnthropicMantle``): rather than requiring a manually-minted static
+    the Bedrock OpenAI-compatible chat models (``ChatOpenAIMantle`` /
+    ``ChatOpenAIBedrock``): rather than requiring a manually-minted static
     ``AWS_BEARER_TOKEN_BEDROCK``, it derives short-term keys from ordinary AWS
     credentials (explicit keys, a named profile, or the default chain) and
     transparently refreshes them.

--- a/libs/aws/tests/integration_tests/chat_models/test_openai_bedrock.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_openai_bedrock.py
@@ -1,0 +1,143 @@
+"""Standard LangChain integration tests for ChatOpenAIBedrock.
+
+These hit the live Amazon Bedrock ``bedrock-runtime`` OpenAI-compatible endpoint
+and are skipped by default. Two independent live checks are provided:
+
+1. ``TestOpenAIBedrockIntegration`` — the standard suite, run with a static
+   Bedrock API key::
+
+       AWS_REGION=us-west-2 AWS_BEARER_TOKEN_BEDROCK=... \\
+           uv run --group test --group test_integration \\
+           pytest tests/integration_tests/chat_models/test_openai_bedrock.py -v
+
+2. ``test_credential_derived_auth_live`` — the credential-derived path, which
+   mints and refreshes a short-term key from ordinary AWS credentials (no static
+   token needed). Run with an opt-in flag plus any AWS credentials for an
+   account with access to the OpenAI models on bedrock-runtime::
+
+       BEDROCK_OAI_CREDS_E2E=1 AWS_REGION=us-west-2 \\
+           uv run --group test --group test_integration \\
+           pytest tests/integration_tests/chat_models/test_openai_bedrock.py \\
+           -k credential_derived -v
+"""
+
+import os
+from typing import Type
+
+import pytest
+from langchain_core.language_models import BaseChatModel
+from langchain_tests.integration_tests import ChatModelIntegrationTests
+
+from langchain_aws import ChatOpenAIBedrock
+from langchain_aws.utils import _BedrockApiKeyProvider
+
+# Static-key path: skip until a Bedrock API key is available.
+requires_static_key = pytest.mark.skipif(
+    not os.getenv("AWS_BEARER_TOKEN_BEDROCK"),
+    reason=(
+        "Requires a Bedrock API key in AWS_BEARER_TOKEN_BEDROCK for an account "
+        "with access to OpenAI models on the bedrock-runtime endpoint."
+    ),
+)
+
+# Credential-derived path: opt-in via a simple flag. Needs only ambient AWS
+# credentials + region for a bedrock-runtime OpenAI-enabled account.
+requires_aws_creds = pytest.mark.skipif(
+    not os.getenv("BEDROCK_OAI_CREDS_E2E"),
+    reason=(
+        "Set BEDROCK_OAI_CREDS_E2E=1 (with AWS credentials + region for an "
+        "account with OpenAI models on bedrock-runtime) to run the "
+        "credential-derived auth check."
+    ),
+)
+
+# bedrock-runtime requires a cross-Region inference-profile id (e.g. "us."),
+# not a bare foundation-model id.
+MODEL_NAME = os.getenv("BEDROCK_OAI_MODEL", "us.openai.gpt-5.6-sol")
+
+
+@requires_static_key
+class TestOpenAIBedrockIntegration(ChatModelIntegrationTests):
+    @property
+    def chat_model_class(self) -> Type[BaseChatModel]:
+        return ChatOpenAIBedrock
+
+    @property
+    def chat_model_params(self) -> dict:
+        # Use the Responses API: GPT-5.x reasoning models reject function tools
+        # on the Chat Completions path while reasoning is active (they require
+        # /v1/responses or reasoning_effort="none"), so the standard tool and
+        # structured-output tests need the Responses path.
+        return {
+            "model": MODEL_NAME,
+            "region_name": os.getenv("AWS_REGION", "us-west-2"),
+            "use_responses_api": True,
+            "stream_usage": True,
+        }
+
+    @property
+    def standard_chat_model_params(self) -> dict:
+        # GPT-5.x on bedrock-runtime rejects ``max_tokens`` and requires
+        # ``max_completion_tokens`` (handled by BaseChatOpenAI), and only
+        # supports the default temperature.
+        return {"max_tokens": 1000}
+
+    @property
+    def has_tool_calling(self) -> bool:
+        return True
+
+    @property
+    def has_structured_output(self) -> bool:
+        return True
+
+
+@requires_aws_creds
+def test_credential_derived_auth_live() -> None:
+    """End-to-end: derive a short-term Bedrock key from AWS creds and invoke.
+
+    With no static ``AWS_BEARER_TOKEN_BEDROCK``, ``ChatOpenAIBedrock`` installs a
+    ``_BedrockApiKeyProvider`` that mints (and transparently refreshes) a
+    short-term Bedrock API key from the ambient AWS credential chain (env,
+    profile, assumed role, IRSA).
+    """
+    assert not os.getenv("AWS_BEARER_TOKEN_BEDROCK"), (
+        "Unset AWS_BEARER_TOKEN_BEDROCK to exercise the credential-derived path."
+    )
+
+    model = ChatOpenAIBedrock(
+        model=MODEL_NAME,
+        region_name=os.getenv("AWS_REGION", "us-west-2"),
+    )
+
+    provider = model.openai_api_key
+    assert isinstance(provider, _BedrockApiKeyProvider)
+    token = provider()
+    assert isinstance(token, str) and token
+
+    response = model.invoke("What is 2 + 2? Reply with just the number.")
+    assert isinstance(response.content, str)
+    assert "4" in response.content
+
+
+@requires_aws_creds
+def test_cross_region_global_profile_live() -> None:
+    """A global cross-Region inference profile works via the model id alone."""
+    model = ChatOpenAIBedrock(
+        model=os.getenv("BEDROCK_OAI_GLOBAL_MODEL", "global.openai.gpt-5.6-sol"),
+        region_name=os.getenv("AWS_REGION", "us-west-2"),
+    )
+    response = model.invoke("What is 2 + 2? Reply with just the number.")
+    assert isinstance(response.content, str)
+    assert "4" in response.content
+
+
+@requires_aws_creds
+def test_responses_api_live() -> None:
+    """The Responses API path works on bedrock-runtime."""
+    model = ChatOpenAIBedrock(
+        model=MODEL_NAME,
+        region_name=os.getenv("AWS_REGION", "us-west-2"),
+        use_responses_api=True,
+    )
+    response = model.invoke("Say OK.")
+    assert isinstance(response.content, str) or isinstance(response.content, list)

--- a/libs/aws/tests/unit_tests/chat_models/test_openai_bedrock.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_openai_bedrock.py
@@ -1,0 +1,465 @@
+"""ChatOpenAIBedrock unit tests (bedrock-runtime OpenAI-compatible endpoint)."""
+
+from collections.abc import AsyncIterator
+from typing import Tuple, Type, cast
+from unittest.mock import patch
+
+import pytest
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import HumanMessage
+from langchain_openai.chat_models.base import BaseChatOpenAI
+from langchain_tests.unit_tests import ChatModelUnitTests
+from pydantic import BaseModel, SecretStr
+from pytest import MonkeyPatch
+
+from langchain_aws import ChatOpenAIBedrock
+from langchain_aws.utils import _BedrockApiKeyProvider
+
+# bedrock-runtime requires a cross-Region inference-profile id, not a bare id.
+MODEL_NAME = "us.openai.gpt-5.6-sol"
+RUNTIME_BASE_URL = "https://bedrock-runtime.us-west-2.amazonaws.com/openai/v1"
+
+
+class TestOpenAIBedrockStandard(ChatModelUnitTests):
+    @property
+    def chat_model_class(self) -> Type[BaseChatModel]:
+        return ChatOpenAIBedrock
+
+    @property
+    def chat_model_params(self) -> dict:
+        return {
+            "model": MODEL_NAME,
+            "region_name": "us-west-2",
+            "bedrock_api_key": "test-bedrock-key",
+        }
+
+    @property
+    def init_from_env_params(self) -> Tuple[dict, dict, dict]:
+        """Env vars, init args, and expected attrs for env-based initialization."""
+        return (
+            {
+                "AWS_BEARER_TOKEN_BEDROCK": "env-bedrock-key",
+                "AWS_REGION": "us-west-2",
+            },
+            {"model": MODEL_NAME},
+            {"bedrock_api_key": "env-bedrock-key"},
+        )
+
+
+def test_initialization() -> None:
+    """Explicit params are stored and the model is an OpenAI-compatible model."""
+    model = ChatOpenAIBedrock(
+        model=MODEL_NAME,
+        region_name="us-west-2",
+        bedrock_api_key=SecretStr("test-key"),
+    )
+    assert model.model_name == MODEL_NAME
+    assert model.region_name == "us-west-2"
+    assert cast("SecretStr", model.bedrock_api_key).get_secret_value() == "test-key"
+
+
+def test_default_base_url_from_region() -> None:
+    """base_url defaults to the region's bedrock-runtime OpenAI endpoint."""
+    model = ChatOpenAIBedrock(
+        model=MODEL_NAME,
+        region_name="us-west-2",
+        bedrock_api_key=SecretStr("test-key"),
+    )
+    assert model.openai_api_base == RUNTIME_BASE_URL
+
+
+def test_explicit_base_url_is_respected() -> None:
+    """An explicit base_url overrides the region-derived default."""
+    custom = "https://bedrock-runtime.us-east-1.amazonaws.com/openai/v1"
+    model = ChatOpenAIBedrock(
+        model=MODEL_NAME,
+        region_name="us-west-2",
+        base_url=custom,
+        bedrock_api_key=SecretStr("test-key"),
+    )
+    assert model.openai_api_base == custom
+
+
+def test_missing_region_and_base_url_raises() -> None:
+    """Fail locally instead of routing the Bedrock key to the default OpenAI host."""
+    with MonkeyPatch().context() as m:
+        m.delenv("AWS_REGION", raising=False)
+        m.delenv("AWS_DEFAULT_REGION", raising=False)
+        with pytest.raises(ValueError, match="region"):
+            ChatOpenAIBedrock(model=MODEL_NAME, bedrock_api_key=SecretStr("test-key"))
+
+
+def test_explicit_base_url_without_region_ok() -> None:
+    """An explicit base_url bypasses the region requirement."""
+    with MonkeyPatch().context() as m:
+        m.delenv("AWS_REGION", raising=False)
+        m.delenv("AWS_DEFAULT_REGION", raising=False)
+        model = ChatOpenAIBedrock(
+            model=MODEL_NAME,
+            base_url=RUNTIME_BASE_URL,
+            bedrock_api_key=SecretStr("test-key"),
+        )
+    assert model.openai_api_base == RUNTIME_BASE_URL
+
+
+def test_region_and_key_from_env() -> None:
+    """Region and bedrock_api_key are read from the environment."""
+    with MonkeyPatch().context() as m:
+        m.delenv("AWS_DEFAULT_REGION", raising=False)
+        m.setenv("AWS_REGION", "eu-west-1")
+        m.setenv("AWS_BEARER_TOKEN_BEDROCK", "env-key")
+        model = ChatOpenAIBedrock(model=MODEL_NAME)
+        assert (
+            model.openai_api_base
+            == "https://bedrock-runtime.eu-west-1.amazonaws.com/openai/v1"
+        )
+        assert cast("SecretStr", model.bedrock_api_key).get_secret_value() == "env-key"
+
+
+def test_bedrock_api_key_routed_to_openai_key() -> None:
+    """The Bedrock API key is used as the OpenAI client api_key."""
+    model = ChatOpenAIBedrock(
+        model=MODEL_NAME,
+        region_name="us-west-2",
+        bedrock_api_key=SecretStr("bearer-abc"),
+    )
+    assert cast("SecretStr", model.openai_api_key).get_secret_value() == "bearer-abc"
+
+
+def test_ls_params_provider() -> None:
+    """Tracing provider is reported as openai-bedrock."""
+    model = ChatOpenAIBedrock(
+        model=MODEL_NAME,
+        region_name="us-west-2",
+        bedrock_api_key=SecretStr("test-key"),
+    )
+    ls_params = model._get_ls_params()
+    assert ls_params["ls_provider"] == "openai-bedrock"
+    assert ls_params["ls_model_name"] == MODEL_NAME
+
+
+def test_llm_type_and_namespace() -> None:
+    """Endpoint-specific llm_type and serialization namespace."""
+    model = ChatOpenAIBedrock(
+        model=MODEL_NAME,
+        region_name="us-west-2",
+        bedrock_api_key=SecretStr("test-key"),
+    )
+    assert model._llm_type == "openai-bedrock-chat"
+    assert model.get_lc_namespace() == ["langchain", "chat_models", "openai_bedrock"]
+
+
+def test_lc_secrets() -> None:
+    """The bedrock_api_key maps to its environment variable."""
+    model = ChatOpenAIBedrock(
+        model=MODEL_NAME,
+        region_name="us-west-2",
+        bedrock_api_key=SecretStr("test-key"),
+    )
+    assert model.lc_secrets["bedrock_api_key"] == "AWS_BEARER_TOKEN_BEDROCK"
+
+
+def test_explicit_profile_is_respected() -> None:
+    """A caller-supplied profile is not overwritten by the default lookup."""
+    custom = {"tool_calling": False}
+    model = ChatOpenAIBedrock(
+        model=MODEL_NAME,
+        region_name="us-west-2",
+        bedrock_api_key=SecretStr("test-key"),
+        profile=custom,  # type: ignore[arg-type]
+    )
+    assert model.profile == custom
+
+
+def test_profile_empty_for_unknown_model() -> None:
+    """An unknown model resolves to an empty profile rather than raising."""
+    model = ChatOpenAIBedrock(
+        model="us.openai.does-not-exist",
+        region_name="us-west-2",
+        bedrock_api_key=SecretStr("test-key"),
+    )
+    assert model.profile == {}
+
+
+def test_profile_resolved_through_cross_region_prefix() -> None:
+    """A geographic inference-profile id inherits the base model's profile.
+
+    ``us.openai.gpt-5.6-sol`` is not registered directly, but the cross-Region
+    prefix is stripped so it resolves to the base ``openai.gpt-5.6-sol`` profile.
+    """
+    model = ChatOpenAIBedrock(
+        model="us.openai.gpt-5.6-sol",
+        region_name="us-west-2",
+        bedrock_api_key=SecretStr("test-key"),
+    )
+    base = ChatOpenAIBedrock(
+        model="openai.gpt-5.6-sol",
+        region_name="us-west-2",
+        bedrock_api_key=SecretStr("test-key"),
+    )
+    assert model.profile != {}
+    assert model.profile == base.profile
+
+
+def test_stream_routes_to_responses_api() -> None:
+    """_stream delegates to the Responses API path when it is active."""
+    model = ChatOpenAIBedrock(
+        model=MODEL_NAME,
+        region_name="us-west-2",
+        bedrock_api_key=SecretStr("test-key"),
+        use_responses_api=True,
+    )
+    with (
+        patch.object(
+            BaseChatOpenAI, "_stream_responses", return_value=iter([])
+        ) as responses,
+        patch.object(BaseChatOpenAI, "_stream", return_value=iter([])) as completions,
+    ):
+        list(model._stream([HumanMessage("hi")]))
+    responses.assert_called_once()
+    completions.assert_not_called()
+
+
+def test_stream_routes_to_chat_completions_when_disabled() -> None:
+    """_stream falls back to Chat Completions when the Responses API is off."""
+    model = ChatOpenAIBedrock(
+        model=MODEL_NAME,
+        region_name="us-west-2",
+        bedrock_api_key=SecretStr("test-key"),
+        use_responses_api=False,
+    )
+    with (
+        patch.object(
+            BaseChatOpenAI, "_stream_responses", return_value=iter([])
+        ) as responses,
+        patch.object(BaseChatOpenAI, "_stream", return_value=iter([])) as completions,
+    ):
+        list(model._stream([HumanMessage("hi")]))
+    completions.assert_called_once()
+    responses.assert_not_called()
+
+
+async def _empty_async_stream(*args: object, **kwargs: object) -> AsyncIterator[None]:
+    """An async generator that yields nothing (stand-in for a streamed call)."""
+    for _ in ():
+        yield
+
+
+async def test_astream_routes_to_responses_api() -> None:
+    """_astream delegates to the Responses API path when it is active."""
+    model = ChatOpenAIBedrock(
+        model=MODEL_NAME,
+        region_name="us-west-2",
+        bedrock_api_key=SecretStr("test-key"),
+        use_responses_api=True,
+    )
+    with (
+        patch.object(
+            BaseChatOpenAI, "_astream_responses", side_effect=_empty_async_stream
+        ) as responses,
+        patch.object(
+            BaseChatOpenAI, "_astream", side_effect=_empty_async_stream
+        ) as completions,
+    ):
+        async for _ in model._astream([HumanMessage("hi")]):
+            pass
+    responses.assert_called_once()
+    completions.assert_not_called()
+
+
+async def test_astream_routes_to_chat_completions_when_disabled() -> None:
+    """_astream falls back to Chat Completions when the Responses API is off."""
+    model = ChatOpenAIBedrock(
+        model=MODEL_NAME,
+        region_name="us-west-2",
+        bedrock_api_key=SecretStr("test-key"),
+        use_responses_api=False,
+    )
+    with (
+        patch.object(
+            BaseChatOpenAI, "_astream_responses", side_effect=_empty_async_stream
+        ) as responses,
+        patch.object(
+            BaseChatOpenAI, "_astream", side_effect=_empty_async_stream
+        ) as completions,
+    ):
+        async for _ in model._astream([HumanMessage("hi")]):
+            pass
+    completions.assert_called_once()
+    responses.assert_not_called()
+
+
+def test_with_structured_output_defaults_to_json_schema() -> None:
+    """with_structured_output defaults method to json_schema."""
+
+    class Schema(BaseModel):
+        answer: str
+
+    model = ChatOpenAIBedrock(
+        model=MODEL_NAME,
+        region_name="us-west-2",
+        bedrock_api_key=SecretStr("test-key"),
+    )
+    with patch.object(BaseChatOpenAI, "with_structured_output") as parent:
+        model.with_structured_output(Schema)
+    assert parent.call_args.kwargs["method"] == "json_schema"
+
+
+# ---------------------------------------------------------------------------
+# Credential-derived (short-term key) authentication path
+# ---------------------------------------------------------------------------
+
+
+def test_provider_installed_when_no_static_key() -> None:
+    """With no static bearer key, a _BedrockApiKeyProvider is used as api_key."""
+    with MonkeyPatch().context() as m:
+        m.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+        m.setenv("AWS_REGION", "us-west-2")
+        model = ChatOpenAIBedrock(
+            model=MODEL_NAME,
+            aws_access_key_id=SecretStr("AKIA_TEST"),
+            aws_secret_access_key=SecretStr("SECRET_TEST"),
+            aws_session_token=SecretStr("TOKEN_TEST"),
+        )
+
+    provider = model.openai_api_key
+    assert isinstance(provider, _BedrockApiKeyProvider)
+    assert model.openai_api_base == RUNTIME_BASE_URL
+    assert provider._region == "us-west-2"
+    assert provider._aws_access_key_id == "AKIA_TEST"
+    assert provider._aws_secret_access_key == "SECRET_TEST"
+    assert provider._aws_session_token == "TOKEN_TEST"
+
+
+def test_static_key_takes_precedence_over_creds() -> None:
+    """A static bedrock_api_key wins over AWS credentials."""
+    with MonkeyPatch().context() as m:
+        m.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+        m.setenv("AWS_REGION", "us-west-2")
+        model = ChatOpenAIBedrock(
+            model=MODEL_NAME,
+            bedrock_api_key=SecretStr("bearer-abc"),
+            aws_access_key_id=SecretStr("AKIA_TEST"),
+            aws_secret_access_key=SecretStr("SECRET_TEST"),
+        )
+    assert cast("SecretStr", model.openai_api_key).get_secret_value() == "bearer-abc"
+
+
+def test_explicit_api_key_not_overridden_by_provider() -> None:
+    """An explicit api_key is left untouched (no provider installed)."""
+    with MonkeyPatch().context() as m:
+        m.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+        m.setenv("AWS_REGION", "us-west-2")
+        model = ChatOpenAIBedrock(model=MODEL_NAME, api_key=SecretStr("explicit"))
+    assert cast("SecretStr", model.openai_api_key).get_secret_value() == "explicit"
+
+
+def test_installed_provider_mints_token_when_called() -> None:
+    """The installed provider returns a minted short-term key when invoked."""
+    with MonkeyPatch().context() as m:
+        m.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+        m.setenv("AWS_REGION", "us-west-2")
+        model = ChatOpenAIBedrock(
+            model=MODEL_NAME,
+            aws_access_key_id=SecretStr("AKIA_TEST"),
+            aws_secret_access_key=SecretStr("SECRET_TEST"),
+        )
+    provider = cast("_BedrockApiKeyProvider", model.openai_api_key)
+    with patch("aws_bedrock_token_generator.provide_token", return_value="tok-xyz"):
+        assert provider() == "tok-xyz"
+
+
+def test_provider_forwards_profile_and_ttl() -> None:
+    """Profile name and requested TTL are forwarded; default chain otherwise."""
+    with MonkeyPatch().context() as m:
+        m.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+        m.delenv("AWS_ACCESS_KEY_ID", raising=False)
+        m.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+        m.setenv("AWS_REGION", "us-west-2")
+        model = ChatOpenAIBedrock(
+            model=MODEL_NAME,
+            credentials_profile_name="my-profile",
+            api_key_ttl_seconds=1800,
+        )
+    provider = model.openai_api_key
+    assert isinstance(provider, _BedrockApiKeyProvider)
+    assert provider._credentials_profile_name == "my-profile"
+    assert provider._ttl_seconds == 1800
+    assert provider._aws_access_key_id is None
+
+
+# ---------------------------------------------------------------------------
+# Guardrails: rejected on the OpenAI-compatible path (model-gated on runtime)
+# ---------------------------------------------------------------------------
+
+
+def _make_model(**kwargs: object) -> ChatOpenAIBedrock:
+    return ChatOpenAIBedrock(
+        model=MODEL_NAME,
+        region_name="us-west-2",
+        bedrock_api_key=SecretStr("test-key"),
+        **kwargs,  # type: ignore[arg-type]
+    )
+
+
+def test_guardrail_config_rejected_at_construction() -> None:
+    with pytest.raises(ValueError, match="Guardrails are not supported"):
+        _make_model(guardrails={"guardrailIdentifier": "gr-1", "guardrailVersion": "1"})
+
+
+def test_guardrail_default_headers_rejected_at_construction() -> None:
+    with pytest.raises(ValueError, match="Guardrails are not supported"):
+        _make_model(
+            default_headers={
+                "X-Amzn-Bedrock-GuardrailIdentifier": "gr-1",
+                "X-Amzn-Bedrock-GuardrailVersion": "1",
+            },
+        )
+
+
+def test_guardrail_extra_headers_rejected_per_request() -> None:
+    model = _make_model()
+    with pytest.raises(ValueError, match="Guardrails are not supported"):
+        model._get_request_payload(
+            "hello",
+            extra_headers={"X-Amzn-Bedrock-GuardrailIdentifier": "gr-1"},
+        )
+
+
+def test_non_guardrail_headers() -> None:
+    model = _make_model(default_headers={"X-Custom-Header": "ok"})
+    payload = model._get_request_payload(
+        "hello", extra_headers={"X-Another-Header": "ok"}
+    )
+    assert payload["extra_headers"] == {"X-Another-Header": "ok"}
+
+
+# ---------------------------------------------------------------------------
+# Misc
+# ---------------------------------------------------------------------------
+
+
+def test_inherits_openai_features() -> None:
+    """Key BaseChatOpenAI methods are inherited unchanged."""
+    model = _make_model()
+    for attr in (
+        "bind_tools",
+        "with_structured_output",
+        "_stream",
+        "_astream",
+        "_generate",
+        "_agenerate",
+    ):
+        assert hasattr(model, attr)
+
+
+def test_base_class_not_instantiable() -> None:
+    """The shared base class cannot be constructed directly."""
+    from langchain_aws.chat_models.openai import _BaseChatBedrockOpenAI
+
+    with pytest.raises(TypeError, match="cannot be instantiated directly"):
+        _BaseChatBedrockOpenAI(
+            model=MODEL_NAME,
+            region_name="us-west-2",
+            bedrock_api_key=SecretStr("test-key"),
+        )


### PR DESCRIPTION
## Summary

Adds `ChatOpenAIBedrock`, an OpenAI-compatible chat model for the **bedrock-runtime** endpoint (`bedrock-runtime.{region}.amazonaws.com/openai/v1`), alongside the existing `ChatOpenAIMantle` (bedrock-mantle). This is the [recommended endpoint](https://docs.aws.amazon.com/bedrock/latest/userguide/endpoints.html) for OpenAI models (e.g. the GPT-5.x family) on Amazon Bedrock, and supports the Chat Completions and Responses APIs plus cross-Region inference.

## Why

The OpenAI-compatible surface is now available on `bedrock-runtime`, along with `bedrock-mantle`. Shared logic has been factored into a private `_BaseChatBedrockOpenAI` base; each public class sets only endpoint-specific attributes. `ChatOpenAIMantle`'s public behavior is unchanged.

## What's in it

- **`ChatOpenAIBedrock`** — runtime base URL, `openai-bedrock` tracing provider. Cross-Region inference is selected via the `model` id (e.g. `us.openai.gpt-5.6-sol`, `global.openai.gpt-5.6-sol`).
- **Shared base refactor** — region/base-URL resolution, Bedrock API-key auth (static bearer token or short-term keys derived from AWS credentials, following #1203), profile resolution, LangSmith tracing, and Chat Completions/Responses routing now live once in `_BaseChatBedrockOpenAI`.
- **Deduplication into `langchain_aws.utils`** — the cross-Region prefix strip and the guardrail-rejection guard (previously duplicated per #1225) are now shared helpers; `ChatBedrockConverse` and `ChatAnthropicMantle` are routed through them. Behavior unchanged.

## Behavior notes

- **Guardrails** are rejected on the OpenAI-compatible path for both endpoints (bedrock-mantle silently ignores them; no OpenAI model on bedrock-runtime accepts them yet), consistent with #1225. Use `ChatBedrockConverse` / `ChatAnthropicBedrock` for guardrails.
- **Tool calling with GPT-5.x reasoning models** is rejected on the Chat Completions path while reasoning is active (a model-level behavior, same on both endpoints). Bind tools via the Responses API (`use_responses_api=True`) or `reasoning_effort="none"`. Open-weight models (gpt-oss) are unaffected. Documented on both classes.

## Areas that need careful review

- The `_BaseChatBedrockOpenAI` extraction restructures `ChatOpenAIMantle` (same file) — its public surface and behavior are unchanged; the full pre-existing Mantle unit suite still passes.
- The dedup deliberately edits `anthropic.py` (`ChatAnthropicMantle`) and `bedrock_converse.py` (`_get_base_model`) so they consume the shared `utils` helpers. That's why an "add ChatOpenAIBedrock" PR touches those files. Behavior is preserved.

## Testing

- `make lint` / `make test` green (**1290 passed**); new-class (`openai.py`) coverage 94.64%.
- New unit suite (`ChatModelUnitTests` + endpoint/auth/guardrail/stream-routing/base-guard cases) and integration suite (standard suite via the Responses API + credential-derived auth + global cross-Region + Responses, skipped without creds).
- Verified live against a Bedrock account (public `langchain_aws` imports, credential-derived auth): chat, Responses API, streaming, `us.`/`global.` GPT-5.6 profiles, guardrail rejection, and a **LangGraph `create_react_agent` tool-call loop** (via the Responses API). `ChatOpenAIMantle` and `ChatBedrockConverse` re-verified live after the refactor.
