### PR TITLE
test(aws): Increase timeout for xAI standard tests

### DIFF
--- a/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/integration_tests/chat_models/test_bedrock_converse.py
@@ -231,7 +231,7 @@ class TestBedrockXaiStandard(ChatModelIntegrationTests):
 
     @property
     def chat_model_params(self) -> dict:
-        return {"model": "global.xai.grok-4.6"}
+        return {"model": "global.xai.grok-4.6", "timeout": 300}
 
     @property
     def standard_chat_model_params(self) -> dict:


### PR DESCRIPTION
Lots of these stochastic errors in recent integ workflow runs:
```
FAILED tests/integration_tests/chat_models/test_bedrock_converse.py::TestBedrockXaiStandard::test_structured_output[pydantic] - urllib3.exceptions.ReadTimeoutError: AWSHTTPSConnectionPool(host='bedrock-runtime.***.amazonaws.com', port=443): Read timed out.
```