### PR TITLE
fix(model-profiles): declare Claude 5 structured output support

### DIFF
--- a/libs/aws/langchain_aws/data/_profiles.py
+++ b/libs/aws/langchain_aws/data/_profiles.py
@@ -336,6 +336,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
+        "structured_output": True,
         "reasoning_effort_levels": [
             "low",
             "medium",
@@ -523,6 +524,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
+        "structured_output": True,
         "reasoning_effort_levels": [
             "low",
             "medium",
@@ -857,6 +859,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
+        "structured_output": True,
         "reasoning_effort_levels": [
             "low",
             "medium",
@@ -1141,6 +1144,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
+        "structured_output": True,
         "reasoning_effort_levels": [
             "low",
             "medium",
@@ -1476,6 +1480,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
+        "structured_output": True,
         "reasoning_effort_levels": [
             "low",
             "medium",
@@ -2834,6 +2839,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "pdf_tool_message": True,
         "image_tool_message": True,
+        "structured_output": True,
         "reasoning_effort_levels": [
             "low",
             "medium",

--- a/libs/aws/langchain_aws/data/profile_augmentations.toml
+++ b/libs/aws/langchain_aws/data/profile_augmentations.toml
@@ -25,21 +25,27 @@ reasoning_effort_levels = ["low", "medium", "high", "xhigh", "max"]
 reasoning_effort_levels = ["low", "medium", "high", "xhigh", "max"]
 
 [overrides."anthropic.claude-sonnet-5"]
+structured_output = true
 reasoning_effort_levels = ["low", "medium", "high", "xhigh", "max"]
 
 [overrides."au.anthropic.claude-sonnet-5"]
+structured_output = true
 reasoning_effort_levels = ["low", "medium", "high", "xhigh", "max"]
 
 [overrides."eu.anthropic.claude-sonnet-5"]
+structured_output = true
 reasoning_effort_levels = ["low", "medium", "high", "xhigh", "max"]
 
 [overrides."global.anthropic.claude-sonnet-5"]
+structured_output = true
 reasoning_effort_levels = ["low", "medium", "high", "xhigh", "max"]
 
 [overrides."jp.anthropic.claude-sonnet-5"]
+structured_output = true
 reasoning_effort_levels = ["low", "medium", "high", "xhigh", "max"]
 
 [overrides."us.anthropic.claude-sonnet-5"]
+structured_output = true
 reasoning_effort_levels = ["low", "medium", "high", "xhigh", "max"]
 
 [overrides."amazon.nova-2-lite-v1:0"]

--- a/libs/aws/langchain_aws/data/profile_augmentations.toml
+++ b/libs/aws/langchain_aws/data/profile_augmentations.toml
@@ -7,21 +7,27 @@ pdf_tool_message = true
 image_tool_message = true
 
 [overrides."anthropic.claude-opus-5"]
+structured_output = true
 reasoning_effort_levels = ["low", "medium", "high", "xhigh", "max"]
 
 [overrides."au.anthropic.claude-opus-5"]
+structured_output = true
 reasoning_effort_levels = ["low", "medium", "high", "xhigh", "max"]
 
 [overrides."eu.anthropic.claude-opus-5"]
+structured_output = true
 reasoning_effort_levels = ["low", "medium", "high", "xhigh", "max"]
 
 [overrides."global.anthropic.claude-opus-5"]
+structured_output = true
 reasoning_effort_levels = ["low", "medium", "high", "xhigh", "max"]
 
 [overrides."jp.anthropic.claude-opus-5"]
+structured_output = true
 reasoning_effort_levels = ["low", "medium", "high", "xhigh", "max"]
 
 [overrides."us.anthropic.claude-opus-5"]
+structured_output = true
 reasoning_effort_levels = ["low", "medium", "high", "xhigh", "max"]
 
 [overrides."anthropic.claude-sonnet-5"]

--- a/libs/aws/tests/unit_tests/test_model_profiles.py
+++ b/libs/aws/tests/unit_tests/test_model_profiles.py
@@ -1,0 +1,31 @@
+"""Tests for AWS model profile augmentations."""
+
+from pathlib import Path
+
+import pytest
+
+PROFILE_AUGMENTATIONS = (
+    Path(__file__).parents[2] / "langchain_aws/data/profile_augmentations.toml"
+)
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "anthropic.claude-sonnet-5",
+        "au.anthropic.claude-sonnet-5",
+        "eu.anthropic.claude-sonnet-5",
+        "global.anthropic.claude-sonnet-5",
+        "jp.anthropic.claude-sonnet-5",
+        "us.anthropic.claude-sonnet-5",
+    ],
+)
+def test_claude_sonnet_5_structured_output_augmentation(model_id: str) -> None:
+    """Claude Sonnet 5 profiles explicitly retain structured output support."""
+    contents = PROFILE_AUGMENTATIONS.read_text()
+    header = f'[overrides."{model_id}"]'
+    _, separator, remainder = contents.partition(header)
+    assert separator
+
+    section = remainder.partition("\n[")[0]
+    assert "structured_output = true" in section.splitlines()

--- a/libs/aws/tests/unit_tests/test_model_profiles.py
+++ b/libs/aws/tests/unit_tests/test_model_profiles.py
@@ -1,17 +1,19 @@
-"""Tests for AWS model profile augmentations."""
-
-from pathlib import Path
+"""Tests for AWS model profiles."""
 
 import pytest
 
-PROFILE_AUGMENTATIONS = (
-    Path(__file__).parents[2] / "langchain_aws/data/profile_augmentations.toml"
-)
+from langchain_aws import ChatBedrockConverse
 
 
 @pytest.mark.parametrize(
     "model_id",
     [
+        "anthropic.claude-opus-5",
+        "au.anthropic.claude-opus-5",
+        "eu.anthropic.claude-opus-5",
+        "global.anthropic.claude-opus-5",
+        "jp.anthropic.claude-opus-5",
+        "us.anthropic.claude-opus-5",
         "anthropic.claude-sonnet-5",
         "au.anthropic.claude-sonnet-5",
         "eu.anthropic.claude-sonnet-5",
@@ -20,12 +22,8 @@ PROFILE_AUGMENTATIONS = (
         "us.anthropic.claude-sonnet-5",
     ],
 )
-def test_claude_sonnet_5_structured_output_augmentation(model_id: str) -> None:
-    """Claude Sonnet 5 profiles explicitly retain structured output support."""
-    contents = PROFILE_AUGMENTATIONS.read_text()
-    header = f'[overrides."{model_id}"]'
-    _, separator, remainder = contents.partition(header)
-    assert separator
-
-    section = remainder.partition("\n[")[0]
-    assert "structured_output = true" in section.splitlines()
+def test_claude_5_structured_output_profiles(model_id: str) -> None:
+    """Claude 5 chat models expose native structured output support."""
+    model = ChatBedrockConverse(model=model_id, region_name="us-west-2")
+    assert model.profile
+    assert model.profile["structured_output"] is True


### PR DESCRIPTION
## Summary

Fixes #1263

- declare structured-output capability for Claude Sonnet 5 and Claude Opus 5 across all Bedrock regional profile IDs
- regenerate the shipped profile table with the official `langchain-profiles` CLI
- exercise the runtime contract by instantiating `ChatBedrockConverse` and checking `.profile` for every affected model ID

## Testing

- red/green: the six Opus 5 cases failed before the added augmentations
- focused profile test: 12 passed
- full package unit suite: 1286 passed, 3 skipped, 1 xpassed
- `make format`: passed
- `make lint`: Ruff, format check, and mypy passed across 146 source files

## AI Disclosure

An AI coding assistant was used to investigate the profile generation path, implement the change, and prepare the tests.