### PR TITLE
fix(aws): Update DeepSeek V3.x tool choice support on ChatBedrockConverse

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock_converse.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock_converse.py
@@ -84,6 +84,7 @@ from langchain_aws.utils import (
     create_aws_client,
     parse_model_provider,
     reasoning_effort_additional_fields,
+    thinking_enabled_in_params,
     thinking_forced_tool_use_unsupported,
     thinking_in_params,
     trim_message_whitespace,
@@ -1168,10 +1169,12 @@ class ChatBedrockConverse(BaseChatModel):
             elif "nova" in base_model:
                 self.supports_tool_choice_values = ("auto", "any", "tool")
             elif "deepseek" in base_model and "r1-v1" not in base_model:
-                if "v3-v1" in base_model:
-                    self.supports_tool_choice_values = ("any",)
+                if thinking_enabled_in_params(
+                    base_model, self.additional_model_request_fields or {}
+                ):
+                    self.supports_tool_choice_values = ("auto",)
                 else:
-                    self.supports_tool_choice_values = ("any", "tool")
+                    self.supports_tool_choice_values = ("auto", "any")
             else:
                 self.supports_tool_choice_values = ()
 
@@ -1510,10 +1513,17 @@ class ChatBedrockConverse(BaseChatModel):
             "langchain_core.exceptions.OutputParserException if tool calls are not "
             "generated. Consider adjusting your prompt to ensure the tool is called."
         )
-        if thinking_forced_tool_use_unsupported(self._get_base_model()):
+        base_model = self._get_base_model()
+        if "claude" in base_model and thinking_forced_tool_use_unsupported(base_model):
             additional_context = (
                 "For Claude 3/4 models, you can also support forced tool use "
                 "by disabling `thinking`."
+            )
+            admonition = f"{admonition} {additional_context}"
+        if "deepseek.v3" in base_model:
+            additional_context = (
+                "For DeepSeek V3 models, forced tool use is not available while "
+                "`reasoning_effort` is set in `additional_model_request_fields`."
             )
             admonition = f"{admonition} {additional_context}"
         warnings.warn(admonition)
@@ -1559,8 +1569,6 @@ class ChatBedrockConverse(BaseChatModel):
                 not enabled (no safe downgrade possible).
         """
         if not tool_choice:
-            if "deepseek.v3" in self._get_base_model():
-                return _format_tool_choice("any")
             return None
 
         formatted = _format_tool_choice(tool_choice)
@@ -1572,7 +1580,9 @@ class ChatBedrockConverse(BaseChatModel):
 
         # Thinking-enabled models: downgrade to auto instead of failing.
         if (
-            thinking_in_params(self.additional_model_request_fields or {})
+            thinking_enabled_in_params(
+                self._get_base_model(), self.additional_model_request_fields or {}
+            )
             and "auto" in supported
         ):
             warnings.warn(

--- a/libs/aws/langchain_aws/utils.py
+++ b/libs/aws/langchain_aws/utils.py
@@ -548,7 +548,7 @@ def thinking_on_by_default(model: str) -> bool:
 
 
 def thinking_forced_tool_use_unsupported(model: str) -> bool:
-    """Check if the model rejects forced tool use while thinking is enabled."""
+    """Check if the model rejects or ignores forced tool use with thinking enabled."""
     if "claude-opus-4-8" in model:
         return False
     return any(
@@ -558,8 +558,17 @@ def thinking_forced_tool_use_unsupported(model: str) -> bool:
             "claude-sonnet-4",
             "claude-opus-4",
             "claude-haiku-4",
+            "deepseek.v3",
         )
     )
+
+
+def thinking_enabled_in_params(model: str, params: dict) -> bool:
+    """Check if thinking is explicitly enabled in the request."""
+    if "deepseek.v3" in model:
+        effort = params.get("reasoning_effort")
+        return bool(effort) and str(effort).lower() not in ("none", "low", "medium")
+    return thinking_in_params(params)
 
 
 def reasoning_effort_additional_fields(base_model: str, effort: str) -> Dict[str, Any]:

--- a/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
+++ b/libs/aws/tests/unit_tests/chat_models/test_bedrock_converse.py
@@ -340,14 +340,8 @@ def test_llama_bind_tools_tool_choice_variants(
     "model,expected_values",
     [
         ("us.deepseek.r1-v1:0", ()),
-        ("deepseek.v3-v1:0", ("any",)),
-        (
-            "deepseek.v3-x:0",
-            (
-                "any",
-                "tool",
-            ),
-        ),
+        ("deepseek.v3-v1:0", ("auto", "any")),
+        ("deepseek.v3.2", ("auto", "any")),
     ],
 )
 def test_deepseek_supports_tool_choice_values(
@@ -384,28 +378,61 @@ def test_deepseek_r1_no_tool_choice_support() -> None:
         chat_model.bind_tools([GetWeather], tool_choice="GetWeather")
 
 
-def test_deepseek_v3_bind_tools_tool_choice_variants() -> None:
-    chat_model = ChatBedrockConverse(model="deepseek.v3-v1:0", region_name="us-east-1")  # type: ignore[call-arg]
+@pytest.mark.parametrize("model", ["deepseek.v3-v1:0", "deepseek.v3.2"])
+def test_deepseek_v3_bind_tools_tool_choice_variants(model: str) -> None:
+    chat_model = ChatBedrockConverse(model=model, region_name="us-east-1")  # type: ignore[call-arg]
 
     chat_model_with_tools = chat_model.bind_tools([GetWeather], tool_choice="any")
     assert cast(RunnableBinding, chat_model_with_tools).kwargs["tool_choice"] == {
         "any": {}
     }
 
-    with pytest.raises(ValueError):
-        chat_model.bind_tools([GetWeather], tool_choice="auto")
+    chat_model_with_tools = chat_model.bind_tools([GetWeather], tool_choice="auto")
+    assert cast(RunnableBinding, chat_model_with_tools).kwargs["tool_choice"] == {
+        "auto": {}
+    }
 
     with pytest.raises(ValueError):
         chat_model.bind_tools([GetWeather], tool_choice="GetWeather")
 
 
-def test_deepseek_v3_bind_tools_default_tool_choice() -> None:
-    chat_model = ChatBedrockConverse(model="deepseek.v3-v1:0", region_name="us-east-1")  # type: ignore[call-arg]
+@pytest.mark.parametrize("model", ["deepseek.v3-v1:0", "deepseek.v3.2"])
+def test_deepseek_v3_bind_tools_default_tool_choice(model: str) -> None:
+    chat_model = ChatBedrockConverse(model=model, region_name="us-east-1")  # type: ignore[call-arg]
 
     chat_model_with_tools = chat_model.bind_tools([GetWeather])
-    assert cast(RunnableBinding, chat_model_with_tools).kwargs["tool_choice"] == {
-        "any": {}
-    }
+    assert (
+        cast(RunnableBinding, chat_model_with_tools).kwargs.get("tool_choice") is None
+    )
+
+
+_DEEPSEEK_REASONING = {"reasoning_effort": "high"}
+
+
+@pytest.mark.parametrize("model", ["deepseek.v3-v1:0", "deepseek.v3.2"])
+def test_deepseek_v3_reasoning_restricts_tool_choice_to_auto(model: str) -> None:
+    chat_model = ChatBedrockConverse(
+        model=model,
+        region_name="us-east-1",
+        additional_model_request_fields=_DEEPSEEK_REASONING,
+    )  # type: ignore[call-arg]
+    assert chat_model.supports_tool_choice_values == ("auto",)
+
+
+def test_deepseek_v3_reasoning_downgrades_forced_tool_choice_to_auto() -> None:
+    chat_model = ChatBedrockConverse(
+        model="deepseek.v3.2",
+        region_name="us-east-1",
+        additional_model_request_fields=_DEEPSEEK_REASONING,
+    )  # type: ignore[call-arg]
+
+    with pytest.warns(UserWarning, match="Downgrading to tool_choice='auto'"):
+        bound = chat_model.bind_tools([GetWeather], tool_choice="any")
+    assert cast(RunnableBinding, bound).kwargs["tool_choice"] == {"auto": {}}
+
+    with pytest.warns(UserWarning, match="Downgrading to tool_choice='auto'"):
+        bound = chat_model.bind_tools([GetWeather], tool_choice="GetWeather")
+    assert cast(RunnableBinding, bound).kwargs["tool_choice"] == {"auto": {}}
 
 
 def test__messages_to_bedrock() -> None:

--- a/libs/aws/tests/unit_tests/test_utils.py
+++ b/libs/aws/tests/unit_tests/test_utils.py
@@ -19,6 +19,7 @@ from langchain_aws.utils import (
     parse_model_provider,
     reasoning_effort_additional_fields,
     thinking_disabled_in_params,
+    thinking_enabled_in_params,
     thinking_forced_tool_use_unsupported,
     thinking_in_params,
     thinking_on_by_default,
@@ -489,12 +490,31 @@ def test_count_tokens_api_supported_for_model(
         ("us.anthropic.claude-sonnet-5", False),
         ("global.anthropic.claude-opus-5", False),
         ("global.anthropic.claude-fable-5", False),
+        ("deepseek.v3-v1:0", True),
+        ("deepseek.v3.2", True),
     ],
 )
 def test_thinking_forced_tool_use_unsupported(
     model_id: str, expected_result: bool
 ) -> None:
     assert thinking_forced_tool_use_unsupported(model_id) == expected_result
+
+
+@pytest.mark.parametrize(
+    "model_id,params,expected_result",
+    [
+        ("anthropic.claude-sonnet-4-6", {"thinking": {"type": "enabled"}}, True),
+        ("anthropic.claude-sonnet-4-6", {"reasoning_effort": "high"}, False),
+        ("deepseek.v3.2", {"reasoning_effort": "high"}, True),
+        ("deepseek.v3.2", {"reasoning_effort": "low"}, False),
+        ("deepseek.v3.2", {"thinking": {"type": "enabled"}}, False),
+        ("deepseek.v3.2", {}, False),
+    ],
+)
+def test_thinking_enabled_in_params(
+    model_id: str, params: Dict[str, Any], expected_result: bool
+) -> None:
+    assert thinking_enabled_in_params(model_id, params) == expected_result
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #1259

#688, merged in Oct. 2025, restricted DeepSeek V3 models to `any` ToolChoice mode (based on Bedrock V3.1's tested behavior and upstream V3.2-Exp's docs). However, since then, V3.1's tool choice behavior has changed, as well as that of the stable V3.2 version Bedrock added in Dec. 2025.

Manually ran `tool_choice` value tests against Converse API to confirm the current situation:
- With thinking **disabled** (model default), both DeepSeek V3.1 and V3.2 behave the same:
   - Both `auto` and `any` mode now work unconditionally
   - Specific `tool` mode, while still accepted by Converse API, is not obeyed by either model.
- With thinking **enabled** (via `{"reasoning_effort": "high"}`):
  - `any` doesn't produce tool calls on either V3.1 or V3.2
  - `auto` doesn't work on V3.1, but **does** on V3.2 (which matches the DeepSeek [docs](https://api-docs.deepseek.com/guides/tool_calls/#thinking-mode))
  - `tool` mode: same as non-thinking.

Based on these observations, updated the following for DeepSeek V3.1/3.2 on ChatBedrockConverse:
- Allowed ToolChoice values goes to `("auto", "any")`
- Removed the forced `any` ToolChoice mode override for these models in `bind_tools`
- Added `any` -> `auto` auto-downgrade in the case that thinking is also enabled.
  - Note: may need further updates for when Bedrock adds DeepSeek V4, which now uses thinking by default; see: https://github.com/deepseek-ai/DeepSeek-V3/issues/1376


 