### PR TITLE
fix(aws): allow auto tool_choice for DeepSeek V3 models

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -1165,10 +1165,9 @@ class ChatBedrockConverse(BaseChatModel):
             elif "nova" in base_model:
                 self.supports_tool_choice_values = ("auto", "any", "tool")
             elif "deepseek" in base_model and "r1-v1" not in base_model:
-                if "v3-v1" in base_model:
-                    self.supports_tool_choice_values = ("any",)
-                else:
-                    self.supports_tool_choice_values = ("any", "tool")
+                # DeepSeek V3 models accept `auto` (Bedrock's default), `any`,
+                # and named `tool` selection on the Converse API.
+                self.supports_tool_choice_values = ("auto", "any", "tool")
             else:
                 self.supports_tool_choice_values = ()
 
@@ -1556,8 +1555,6 @@ class ChatBedrockConverse(BaseChatModel):
                 not enabled (no safe downgrade possible).
         """
         if not tool_choice:
-            if "deepseek.v3" in self._get_base_model():
-                return _format_tool_choice("any")
             return None
 
         formatted = _format_tool_choice(tool_choice)

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -340,10 +340,12 @@ def test_llama_bind_tools_tool_choice_variants(
     "model,expected_values",
     [
         ("us.deepseek.r1-v1:0", ()),
-        ("deepseek.v3-v1:0", ("any",)),
+        ("deepseek.v3-v1:0", ("auto", "any", "tool")),
+        ("deepseek.v3.2", ("auto", "any", "tool")),
         (
             "deepseek.v3-x:0",
             (
+                "auto",
                 "any",
                 "tool",
             ),
@@ -392,20 +394,30 @@ def test_deepseek_v3_bind_tools_tool_choice_variants() -> None:
         "any": {}
     }
 
-    with pytest.raises(ValueError):
-        chat_model.bind_tools([GetWeather], tool_choice="auto")
+    # `auto` is accepted by Bedrock for DeepSeek V3 and must not be refused
+    # (regression test for issue #1259).
+    chat_model_with_auto = chat_model.bind_tools([GetWeather], tool_choice="auto")
+    assert cast(RunnableBinding, chat_model_with_auto).kwargs["tool_choice"] == {
+        "auto": {}
+    }
 
-    with pytest.raises(ValueError):
-        chat_model.bind_tools([GetWeather], tool_choice="GetWeather")
+    chat_model_with_named = chat_model.bind_tools(
+        [GetWeather], tool_choice="GetWeather"
+    )
+    assert cast(RunnableBinding, chat_model_with_named).kwargs["tool_choice"] == {
+        "tool": {"name": "GetWeather"}
+    }
 
 
 def test_deepseek_v3_bind_tools_default_tool_choice() -> None:
     chat_model = ChatBedrockConverse(model="deepseek.v3-v1:0", region_name="us-east-1")  # type: ignore[call-arg]
 
+    # With no explicit tool_choice, the resolved tool_choice must be None so no
+    # toolChoice is sent and Bedrock's default (`auto`) applies, letting the
+    # model answer in text instead of being forced into a tool call
+    # (regression test for issue #1259).
     chat_model_with_tools = chat_model.bind_tools([GetWeather])
-    assert cast(RunnableBinding, chat_model_with_tools).kwargs["tool_choice"] == {
-        "any": {}
-    }
+    assert cast(RunnableBinding, chat_model_with_tools).kwargs["tool_choice"] is None
 
 
 def test__messages_to_bedrock() -> None:


### PR DESCRIPTION
## Why

`ChatBedrockConverse` forced `tool_choice="any"` for `deepseek.v3*` models whenever tools were bound, and omitted `"auto"` from their capability table. This had two user-facing consequences once tools were in use:

- Every request went out with `toolChoice: {"any": {}}`, so DeepSeek V3 could **never answer in text** — it was always forced into a tool call, even when explicitly asked for a plain text reply.
- Requesting `tool_choice="auto"` was rejected by langchain-aws with a `ValueError` before any request was even sent.

Bedrock's Converse API accepts `auto` (and no `toolChoice`, whose default is `auto`) for both DeepSeek V3.1 and V3.2 today, so the restriction is no longer correct. It originated in #688, when `auto` reportedly did not produce valid tool output for these models; that no longer holds.

## What changed

- Removed the `deepseek.v3` branch in `_resolve_tool_choice`, so with no explicit `tool_choice` the resolved value is `None` and Bedrock's default (`auto`) applies.
- Added `"auto"` to `supports_tool_choice_values` for DeepSeek V3 (now `("auto", "any", "tool")`), so `auto` is no longer refused.
- Updated the affected unit tests to assert the new behavior.

## Testing

- Unit tests: full `tests/unit_tests/` suite passes (1253 passed, 5 skipped). Updated `test_deepseek_supports_tool_choice_values`, `test_deepseek_v3_bind_tools_tool_choice_variants`, and `test_deepseek_v3_bind_tools_default_tool_choice`.
- Lint: `ruff check`, `ruff format`, and `mypy` all clean on the changed files.
- **Live validation against Bedrock** (`deepseek.v3.2`, `us-east-1`), before vs. after:

  | Case | Before (bug) | After (fix) |
  |------|-------------|-------------|
  | `supports_tool_choice_values` | `('any', 'tool')` | `('auto', 'any', 'tool')` |
  | tools bound, no choice, asked for text | `{'any': {}}` → forced tool call | `None` → text `'OK'` |
  | `tool_choice="auto"` | `ValueError` (refused) | accepted |
  | after a tool result, asked to answer | `{'any': {}}` → another tool call | `None` → text answer |

## Areas worth careful review

- I unified DeepSeek V3.1 (`v3-v1`) and later V3 entries to `("auto", "any", "tool")`. The issue's literal proposal was `("auto", "any")` for V3.1, but the reporter's live data shows named `tool` selection also works on V3.1. My own live validation only covered `deepseek.v3.2` (the only DeepSeek V3 model enabled in the test account/region), so the V3.1 `tool` support relies on the issue's data rather than a test I ran directly.

Closes #1259

---

> [!NOTE]
> This contribution was prepared with the assistance of an AI agent (Kiro). The diagnosis was reproduced live against Bedrock, and the code, tests, and this description were reviewed before submission.