### PR TITLE
feat(langgraph-checkpoint-aws): Enable async support on AgentCoreMemoryStore

### DIFF
--- a/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/store/agentcore/store.py
+++ b/libs/langgraph-checkpoint-aws/langgraph_checkpoint_aws/store/agentcore/store.py
@@ -15,6 +15,7 @@ import boto3
 from botocore.config import Config
 from botocore.exceptions import ClientError
 from langchain_core.messages import BaseMessage
+from langchain_core.runnables import run_in_executor
 from langgraph.store.base import (
     BaseStore,
     GetOp,
@@ -117,10 +118,8 @@ class AgentCoreMemoryStore(BaseStore):
         return results
 
     async def abatch(self, ops: Iterable[Op]) -> list[Result]:
-        """Execute multiple operations asynchronously (not implemented)."""
-        raise NotImplementedError(
-            "AgentCore Memory client does not support async operations yet"
-        )
+        """Execute multiple operations asynchronously."""
+        return await run_in_executor(None, self.batch, list(ops))
 
     def _handle_put(self, op: PutOp) -> None:
         """Handle PutOp by creating conversational events in AgentCore Memory."""

--- a/libs/langgraph-checkpoint-aws/tests/integration_tests/agentcore/test_async_store.py
+++ b/libs/langgraph-checkpoint-aws/tests/integration_tests/agentcore/test_async_store.py
@@ -1,0 +1,184 @@
+import asyncio
+import os
+import random
+import string
+import time
+import uuid
+from collections.abc import Iterator
+
+import boto3
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+from langgraph.store.base import GetOp, PutOp, SearchOp
+
+from langgraph_checkpoint_aws.store.agentcore.store import AgentCoreMemoryStore
+
+AWS_REGION = os.getenv("AWS_REGION", "us-west-2")
+
+
+def _random_suffix(k: int = 6) -> str:
+    chars = string.ascii_letters + string.digits
+    return "".join(random.choices(chars, k=k))
+
+
+class TestAgentCoreMemoryStoreAsyncIntegration:
+    @pytest.fixture
+    def memory_id(self) -> str:
+        memory_id = os.environ.get("AGENTCORE_MEMORY_ID")
+        if not memory_id:
+            pytest.skip("AGENTCORE_MEMORY_ID environment variable not set")
+        return memory_id
+
+    @pytest.fixture
+    def store(self, memory_id: str) -> AgentCoreMemoryStore:
+        return AgentCoreMemoryStore(memory_id=memory_id, region_name=AWS_REGION)
+
+    @pytest.fixture
+    def actor_id(self) -> str:
+        return "actor" + _random_suffix()
+
+    @pytest.fixture
+    def session_id(self, memory_id: str, actor_id: str) -> Iterator[str]:
+        session_id = "session" + _random_suffix()
+        yield session_id
+
+        client = boto3.client("bedrock-agentcore", region_name=AWS_REGION)
+        params = {
+            "memoryId": memory_id,
+            "actorId": actor_id,
+            "sessionId": session_id,
+            "maxResults": 100,
+            "includePayloads": False,
+        }
+        while True:
+            response = client.list_events(**params)
+            for event in response.get("events", []):
+                client.delete_event(
+                    memoryId=memory_id,
+                    actorId=actor_id,
+                    sessionId=session_id,
+                    eventId=event["eventId"],
+                )
+            next_token = response.get("nextToken")
+            if not next_token:
+                break
+            params["nextToken"] = next_token
+
+    @staticmethod
+    def _event_count(memory_id: str, actor_id: str, session_id: str) -> int:
+        client = boto3.client("bedrock-agentcore", region_name=AWS_REGION)
+        response = client.list_events(
+            memoryId=memory_id,
+            actorId=actor_id,
+            sessionId=session_id,
+            maxResults=100,
+            includePayloads=False,
+        )
+        return len(response.get("events", []))
+
+    async def test_aput_creates_event(self, store, memory_id, actor_id, session_id):
+        await store.aput(
+            (actor_id, session_id),
+            str(uuid.uuid4()),
+            {"message": HumanMessage("I prefer window seats on long flights.")},
+        )
+
+        assert self._event_count(memory_id, actor_id, session_id) == 1
+
+    async def test_concurrent_aput(self, store, memory_id, actor_id, session_id):
+        await asyncio.gather(
+            *(
+                store.aput(
+                    (actor_id, session_id),
+                    str(uuid.uuid4()),
+                    {"message": AIMessage(f"Noted preference number {i}.")},
+                )
+                for i in range(4)
+            )
+        )
+
+        assert self._event_count(memory_id, actor_id, session_id) == 4
+
+    async def test_asearch_returns_list(self, store, actor_id, session_id):
+        results = await store.asearch(
+            (actor_id, session_id), query="seat preferences", limit=3
+        )
+
+        assert isinstance(results, list)
+
+    async def test_aget_missing_record_returns_none(self, store, actor_id, session_id):
+        item = await store.aget((actor_id, session_id), "mem-" + "0" * 40)
+
+        assert item is None
+
+    async def test_abatch_mixed_ops(self, store, memory_id, actor_id, session_id):
+        namespace = (actor_id, session_id)
+        results = await store.abatch(
+            [
+                PutOp(
+                    namespace=namespace,
+                    key=str(uuid.uuid4()),
+                    value={"message": HumanMessage("Aisle is fine on short hops.")},
+                ),
+                SearchOp(namespace_prefix=namespace, query="seats", limit=2),
+                GetOp(namespace=namespace, key="mem-" + "1" * 40),
+            ]
+        )
+
+        assert results[0] is None
+        assert isinstance(results[1], list)
+        assert results[2] is None
+        assert self._event_count(memory_id, actor_id, session_id) == 1
+
+    async def test_async_error_handling(self, store, actor_id, session_id):
+        """Validation errors propagate through the async path unchanged."""
+        with pytest.raises(ValueError, match="'message' key"):
+            await store.aput(
+                (actor_id, session_id), str(uuid.uuid4()), {"message": "not a message"}
+            )
+
+        with pytest.raises(ValueError, match="tuple of"):
+            await store.aput(
+                (actor_id,), str(uuid.uuid4()), {"message": HumanMessage("hi")}
+            )
+
+    async def test_concurrent_aput_overlaps(
+        self, store, memory_id, actor_id, session_id
+    ):
+        """Concurrent puts complete faster than the same puts run sequentially."""
+        n_calls = 6
+
+        def make_put(i: int):
+            return store.aput(
+                (actor_id, session_id),
+                str(uuid.uuid4()),
+                {"message": HumanMessage(f"Concurrency probe {i}.")},
+            )
+
+        start = time.perf_counter()
+        await make_put(0)
+        single = time.perf_counter() - start
+
+        start = time.perf_counter()
+        await asyncio.gather(*(make_put(i) for i in range(1, n_calls)))
+        concurrent = time.perf_counter() - start
+
+        assert self._event_count(memory_id, actor_id, session_id) == n_calls
+        assert concurrent < (n_calls - 1) * single * 0.75
+
+    async def test_sync_async_parity(self, store, memory_id, actor_id, session_id):
+        namespace = (actor_id, session_id)
+        message = HumanMessage("Parity check message.")
+
+        store.put(namespace, str(uuid.uuid4()), {"message": message})
+        await store.aput(namespace, str(uuid.uuid4()), {"message": message})
+        assert self._event_count(memory_id, actor_id, session_id) == 2
+
+        sync_search = store.search(namespace, query="parity", limit=3)
+        async_search = await store.asearch(namespace, query="parity", limit=3)
+        assert [item.key for item in sync_search] == [item.key for item in async_search]
+
+        missing_key = "mem-" + "2" * 40
+        assert store.get(namespace, missing_key) == await store.aget(
+            namespace, missing_key
+        )

--- a/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_store.py
+++ b/libs/langgraph-checkpoint-aws/tests/unit_tests/agentcore/test_store.py
@@ -2,6 +2,8 @@
 Unit tests for AgentCore Memory Store.
 """
 
+import asyncio
+import time
 from datetime import datetime, timezone
 from unittest.mock import ANY, MagicMock, Mock, patch
 
@@ -405,18 +407,139 @@ class TestAgentCoreMemoryStore:
         with pytest.raises(ValueError, match="Unknown operation type"):
             store.batch(ops)
 
-    def test_abatch_not_implemented(self, store):
-        """Test that abatch raises NotImplementedError."""
-        ops = [SearchOp(namespace_prefix=("test_actor",), query="test", limit=5)]
+    async def test_abatch_mixed_operations(
+        self, store, mock_boto_client, sample_memory_record, sample_item_data
+    ):
+        """Test abatch delegates to batch and preserves result order."""
+        mock_boto_client.get_memory_record.return_value = {
+            "memoryRecord": sample_memory_record
+        }
+        mock_boto_client.retrieve_memory_records.return_value = {
+            "memoryRecordSummaries": [sample_memory_record]
+        }
+        mock_boto_client.create_event.return_value = {"event": {"eventId": "event-123"}}
 
-        # Use asyncio to test async method
-        import asyncio
+        ops = [
+            GetOp(namespace=("test_actor", "test_session"), key="test-key"),
+            PutOp(
+                namespace=("test_actor", "test_session"),
+                key="new-key",
+                value=sample_item_data,
+            ),
+            SearchOp(namespace_prefix=("test_actor",), query="test query", limit=5),
+            ListNamespacesOp(limit=10),
+        ]
+        results = await store.abatch(ops)
 
-        async def test_async():
-            with pytest.raises(NotImplementedError):
-                await store.abatch(ops)
+        assert len(results) == 4
+        assert isinstance(results[0], Item)  # GetOp
+        assert results[1] is None  # PutOp
+        assert isinstance(results[2], list)  # SearchOp
+        assert results[3] == []  # ListNamespacesOp
+        mock_boto_client.create_event.assert_called_once()
 
-        asyncio.run(test_async())
+    async def test_abatch_consumes_lazy_iterable(self, store, mock_boto_client):
+        """Test abatch materializes generator ops before the executor thread."""
+        mock_boto_client.retrieve_memory_records.return_value = {
+            "memoryRecordSummaries": []
+        }
+
+        ops = (
+            SearchOp(namespace_prefix=("test_actor",), query="test", limit=5)
+            for _ in range(2)
+        )
+        results = await store.abatch(ops)
+
+        assert results == [[], []]
+
+    async def test_async_convenience_methods_route_through_abatch(
+        self, store, mock_boto_client, sample_memory_record, sample_item_data
+    ):
+        """Test BaseStore's aget/aput/asearch work against the sync client."""
+        mock_boto_client.get_memory_record.return_value = {
+            "memoryRecord": sample_memory_record
+        }
+        mock_boto_client.retrieve_memory_records.return_value = {
+            "memoryRecordSummaries": [sample_memory_record]
+        }
+        mock_boto_client.create_event.return_value = {"event": {"eventId": "event-123"}}
+
+        await store.aput(("test_actor", "test_session"), "key1", sample_item_data)
+        mock_boto_client.create_event.assert_called_once()
+
+        item = await store.aget(("test_actor", "test_session"), "test-key")
+        assert isinstance(item, Item)
+
+        found = await store.asearch(("test_actor",), query="test query", limit=5)
+        assert len(found) == 1
+        assert isinstance(found[0], SearchItem)
+
+    async def test_abatch_does_not_block_event_loop(self, store, mock_boto_client):
+        """Test the event loop keeps running while abatch waits on the client."""
+        call_duration = 0.2
+
+        def slow_search(**kwargs):
+            time.sleep(call_duration)
+            return {"memoryRecordSummaries": []}
+
+        mock_boto_client.retrieve_memory_records.side_effect = slow_search
+        heartbeats = 0
+
+        async def heartbeat():
+            nonlocal heartbeats
+            while True:
+                await asyncio.sleep(0.01)
+                heartbeats += 1
+
+        ticker = asyncio.create_task(heartbeat())
+        try:
+            await store.abatch(
+                [SearchOp(namespace_prefix=("test_actor",), query="q", limit=1)]
+            )
+        finally:
+            ticker.cancel()
+
+        assert heartbeats >= 5
+
+    async def test_abatch_runs_ops_concurrently(self, store, mock_boto_client):
+        """Test concurrent abatch calls overlap instead of serializing."""
+        call_duration = 0.2
+        n_calls = 4
+
+        def slow_search(**kwargs):
+            time.sleep(call_duration)
+            return {"memoryRecordSummaries": []}
+
+        mock_boto_client.retrieve_memory_records.side_effect = slow_search
+        op = SearchOp(namespace_prefix=("test_actor",), query="q", limit=1)
+
+        start = time.perf_counter()
+        await asyncio.gather(*(store.abatch([op]) for _ in range(n_calls)))
+        elapsed = time.perf_counter() - start
+
+        assert elapsed < (n_calls * call_duration) * 0.75
+
+    async def test_abatch_propagates_validation_errors(self, store):
+        """Test ValueErrors raised on the executor thread reach the awaiter."""
+        with pytest.raises(ValueError, match="'message' key"):
+            await store.aput(
+                ("test_actor", "test_session"), "k", {"message": "not a message"}
+            )
+
+        with pytest.raises(ValueError, match="tuple of \\(actor_id, session_id\\)"):
+            await store.aput(("only_actor",), "k", {"message": HumanMessage("hi")})
+
+    async def test_abatch_propagates_client_errors(self, store, mock_boto_client):
+        """Test botocore ClientErrors surface unchanged through abatch."""
+        mock_boto_client.get_memory_record.side_effect = ClientError(
+            {"Error": {"Code": "AccessDeniedException", "Message": "denied"}},
+            "GetMemoryRecord",
+        )
+
+        with pytest.raises(ClientError) as exc_info:
+            await store.aget(("test_actor", "test_session"), "mem-" + "0" * 40)
+
+        assert exc_info.value.response["Error"]["Code"] == "AccessDeniedException"
 
     def test_convert_memory_record_to_item(self, store, sample_memory_record):
         """Test conversion of memory record to Item."""


### PR DESCRIPTION
Implements the `abatch()` method on `AgentCoreMemoryStore` (not true async as this just runs `batch()` in an executor, but this follows the `AgentCoreMemorySaver` implementations) to unblock use of the rest of the inherited async methods from `BaseStore`.

Manually verified integration tests against AgentCore memory resource in my dev AWS account.