### PR TITLE
perf(aws): omit prompt-caching trace inputs

### DIFF
--- a/libs/aws/langchain_aws/middleware/prompt_caching.py
+++ b/libs/aws/langchain_aws/middleware/prompt_caching.py
@@ -1,5 +1,5 @@
 from collections.abc import Awaitable, Callable
-from typing import Literal, Union
+from typing import Any, Literal, Union
 from warnings import warn
 
 from langchain_aws.chat_models.bedrock import ChatBedrock
@@ -11,8 +11,6 @@ try:
         ModelCallResult,
         ModelRequest,
         ModelResponse,
-        TracePolicy,
-        omit_payload,
     )
 except ImportError as e:
     msg = (
@@ -21,6 +19,18 @@ except ImportError as e:
         "Install it with: pip install langchain"
     )
     raise ImportError(msg) from e
+
+
+def _get_trace_policy() -> Any:
+    """Use tracing optimizations when supported by the installed LangChain."""
+    try:
+        from langchain.agents.middleware.types import TracePolicy, omit_payload
+    except ImportError:
+        return None
+    return TracePolicy(process_inputs=omit_payload)
+
+
+_TRACE_POLICY = _get_trace_policy()
 
 
 def _is_supported_model(model: Union[ChatBedrock, ChatBedrockConverse]) -> bool:
@@ -54,7 +64,7 @@ class BedrockPromptCachingMiddleware(AgentMiddleware):
     - `AWS Bedrock <https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html>`
     """
 
-    trace_policy = TracePolicy(process_inputs=omit_payload)
+    trace_policy = _TRACE_POLICY
 
     def __init__(
         self,

--- a/libs/aws/langchain_aws/middleware/prompt_caching.py
+++ b/libs/aws/langchain_aws/middleware/prompt_caching.py
@@ -11,6 +11,8 @@ try:
         ModelCallResult,
         ModelRequest,
         ModelResponse,
+        TracePolicy,
+        omit_payload,
     )
 except ImportError as e:
     msg = (
@@ -51,6 +53,8 @@ class BedrockPromptCachingMiddleware(AgentMiddleware):
     - `Anthropic <https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching>`
     - `AWS Bedrock <https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html>`
     """
+
+    trace_policy = TracePolicy(process_inputs=omit_payload)
 
     def __init__(
         self,

--- a/libs/aws/tests/unit_tests/middleware/test_prompt_caching.py
+++ b/libs/aws/tests/unit_tests/middleware/test_prompt_caching.py
@@ -8,6 +8,12 @@ from langchain_aws import ChatBedrock, ChatBedrockConverse
 from langchain_aws.middleware.prompt_caching import BedrockPromptCachingMiddleware
 
 
+def test_trace_inputs_are_omitted() -> None:
+    policy = BedrockPromptCachingMiddleware.trace_policy
+    assert policy.process_inputs is not None
+    assert policy.process_inputs({"messages": [HumanMessage("secret")]}) == {}
+
+
 def test_bedrock_skips_non_chatbedrock() -> None:
     middleware = BedrockPromptCachingMiddleware(unsupported_model_behavior="ignore")
 

--- a/libs/aws/tests/unit_tests/middleware/test_prompt_caching.py
+++ b/libs/aws/tests/unit_tests/middleware/test_prompt_caching.py
@@ -13,7 +13,7 @@ from langchain_aws.middleware.prompt_caching import BedrockPromptCachingMiddlewa
 def test_trace_inputs_are_omitted() -> None:
     policy = BedrockPromptCachingMiddleware.trace_policy
     assert policy.process_inputs is not None
-    assert policy.process_inputs({"messages": [HumanMessage("secret")]}) == {}
+    assert policy.process_inputs({"messages": [HumanMessage("foo")]}) == {}
 
 
 def test_trace_policy_unsupported_langchain() -> None:

--- a/libs/aws/tests/unit_tests/middleware/test_prompt_caching.py
+++ b/libs/aws/tests/unit_tests/middleware/test_prompt_caching.py
@@ -1,10 +1,12 @@
 # type:ignore
 
-from unittest.mock import MagicMock
+from types import ModuleType
+from unittest.mock import MagicMock, patch
 
 from langchain_core.messages import AIMessage, HumanMessage
 
 from langchain_aws import ChatBedrock, ChatBedrockConverse
+from langchain_aws.middleware import prompt_caching
 from langchain_aws.middleware.prompt_caching import BedrockPromptCachingMiddleware
 
 
@@ -12,6 +14,12 @@ def test_trace_inputs_are_omitted() -> None:
     policy = BedrockPromptCachingMiddleware.trace_policy
     assert policy.process_inputs is not None
     assert policy.process_inputs({"messages": [HumanMessage("secret")]}) == {}
+
+
+def test_trace_policy_unsupported_langchain() -> None:
+    old_types = ModuleType("langchain.agents.middleware.types")
+    with patch.dict("sys.modules", {"langchain.agents.middleware.types": old_types}):
+        assert prompt_caching._get_trace_policy() is None
 
 
 def test_bedrock_skips_non_chatbedrock() -> None:


### PR DESCRIPTION
`BedrockPromptCachingMiddleware` no longer serializes the full model request into every wrapper span, reducing tracing overhead for long conversations.

The middleware now uses `TracePolicy(process_inputs=omit_payload)`, consistent with other request-wrapping middleware. Focused coverage verifies the input transform omits payloads.

Made by [Open SWE](https://openswe.vercel.app/agents/bf7bb34a-16fc-509a-80a9-7f4f1af71620)